### PR TITLE
Use camelcased frontmatter keys

### DIFF
--- a/packages/preset-hugo/index.js
+++ b/packages/preset-hugo/index.js
@@ -1,3 +1,4 @@
+import camelcaseKeys from 'camelcase-keys';
 import TOML from '@iarna/toml';
 import YAML from 'yaml';
 
@@ -161,6 +162,11 @@ export const HugoPreset = class {
    * @returns {string} Rendered template
    */
   postTemplate(properties) {
+    // Go templates don’t accept hyphens in property names
+    // and Hugo camelCases its predefined front matter keys
+    // https://gohugo.io/content-management/front-matter/
+    properties = camelcaseKeys(properties, {deep: true});
+
     let content;
     if (properties.content) {
       content = properties.content.text || properties.content.html || properties.content;
@@ -182,14 +188,14 @@ export const HugoPreset = class {
       ...(properties.audio && {audio: properties.audio}),
       ...(properties.photo && {images: properties.photo}),
       ...(properties.video && {videos: properties.video}),
-      ...(properties['bookmark-of'] && {'bookmark-of': properties['bookmark-of']}),
-      ...(properties['like-of'] && {'like-of': properties['like-of']}),
-      ...(properties['repost-of'] && {'repost-of': properties['repost-of']}),
-      ...(properties['in-reply-to'] && {'in-reply-to': properties['in-reply-to']}),
-      ...(properties['post-status'] === 'draft' && {draft: true}),
+      ...(properties.bookmarkOf && {bookmarkOf: properties.bookmarkOf}),
+      ...(properties.likeOf && {likeOf: properties.likeOf}),
+      ...(properties.repostOf && {repostOf: properties.repostOf}),
+      ...(properties.inReplyTo && {inReplyTo: properties.inReplyTo}),
+      ...(properties.postStatus === 'draft' && {draft: true}),
       ...(properties.visibility && {visibility: properties.visibility}),
       ...(properties.syndication && {syndication: properties.syndication}),
-      ...(properties['mp-syndicate-to'] && {'mp-syndicate-to': properties['mp-syndicate-to']})
+      ...(properties.mpSyndicateTo && {mpSyndicateTo: properties.mpSyndicateTo})
     };
 
     const frontMatter = this._getFrontMatter(properties);

--- a/packages/preset-hugo/package.json
+++ b/packages/preset-hugo/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "camelcase-keys": "^6.2.2",
     "yaml": "^1.10.2"
   },
   "publishConfig": {

--- a/packages/preset-hugo/tests/unit/preset.js
+++ b/packages/preset-hugo/tests/unit/preset.js
@@ -77,7 +77,7 @@ test('Renders post template with JSON frontmatter', t => {
   "rsvp": "Yes",
   "location": {
     "type": "adr",
-    "country-name": "United Kingdom"
+    "countryName": "United Kingdom"
   },
   "checkin": {
     "type": "card",
@@ -104,14 +104,14 @@ test('Renders post template with JSON frontmatter', t => {
       "url": "https://website.example/video.mp4"
     }
   ],
-  "bookmark-of": "https://website.example",
-  "like-of": "https://website.example",
-  "repost-of": "https://website.example",
-  "in-reply-to": "https://website.example",
+  "bookmarkOf": "https://website.example",
+  "likeOf": "https://website.example",
+  "repostOf": "https://website.example",
+  "inReplyTo": "https://website.example",
   "draft": true,
   "visibility": "private",
   "syndication": "https://website.example/post/12345",
-  "mp-syndicate-to": "https://social.example"
+  "mpSyndicateTo": "https://social.example"
 }
 I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.
 `);
@@ -130,18 +130,18 @@ category = [ "lunch", "food" ]
 start = "2020-02-02"
 end = "2020-02-20"
 rsvp = "Yes"
-bookmark-of = "https://website.example"
-like-of = "https://website.example"
-repost-of = "https://website.example"
-in-reply-to = "https://website.example"
+bookmarkOf = "https://website.example"
+likeOf = "https://website.example"
+repostOf = "https://website.example"
+inReplyTo = "https://website.example"
 draft = true
 visibility = "private"
 syndication = "https://website.example/post/12345"
-mp-syndicate-to = "https://social.example"
+mpSyndicateTo = "https://social.example"
 
 [location]
 type = "adr"
-country-name = "United Kingdom"
+countryName = "United Kingdom"
 
 [checkin]
 type = "card"
@@ -179,7 +179,7 @@ end: 2020-02-20
 rsvp: Yes
 location:
   type: adr
-  country-name: United Kingdom
+  countryName: United Kingdom
 checkin:
   type: card
   latitude:
@@ -193,14 +193,14 @@ images:
     url: https://website.example/photo.jpg
 videos:
   - url: https://website.example/video.mp4
-bookmark-of: https://website.example
-like-of: https://website.example
-repost-of: https://website.example
-in-reply-to: https://website.example
+bookmarkOf: https://website.example
+likeOf: https://website.example
+repostOf: https://website.example
+inReplyTo: https://website.example
 draft: true
 visibility: private
 syndication: https://website.example/post/12345
-mp-syndicate-to: https://social.example
+mpSyndicateTo: https://social.example
 ---
 I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.
 `);


### PR DESCRIPTION
[Go templates don’t accept hyphens in property names](https://github.com/gohugoio/hugo/issues/1474), and [Hugo camelCases its predefined front matter keys](https://gohugo.io/content-management/front-matter/).

This PR ensures all front matter (including nested ones) use camelCased key names. Fixes #345.