### PR TITLE
Add FTP content store plug-in. Fixes #278

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "indiekit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "indiekit",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "indiekit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "An IndieWeb publishing toolkit",
   "keywords": [
     "indieweb",

--- a/packages/store-ftp/README.md
+++ b/packages/store-ftp/README.md
@@ -1,0 +1,26 @@
+# @indiekit/store-ftp
+
+Store IndieWeb content via FTP.
+
+## Installation
+
+`npm i @indiekit/store-ftp`
+
+## Configuration
+
+```js
+const FtpStore = require('@indiekit/store-ftp');
+
+const ftp = new FtpStore({
+  // Options
+});
+```
+
+## Options
+
+| Option | Type | Description |
+| :----- | :--- | :---------- |
+| `host` | `string` | Your FTP hostname, for example ftp.server.example. *Required* |
+| `directory` | `string` | Directory to save files to. *Optional* |
+| `user` | `string` | Your FTP username. *Required* |
+| `password` | `string` | Your FTP password. *Required* |

--- a/packages/store-ftp/index.js
+++ b/packages/store-ftp/index.js
@@ -1,0 +1,123 @@
+import path from 'path';
+import ftp from 'basic-ftp';
+import {Readable} from 'stream';
+
+const defaults = {
+  port: 21,
+  verbose: true
+};
+
+/**
+ * @typedef Response
+ * @property {object} response HTTP response
+ */
+export const FtpStore = class {
+  constructor(options = {}) {
+    this.id = 'ftp';
+    this.name = 'FTP';
+    this.options = {...defaults, ...options};
+  }
+
+  async client() {
+    const {host, user, password, port, verbose} = this.options;
+    const client = new ftp.Client();
+    client.ftp.verbose = verbose;
+    await client.access({host, user, password, port, secure: true});
+    return client;
+  }
+
+  /**
+   * Create readable stream
+   *
+   * @private
+   * @param {string} content File content
+   * @returns {string} Readable stream
+   */
+  #createReadableStream(content) {
+    const readableStream = new Readable();
+    readableStream._read = () => {};
+    readableStream.push(content, 'utf-8');
+    readableStream.push(null);
+    return readableStream;
+  };
+
+  /**
+   * Get absolute file path
+   *
+   * @private
+   * @param {string} filePath Path to file
+   * @returns {string} Absolute file path
+   */
+  #getAbsolutePath(filePath) {
+    return path.join(this.options.directory, filePath);
+  };
+
+  /**
+   * Create file
+   *
+   * @param {string} filePath Path to file
+   * @param {string} content File content
+   * @returns {Promise<Response>} HTTP response
+   */
+  async createFile(filePath, content) {
+    const client = await this.client();
+
+    try {
+      const readableStream = this.#createReadableStream(content);
+      const absolutePath = this.#getAbsolutePath(filePath);
+      const dirname = path.dirname(absolutePath);
+      const basename = path.basename(absolutePath);
+
+      await client.ensureDir(dirname);
+      await client.uploadFrom(readableStream, basename);
+    } catch (error) {
+      throw new Error(error.message);
+    }
+
+    client.close();
+    return true;
+  }
+
+  /**
+   * Update file
+   *
+   * @param {string} filePath Path to file
+   * @param {string} content File content
+   * @returns {Promise<Response>} A promise to the response
+   */
+  async updateFile(filePath, content) {
+    const client = await this.client();
+
+    try {
+      const readableStream = this.#createReadableStream(content);
+      const absolutePath = this.#getAbsolutePath(filePath);
+
+      await client.uploadFrom(readableStream, absolutePath);
+    } catch (error) {
+      throw new Error(error);
+    }
+
+    client.close();
+    return true;
+  }
+
+  /**
+   * Delete file
+   *
+   * @param {string} filePath Path to file
+   * @returns {Promise<Response>} A promise to the response
+   */
+  async deleteFile(filePath) {
+    const absolutePath = this.#getAbsolutePath(filePath);
+    const client = await this.client();
+
+    try {
+      await client.remove(absolutePath);
+    } catch (error) {
+      throw new Error(error);
+    }
+
+    client.close();
+    return true;
+  }
+};

--- a/packages/store-ftp/package.json
+++ b/packages/store-ftp/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@indiekit/store-ftp",
+  "version": "0.1.4",
+  "description": "Store IndieWeb content via FTP",
+  "keywords": [
+    "indiekit",
+    "indieweb",
+    "micropub",
+    "ftp"
+  ],
+  "homepage": "https://getindiekit.com",
+  "author": {
+    "name": "Paul Robert Lloyd",
+    "url": "https://paulrobertlloyd.com"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "type": "module",
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "bugs": {
+    "url": "https://github.com/getindiekit/indiekit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getindiekit/indiekit.git",
+    "directory": "packages/store-ftp"
+  },
+  "dependencies": {
+    "basic-ftp": "^4.6.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
Adds support for FTP as a content store. It’s missing tests, but wasn’t able to work out how to stub out a fake FTP server to test against.

This plug-in really exists to demonstrate the ability to connect to content stores that are not Git repositories, so it’s worth publishing for that reason alone.