### PR TITLE
feat(n token): add post type count token for the day

### DIFF
--- a/docs/customisation/post-types.md
+++ b/docs/customisation/post-types.md
@@ -82,6 +82,7 @@ Both `*.path` and `*.url` values can be customised using the following tokens:
 | `T`            | `post` `media`  | UNIX epoch milliseconds, eg <samp>51296952000</samp>                           |
 | `uuid`         | `post` `media`  | A [random UUID][uuid]                                                          |
 | `slug`         | `post`          | Provided slug, slugified `name` or a 5 character string, eg <samp>ycf9o</samp> |
+| `n`            | `post`          | Incremental count of posts (for type) in the same day, eq <samp>1</samp>       |
 | `basename`     | `media`         | 5 character alpha-numeric string, eg <samp>w9gwi</samp>                        |
 | `ext`          | `media`         | File extension of uploaded file, eg <samp>jpg</samp>                           |
 | `filename`     | `media`         | `basename` plus `ext`, eg <samp>w9gwi.jpg</samp>                               |

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -37,8 +37,8 @@ export const postData = {
       properties['post-type'] = type;
 
       // Post paths
-      const path = renderPath(typeConfig.post.path, properties, timeZone);
-      const url = renderPath(typeConfig.post.url, properties, timeZone);
+      const path = await renderPath(typeConfig.post.path, properties, publication, timeZone);
+      const url = await renderPath(typeConfig.post.url, properties, publication, timeZone);
       properties.url = getPermalink(me, url);
 
       // Post data
@@ -136,8 +136,8 @@ export const postData = {
       properties['post-type'] = type;
 
       // Post paths
-      const path = renderPath(typeConfig.post.path, properties, timeZone);
-      const updatedUrl = renderPath(typeConfig.post.url, properties, timeZone);
+      const path = await renderPath(typeConfig.post.path, properties, publication, timeZone);
+      const updatedUrl = await renderPath(typeConfig.post.url, properties, publication, timeZone);
       properties.url = getPermalink(me, updatedUrl);
 
       // Return post data

--- a/packages/endpoint-micropub/lib/post-type-count.js
+++ b/packages/endpoint-micropub/lib/post-type-count.js
@@ -1,0 +1,60 @@
+import HttpError from 'http-errors';
+import {getPostType} from './post-type-discovery.js';
+import {normaliseProperties} from './jf2.js';
+
+export const postTypeCount = {
+  /**
+   * Count number of posts in given type
+   *
+   * @param {object} publication Publication configuration
+   * @param {object} properties JF2 properties
+   * @returns {object} Post count
+   */
+  async get(publication, properties) {
+    try {
+      if (!publication) {
+        throw new Error('No publication configuration provided');
+      }
+
+      if (!publication.posts || !publication.posts.count()) {
+        throw new Error('No database configuration provided');
+      }
+
+      if (!properties) {
+        throw new Error('No properties included in request');
+      }
+
+      // Normalise properties
+      properties = normaliseProperties(publication, properties);
+
+      // Post type
+      const type = getPostType(properties);
+      const startDate = new Date(new Date(properties.published).toDateString());
+      const endDate = new Date(startDate);
+      endDate.setDate(endDate.getDate() + 1);
+      const response = await publication.posts
+        .aggregate([
+          {
+            $addFields: {
+              convertedDate: {
+                $toDate: '$properties.published',
+              },
+            },
+          },
+          {
+            $match: {
+              'properties.post-type': type,
+              convertedDate: {
+                $gte: startDate,
+                $lt: endDate,
+              },
+            },
+          },
+        ])
+        .toArray();
+      return response.length;
+    } catch (error) {
+      throw new HttpError(400, error);
+    }
+  },
+};

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -4,6 +4,7 @@ import newbase60 from 'newbase60';
 import slugify from '@sindresorhus/slugify';
 import {v4 as uuidv4} from 'uuid';
 import {getServerTimeZone} from './date.js';
+import {postTypeCount} from './post-type-count.js';
 
 const {format} = dateFnsTz;
 
@@ -106,7 +107,7 @@ export const relativeMediaPath = (url, me) => url.includes(me) ? url.replace(me,
  * @param {string} timeZoneSetting Time zone setting
  * @returns {string} Path
  */
-export const renderPath = (path, properties, timeZoneSetting) => {
+export const renderPath = async (path, properties, publication, timeZoneSetting) => {
   let tokens = {};
   const dateObject = new Date(properties.published);
   const serverTimeZone = getServerTimeZone();
@@ -145,6 +146,10 @@ export const renderPath = (path, properties, timeZoneSetting) => {
 
   // Add day of the year (NewBase60) token
   tokens.D60 = newbase60.DateToSxg(dateObject); // eslint-disable-line new-cap
+
+  // Add count of post-type for the day
+  const count = await postTypeCount.get(publication, properties);
+  tokens.n = count + 1;
 
   // Add slug token if 'mp-slug' property
   if (properties['mp-slug']) {

--- a/packages/endpoint-micropub/tests/unit/utils.js
+++ b/packages/endpoint-micropub/tests/unit/utils.js
@@ -70,7 +70,24 @@ test('Renders path from URI template and properties', t => {
   };
   const template = '{yyyy}/{MM}/{uuid}/{slug}';
 
-  const result = renderPath(template, properties);
+  const publication = {
+    posts: {
+      path: 'foo',
+      properties: {
+        type: 'entry',
+        published: '2019-08-17T23:56:38.977+01:00',
+        'post-type': 'note',
+      },
+      count() {
+        return 1;
+      },
+      aggregate: () => ({
+        toArray: async () => [],
+      }),
+    },
+  };
+
+  const result = renderPath(template, properties, publication);
 
   t.regex(result, /\d{4}\/\d{2}\/[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}\/foo/);
 });


### PR DESCRIPTION
Per discussion here: https://github.com/getindiekit/indiekit/issues/257

This does nothing more than create a `post` url token to search the MongoDB (if it exists and is called) for the count of posts (of a given type) created in the day. No new database creations.

If the `n` token is used, but no database connection is configured, it will throw an error.