### PR TITLE
Add file system store

### DIFF
--- a/docs/plug-ins.md
+++ b/docs/plug-ins.md
@@ -11,6 +11,7 @@ You can find more plug-ins on npm under the [`indiekit-plugin`](https://www.npmj
 A [content store](../concepts#content-store) is a location where Indiekit can save post content and media files. Plug-ins are available for the following platforms:
 
 - [@indiekit/store-bitbucket](https://npmjs.org/package/@indiekit/store-bitbucket)
+- [@indiekit/store-file-system](https://npmjs.org/package/@indiekit/store-file-system)
 - [@indiekit/store-ftp](https://npmjs.org/package/@indiekit/store-ftp)
 - [@indiekit/store-gitea](https://npmjs.org/package/@indiekit/store-gitea)
 - [@indiekit/store-github](https://npmjs.org/package/@indiekit/store-github)

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "create-indiekit": "*",
         "eslint-plugin-jsdoc": "^39.0.0",
         "jsdom": "^19.0.0",
+        "mock-fs": "^5.1.2",
         "mock-req-res": "^1.2.0",
         "mock-session": "^0.0.5",
         "mongodb-memory-server": "^8.2.0",
@@ -56,30 +57,37 @@
       }
     },
     "helpers/config": {
+      "name": "@indiekit-test/config",
       "version": "0.0.0-test-only",
       "license": "MIT"
     },
     "helpers/fixtures": {
+      "name": "@indiekit-test/fixtures",
       "version": "0.0.0-test-only",
       "license": "MIT"
     },
     "helpers/media-data": {
+      "name": "@indiekit-test/media-data",
       "version": "0.0.0-test-only",
       "license": "MIT"
     },
     "helpers/mock-agent": {
+      "name": "@indiekit-test/mock-agent",
       "version": "0.0.0-test-only",
       "license": "MIT"
     },
     "helpers/post-data": {
+      "name": "@indiekit-test/post-data",
       "version": "0.0.0-test-only",
       "license": "MIT"
     },
     "helpers/publication": {
+      "name": "@indiekit-test/publication",
       "version": "0.0.0-test-only",
       "license": "MIT"
     },
     "helpers/server": {
+      "name": "@indiekit-test/server",
       "version": "0.0.0-test-only",
       "license": "MIT",
       "dependencies": {
@@ -98,6 +106,7 @@
       }
     },
     "helpers/session": {
+      "name": "@indiekit-test/session",
       "version": "0.0.0-test-only",
       "license": "MIT"
     },
@@ -1322,6 +1331,10 @@
     },
     "node_modules/@indiekit/store-bitbucket": {
       "resolved": "packages/store-bitbucket",
+      "link": true
+    },
+    "node_modules/@indiekit/store-file-system": {
+      "resolved": "packages/store-file-system",
       "link": true
     },
     "node_modules/@indiekit/store-ftp": {
@@ -13649,6 +13662,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/mock-fs": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
+      "integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/mock-req-res": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mock-req-res/-/mock-req-res-1.2.0.tgz",
@@ -21440,6 +21462,7 @@
       }
     },
     "packages/endpoint-image": {
+      "name": "@indiekit/endpoint-image",
       "version": "1.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
@@ -21640,6 +21663,7 @@
       }
     },
     "packages/endpoint-media": {
+      "name": "@indiekit/endpoint-media",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21659,6 +21683,7 @@
       }
     },
     "packages/endpoint-micropub": {
+      "name": "@indiekit/endpoint-micropub",
       "version": "1.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
@@ -21683,6 +21708,7 @@
       }
     },
     "packages/endpoint-share": {
+      "name": "@indiekit/endpoint-share",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21695,6 +21721,7 @@
       }
     },
     "packages/endpoint-syndicate": {
+      "name": "@indiekit/endpoint-syndicate",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21707,6 +21734,7 @@
       }
     },
     "packages/endpoint-token": {
+      "name": "@indiekit/endpoint-token",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21721,6 +21749,7 @@
       }
     },
     "packages/frontend": {
+      "name": "@indiekit/frontend",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21742,6 +21771,7 @@
       }
     },
     "packages/indiekit": {
+      "name": "@indiekit/indiekit",
       "version": "1.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
@@ -21790,6 +21820,7 @@
       }
     },
     "packages/preset-hugo": {
+      "name": "@indiekit/preset-hugo",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21810,6 +21841,7 @@
       }
     },
     "packages/preset-jekyll": {
+      "name": "@indiekit/preset-jekyll",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21828,6 +21860,7 @@
       }
     },
     "packages/store-bitbucket": {
+      "name": "@indiekit/store-bitbucket",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21837,7 +21870,16 @@
         "node": ">=18"
       }
     },
+    "packages/store-file-system": {
+      "name": "@indiekit/store-file-system",
+      "version": "1.0.0-alpha.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "packages/store-ftp": {
+      "name": "@indiekit/store-ftp",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21848,6 +21890,7 @@
       }
     },
     "packages/store-gitea": {
+      "name": "@indiekit/store-gitea",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21858,6 +21901,7 @@
       }
     },
     "packages/store-github": {
+      "name": "@indiekit/store-github",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21868,6 +21912,7 @@
       }
     },
     "packages/store-gitlab": {
+      "name": "@indiekit/store-gitlab",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21878,6 +21923,7 @@
       }
     },
     "packages/syndicator-internet-archive": {
+      "name": "@indiekit/syndicator-internet-archive",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21888,6 +21934,7 @@
       }
     },
     "packages/syndicator-mastodon": {
+      "name": "@indiekit/syndicator-mastodon",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -21902,6 +21949,7 @@
       }
     },
     "packages/syndicator-twitter": {
+      "name": "@indiekit/syndicator-twitter",
       "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -23091,6 +23139,9 @@
       "requires": {
         "bitbucket": "^2.6.2"
       }
+    },
+    "@indiekit/store-file-system": {
+      "version": "file:packages/store-file-system"
     },
     "@indiekit/store-ftp": {
       "version": "file:packages/store-ftp",
@@ -32498,6 +32549,12 @@
         "infer-owner": "^1.0.4",
         "mkdirp": "^1.0.3"
       }
+    },
+    "mock-fs": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
+      "integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
+      "dev": true
     },
     "mock-req-res": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "create-indiekit": "*",
     "eslint-plugin-jsdoc": "^39.0.0",
     "jsdom": "^19.0.0",
+    "mock-fs": "^5.1.2",
     "mock-req-res": "^1.2.0",
     "mock-session": "^0.0.5",
     "mongodb-memory-server": "^8.2.0",

--- a/packages/store-file-system/README.md
+++ b/packages/store-file-system/README.md
@@ -1,0 +1,26 @@
+# @indiekit/store-file-system
+
+Store IndieWeb content on your local file system.
+
+## Installation
+
+`npm i @indiekit/store-file-system`
+
+## Usage
+
+Add `@indiekit/store-file-system` to your list of plugins, specifying options as required:
+
+```json
+{
+  "plugins": ["@indiekit/store-file-system"],
+  "@indiekit/store-file-system": {
+    "directory": "project/www"
+  }
+}
+```
+
+## Options
+
+| Option      | Type     | Description                                                                    |
+| :---------- | :------- | :----------------------------------------------------------------------------- |
+| `directory` | `string` | Directory to save files to. _Optional_, defaults to current working directory. |

--- a/packages/store-file-system/assets/icon.svg
+++ b/packages/store-file-system/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <path fill="#F70" d="M0 0h96v96H0z"/>
+  <path fill="#FFF" d="M78 33c2 0 4 2 4 4v32c0 2-2 4-4 4H18c-2 0-4-2-4-4V27c0-2 2-4 4-4h17c2 0 4 1 5 3l3 5H17l-1 1 1 1h61Z"/>
+</svg>

--- a/packages/store-file-system/index.js
+++ b/packages/store-file-system/index.js
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const defaults = {
+  directory: process.cwd(),
+};
+
+/**
+ * @typedef Response
+ * @property {boolean} response Response
+ */
+export const FileSystemStore = class {
+  constructor(options = {}) {
+    this.id = "file-system";
+    this.meta = import.meta;
+    this.name = "File system store";
+    this.options = { ...defaults, ...options };
+  }
+
+  get info() {
+    const { directory } = this.options;
+
+    return {
+      name: directory,
+      uid: `file://${directory}`,
+    };
+  }
+
+  get prompts() {
+    return [
+      {
+        type: "text",
+        name: "directory",
+        message: "Which directory do you want to save files in?",
+      },
+    ];
+  }
+
+  /**
+   * Get absolute file path
+   *
+   * @private
+   * @param {string} filePath Path to file
+   * @returns {string} Absolute file path
+   */
+  #getAbsolutePath(filePath) {
+    return path.join(this.options.directory, filePath);
+  }
+
+  /**
+   * Create file in a directory
+   *
+   * @param {string} filePath Path to file
+   * @param {string} content File content
+   * @returns {Promise<Response>} A promise to the response
+   */
+  async createFile(filePath, content) {
+    const absolutePath = this.#getAbsolutePath(filePath);
+    const dirname = path.dirname(absolutePath);
+
+    try {
+      if (!existsSync(dirname)) {
+        await fs.mkdir(dirname, { recursive: true });
+      }
+
+      await fs.writeFile(absolutePath, content);
+    } catch (error) {
+      throw new Error(error.message);
+    }
+
+    return true;
+  }
+
+  /**
+   * Update file in a directory
+   *
+   * @param {string} filePath Path to file
+   * @param {string} content File content
+   * @returns {Promise<Response>} A promise to the response
+   */
+  async updateFile(filePath, content) {
+    const absolutePath = this.#getAbsolutePath(filePath);
+
+    try {
+      await fs.writeFile(absolutePath, content);
+    } catch (error) {
+      throw new Error(error.message);
+    }
+
+    return true;
+  }
+
+  /**
+   * Delete file in a directory
+   *
+   * @param {string} filePath Path to file
+   * @returns {Promise<Response>} A promise to the response
+   */
+  async deleteFile(filePath) {
+    const absolutePath = this.#getAbsolutePath(filePath);
+
+    try {
+      await fs.rm(absolutePath);
+    } catch (error) {
+      throw new Error(error.message);
+    }
+
+    return true;
+  }
+
+  init(Indiekit) {
+    Indiekit.addStore(this);
+  }
+};
+
+export default FileSystemStore;

--- a/packages/store-file-system/package.json
+++ b/packages/store-file-system/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@indiekit/store-file-system",
+  "version": "1.0.0-alpha.0",
+  "description": "File system content store adaptor for Indiekit",
+  "keywords": [
+    "indiekit",
+    "indiekit-plugin",
+    "indieweb",
+    "micropub"
+  ],
+  "homepage": "https://getindiekit.com",
+  "author": {
+    "name": "Paul Robert Lloyd",
+    "url": "https://paulrobertlloyd.com"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "type": "module",
+  "main": "index.js",
+  "files": [
+    "assets",
+    "index.js"
+  ],
+  "bugs": {
+    "url": "https://github.com/getindiekit/indiekit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getindiekit/indiekit.git",
+    "directory": "packages/store-file-system"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/store-file-system/tests/unit/store.js
+++ b/packages/store-file-system/tests/unit/store.js
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import test from "ava";
+import mockFs from "mock-fs";
+import { Indiekit } from "@indiekit/indiekit";
+import { FileSystemStore } from "../../index.js";
+
+const fileSystem = new FileSystemStore({
+  directory: "directory",
+});
+
+test("Gets plug-in info", (t) => {
+  t.is(fileSystem.name, "File system store");
+  t.is(fileSystem.info.name, "directory");
+  t.is(fileSystem.info.uid, "file://directory");
+});
+
+test("Gets plug-in installation prompts", (t) => {
+  t.is(
+    fileSystem.prompts[0].message,
+    "Which directory do you want to save files in?"
+  );
+});
+
+test("Initiates plug-in", (t) => {
+  const indiekit = new Indiekit();
+  fileSystem.init(indiekit);
+
+  t.is(indiekit.publication.store.info.name, "directory");
+});
+
+test.serial("Creates file in a directory", async (t) => {
+  mockFs();
+
+  await fileSystem.createFile("foo.txt", "foo");
+  const result = await fs.readFile("directory/foo.txt", "utf8");
+
+  t.is(result, "foo");
+  mockFs.restore();
+});
+
+test("Throws error creating file in a directory", async (t) => {
+  mockFs();
+
+  await t.throwsAsync(fileSystem.createFile("", "foo"), {
+    message: "EBADF, bad file descriptor",
+  });
+
+  mockFs.restore();
+});
+
+test.serial("Updates file in a directory", async (t) => {
+  mockFs({
+    "directory/foo.txt": "foo",
+  });
+
+  await fileSystem.updateFile("foo.txt", "bar");
+  const result = await fs.readFile("directory/foo.txt", "utf8");
+
+  t.is(result, "bar");
+  mockFs.restore();
+});
+
+test("Throws error updating file in a directory", async (t) => {
+  mockFs();
+
+  await t.throwsAsync(fileSystem.updateFile("foo.txt", "foo"), {
+    message: "ENOENT, no such file or directory 'directory/foo.txt'",
+  });
+
+  mockFs.restore();
+});
+
+test.serial("Deletes file in a directory", async (t) => {
+  mockFs({
+    "directory/foo.txt": "foo",
+  });
+
+  await fileSystem.deleteFile("foo.txt");
+  const result = existsSync("directory/foo.txt");
+
+  t.false(result);
+  mockFs.restore();
+});
+
+test("Throws error deleting file in a directory", async (t) => {
+  mockFs();
+
+  await t.throwsAsync(fileSystem.deleteFile("foo.txt"), {
+    message: "ENOENT, no such file or directory 'directory/foo.txt'",
+  });
+
+  mockFs.restore();
+});


### PR DESCRIPTION
Useful for testing Indiekit locally. Fixes #420.

Only tested on macOS, though uses Node.js `fs` module so _should_ work across different environments. Can address any issues as/when they arise.

Thanks to @aciccarello for idea and an initial implementation.