### PR TITLE
Fix store-gitea README typo

### DIFF
--- a/packages/store-gitea/README.md
+++ b/packages/store-gitea/README.md
@@ -25,7 +25,7 @@ The branch files will be saved to.
 Type: `string`\
 *Optional*, defaults to `master`
 
-### `host`
+### `instance`
 
 Gitea instance URL.
 


### PR DESCRIPTION
Fix the name of the var host to instance. Took me a long time to figure it out on my install.