### PR TITLE
feat: customise commit message format. fixes #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,13 @@ A [content store](#content-stores) plugin.
 Type: `Function`\
 *Required*
 
+### `publication.storeMessageTemplate`
+
+Function used to customise message format. See [Customising commit messages](#customising-commit-messages).
+
+Type: `Function`\
+*Optional*, defaults to `[action] [postType] [fileType]`
+
 ### `publication.sydnicationTargets`
 
 An array of [syndication targets](https://micropub.spec.indieweb.org/#syndication-targets). Example:
@@ -296,7 +303,7 @@ The time zone for your publication. By default this is set to `UTC`, however if 
 indiekit.set('publication.timeZone', 'Europe/London');
 ```
 
-Some servers will have a time zone saved in the `TZ` environment variable. In which case, you could supply that value instead:
+Some servers will have a time zone saved in the `TZ` environment variable. In which case, you can supply that value instead:
 
 ```js
 indiekit.set('publication.timeZone', process.env.TZ);
@@ -415,6 +422,26 @@ A post template is a function that takes post properties received and parsed by 
 
 * [`postTemplate()` function in Jekyll preset](https://github.com/getindiekit/indiekit/blob/main/packages/preset-jekyll/index.js#L120)
 * [`postTemplate()` function in Hugo preset](https://github.com/getindiekit/indiekit/blob/main/packages/preset-hugo/index.js#L152)
+
+## Customising commit messages
+
+Indiekit provides content store plugins with a `metaData` object that contains meta data that can be used in commit messages:
+
+* `action`: Action to take i.e. ‘create’, ‘upload’.
+* `result`: Result of action, i.e. ‘created’, ’uploaded'.
+* `fileType`: File type, i.e. ’post’ or ‘file‘.
+* `postType`: IndieWeb post type, i.e. ‘note’, ‘photo’, ‘reply’.
+
+By default, Indiekit outputs the `action`, `postType` and `fileType`, for example `create photo post`. If you wanted to change the format to output `Created a photo post`, you can do the following:
+
+```js
+const _ = require('lodash');
+
+indiekit.set('publication.storeMessageTemplate', metaData => {
+  const {result, postType, fileType} = metaData;
+  return `${_.upperFirst(result)} a ${postType} ${fileType}`;
+});
+```
 
 ## Plugins
 

--- a/packages/endpoint-media/lib/media.js
+++ b/packages/endpoint-media/lib/media.js
@@ -1,5 +1,3 @@
-import {supplant} from './utils.js';
-
 export const media = {
   /**
    * Upload file
@@ -10,17 +8,19 @@ export const media = {
    * @returns {object} Data to use in response
    */
   upload: async (publication, mediaData, file) => {
-    const {media, store} = publication;
-    const message = supplant(store.messageFormat, {
+    const {media, store, storeMessageTemplate} = publication;
+    const metaData = {
       action: 'upload',
-      fileType: 'media',
+      result: 'uploaded',
+      fileType: 'file',
       postType: mediaData.properties['post-type']
-    });
+    };
+    const message = storeMessageTemplate(metaData);
     const uploaded = await store.createFile(mediaData.path, file.buffer, message);
 
     if (uploaded) {
       mediaData.date = new Date();
-      mediaData.lastAction = 'upload';
+      mediaData.lastAction = metaData.action;
 
       if (media) {
         await media.insertOne(mediaData);

--- a/packages/endpoint-media/tests/helpers/publication.js
+++ b/packages/endpoint-media/tests/helpers/publication.js
@@ -1,0 +1,18 @@
+import {JekyllPreset} from '../../../preset-jekyll/index.js';
+import {GithubStore} from '../../../store-github/index.js';
+
+export const publication = {
+  config: new JekyllPreset().config,
+  me: 'https://website.example',
+  media: {
+    insertOne: () => {}
+  },
+  store: new GithubStore({
+    token: 'abc123',
+    user: 'user',
+    repo: 'repo'
+  }),
+  storeMessageTemplate: metaData => {
+    return `${metaData.action} ${metaData.postType} ${metaData.fileType}`;
+  }
+};

--- a/packages/endpoint-media/tests/lib/media.js
+++ b/packages/endpoint-media/tests/lib/media.js
@@ -1,23 +1,9 @@
 import test from 'ava';
 import nock from 'nock';
 import {getFixture} from '../helpers/fixture.js';
-import {JekyllPreset} from '../../../preset-jekyll/index.js';
-import {GithubStore} from '../../../store-github/index.js';
+import {publication} from '../helpers/publication.js';
 import {media} from '../../lib/media.js';
 import {mediaData} from '../fixtures/data.js';
-
-const publication = {
-  config: new JekyllPreset().config,
-  me: 'https://website.example',
-  store: new GithubStore({
-    token: 'abc123',
-    user: 'user',
-    repo: 'repo'
-  }),
-  media: {
-    insertOne: () => {}
-  }
-};
 
 test('Uploads a file', async t => {
   const scope = nock('https://api.github.com')

--- a/packages/endpoint-micropub/tests/helpers/publication.js
+++ b/packages/endpoint-micropub/tests/helpers/publication.js
@@ -1,0 +1,22 @@
+import {JekyllPreset} from '../../../preset-jekyll/index.js';
+import {GithubStore} from '../../../store-github/index.js';
+
+export const publication = {
+  config: new JekyllPreset().config,
+  me: 'https://website.example',
+  posts: {
+    insertOne: () => {},
+    replaceOne: () => {}
+  },
+  postTemplate(properties) {
+    return JSON.stringify(properties);
+  },
+  store: new GithubStore({
+    token: 'abc123',
+    user: 'user',
+    repo: 'repo'
+  }),
+  storeMessageTemplate: metaData => {
+    return `${metaData.action} ${metaData.postType} ${metaData.fileType}`;
+  }
+};

--- a/packages/endpoint-micropub/tests/lib/post.js
+++ b/packages/endpoint-micropub/tests/lib/post.js
@@ -1,37 +1,18 @@
 import test from 'ava';
 import nock from 'nock';
-import {JekyllPreset} from '../../../preset-jekyll/index.js';
-import {GithubStore} from '../../../store-github/index.js';
+import {publication} from '../helpers/publication.js';
 import {post} from '../../lib/post.js';
 import {postData} from '../fixtures/data.js';
 
 test.beforeEach(t => {
-  t.context = {
-    publication: {
-      config: new JekyllPreset().config,
-      me: 'https://website.example',
-      store: new GithubStore({
-        token: 'abc123',
-        user: 'user',
-        repo: 'repo'
-      }),
-      postTemplate(properties) {
-        return JSON.stringify(properties);
-      },
-      posts: {
-        insertOne: () => {},
-        replaceOne: () => {}
-      }
-    },
-    url: 'https://website.example/foo'
-  };
+  t.context.url = 'https://website.example/foo';
 });
 
 test.serial('Creates a post', async t => {
   const scope = nock('https://api.github.com')
     .put(uri => uri.includes('foo.md'))
     .reply(200, {commit: {message: 'Create post'}});
-  const result = await post.create(t.context.publication, postData);
+  const result = await post.create(publication, postData);
   t.deepEqual(result, {
     location: 'https://website.example/foo',
     status: 202,
@@ -47,14 +28,14 @@ test('Throws error creating a post', async t => {
   const error = await t.throwsAsync(
     post.create(false, postData)
   );
-  t.is(error.message, 'publication.postTemplate is not a function');
+  t.is(error.message, 'postTemplate is not a function');
 });
 
 test.serial('Updates a post', async t => {
   const scope = nock('https://api.github.com')
     .put(uri => uri.includes('foo.md'))
     .reply(200, {commit: {message: 'Update post'}});
-  const result = await post.update(t.context.publication, postData, t.context.url);
+  const result = await post.update(publication, postData, t.context.url);
   t.deepEqual(result, {
     location: 'https://website.example/foo',
     status: 200,
@@ -70,7 +51,7 @@ test('Throws error updating a post', async t => {
   const error = await t.throwsAsync(
     post.update(false, postData, t.context.url)
   );
-  t.is(error.message, 'publication.postTemplate is not a function');
+  t.is(error.message, 'postTemplate is not a function');
 });
 
 test.serial('Deletes a post', async t => {
@@ -79,7 +60,7 @@ test.serial('Deletes a post', async t => {
     .reply(200, {})
     .delete(uri => uri.includes('foo.md'))
     .reply(200, {commit: {message: 'Delete post'}});
-  const result = await post.delete(t.context.publication, postData);
+  const result = await post.delete(publication, postData);
   t.deepEqual(result, {
     status: 200,
     json: {
@@ -94,7 +75,7 @@ test('Throws error deleting a post', async t => {
   const error = await t.throwsAsync(
     post.delete(false, postData)
   );
-  t.is(error.message, 'Cannot read property \'messageFormat\' of undefined');
+  t.is(error.message, 'storeMessageTemplate is not a function');
 });
 
 test.serial('Undeletes a post', async t => {
@@ -107,9 +88,9 @@ test.serial('Undeletes a post', async t => {
     .reply(200, {commit: {message: 'Delete post'}})
     .put(uri => uri.includes('foo.md'))
     .reply(200, {commit: {message: 'Undelete post'}});
-  await post.create(t.context.publication, postData);
-  await post.delete(t.context.publication, postData);
-  const result = await post.undelete(t.context.publication, postData);
+  await post.create(publication, postData);
+  await post.delete(publication, postData);
+  const result = await post.undelete(publication, postData);
   t.deepEqual(result, {
     location: 'https://website.example/foo',
     status: 200,
@@ -131,10 +112,10 @@ test('Throws error undeleting a post', async t => {
     .reply(200, {commit: {message: 'Delete post'}})
     .put(uri => uri.includes('foo.md'))
     .replyWithError('Not found');
-  await post.create(t.context.publication, postData);
-  await post.delete(t.context.publication, postData);
+  await post.create(publication, postData);
+  await post.delete(publication, postData);
   const error = await t.throwsAsync(
-    post.undelete(t.context.publication, postData)
+    post.undelete(publication, postData)
   );
   t.regex(error.message, /\bNot found\b/);
   scope.done();
@@ -142,7 +123,7 @@ test('Throws error undeleting a post', async t => {
 
 test('Throws error undeleting a post (no post previously deleted)', async t => {
   const error = await t.throwsAsync(
-    post.undelete(t.context.publication, false)
+    post.undelete(publication, false)
   );
   t.is(error.message, 'Post was not previously deleted');
 });

--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -47,7 +47,9 @@ const publication = {
   postTypes: [],
   preset: null,
   slugSeparator: '-',
-  store: null,
+  storeMessageTemplate: metaData => {
+    return `${metaData.action} ${metaData.postType} ${metaData.fileType}`;
+  },
   syndicationTargets: [],
   timeZone: 'UTC',
   tokenEndpoint: 'https://tokens.indieauth.com/token'

--- a/packages/store-github/README.md
+++ b/packages/store-github/README.md
@@ -6,7 +6,7 @@ Store IndieWeb content on GitHub.
 
 `npm i @indiekit/store-github`
 
-## Configuration
+## Usage
 
 ```js
 const GithubStore = require('@indiekit/store-github');
@@ -16,9 +16,32 @@ const github = new GithubStore({
 });
 ```
 
-### Options
+## Options
 
-* `token`: GitHub access token. **Required**.
-* `user`: GitHub username. **Required**.
-* `repo`: GitHub repository. **Required**.
-* `branch`: GitHub branch files are saved to. *Optional*, defaults to `master`.
+### `branch`
+
+The branch files will be saved to.
+
+Type: `string`\
+*Optional*, defaults to `master`
+
+### `repo`
+
+The name of your GitHub repository.
+
+Type: `string`\
+*Required*
+
+### `token`
+
+A GitHub access token.
+
+Type: `string`\
+*Required*
+
+### `user`
+
+Your GitHub username.
+
+Type: `string`\
+*Required*

--- a/packages/store-github/index.js
+++ b/packages/store-github/index.js
@@ -1,8 +1,7 @@
 import octokit from '@octokit/rest';
 
 const defaults = {
-  branch: 'master',
-  messageFormat: '{action} {postType} {fileType}'
+  branch: 'master'
 };
 
 /**
@@ -14,10 +13,6 @@ export const GithubStore = class {
     this.id = 'github';
     this.name = 'GitHub';
     this.options = {...defaults, ...options};
-  }
-
-  get messageFormat() {
-    return this.options.messageFormat;
   }
 
   github() {

--- a/packages/store-github/tests/index.js
+++ b/packages/store-github/tests/index.js
@@ -25,11 +25,6 @@ test.beforeEach(t => {
   };
 });
 
-test('Gets message format', async t => {
-  const result = await t.context.github.messageFormat;
-  t.is(result, '{action} {postType} {fileType}');
-});
-
 test('Creates file in a repository', async t => {
   const scope = t.context.nock
     .put(uri => uri.includes('foo.txt'))

--- a/packages/store-gitlab/README.md
+++ b/packages/store-gitlab/README.md
@@ -16,11 +16,46 @@ const gitlab = new GitlabStore({
 });
 ```
 
-### Options
+## Options
 
-* `host`: GitLab Instance Host URL. *Optional*, defaults to `https://gitlab.com`.
-* `token`: GitLab access token. **Required**.
-* `user`: GitLab username. **Required (if `projectId` not provided)**.
-* `repo`: GitLab repository. **Required (if `projectId` not provided)**.
-* `projectId`: GitLab project ID. **Required (if `user` and `repo` not provided)**.
-* `branch`: GitLab branch files are saved to. *Optional*, defaults to `master`.
+### `branch`
+
+The branch files will be saved to.
+
+Type: `string`\
+*Optional*, defaults to `master`
+
+### `host`
+
+GitLab instance URL.
+
+Type: `string`\
+*Optional*, defaults to `https://gitlab.com`
+
+### `projectId`
+
+GitLab project ID.
+
+Type: `string`\
+*Required (if `user` and `repo` not provided)*
+
+### `repo`
+
+The name of your GitLab repository.
+
+Type: `string`\
+*Required (if `projectId` not provided)*
+
+### `token`
+
+A GitLab access token.
+
+Type: `string`\
+*Required*
+
+### `user`
+
+Your GitLab username.
+
+Type: `string`\
+*Required (if `projectId` not provided)*

--- a/packages/store-gitlab/index.js
+++ b/packages/store-gitlab/index.js
@@ -2,8 +2,7 @@ import gitbeaker from '@gitbeaker/node';
 
 const defaults = {
   branch: 'master',
-  instance: 'https://gitlab.com',
-  messageFormat: '{action} {postType} {fileType}'
+  instance: 'https://gitlab.com'
 };
 
 /**
@@ -16,10 +15,6 @@ export const GitlabStore = class {
     this.name = 'GitLab';
     this.options = {...defaults, ...options};
     this._projectId = options.projectId || `${options.user}/${options.repo}`;
-  }
-
-  get messageFormat() {
-    return this.options.messageFormat;
   }
 
   gitlab() {

--- a/packages/store-gitlab/tests/index.js
+++ b/packages/store-gitlab/tests/index.js
@@ -35,11 +35,6 @@ test.beforeEach(t => {
   t.context.gitlabInstance.options.instance = 'https://gitlab.instance';
 });
 
-test('Gets message format', async t => {
-  const result = await t.context.gitlab.messageFormat;
-  t.is(result, '{action} {postType} {fileType}');
-});
-
 test('Creates file in a repository', async t => {
   const scope = t.context.nock.post(uri => uri.includes('foo.txt'))
     .reply(200, t.context.postResponse);


### PR DESCRIPTION
While this doesn’t entirely address #63, it makes localising commit messages possible, should you ever want to.