### PR TITLE
Return custom post types if no preset provided

### DIFF
--- a/helpers/config/index.js
+++ b/helpers/config/index.js
@@ -6,6 +6,7 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 const defaultOptions = {
   locale: "en",
   useDatabase: true,
+  usePostTypes: true,
   usePreset: true,
   useSyndicator: true,
 };
@@ -17,11 +18,11 @@ export const testConfig = async (options) => {
   const mongod = await MongoMemoryServer.create();
   const mongodbUrl = mongod.getUri();
 
-  // Configure note post type with date-less URL for easier testing
+  // Configure custom note post type with date-less URL for easier testing
   const postTypes = [
     {
       type: "note",
-      name: "Note",
+      name: "Custom note post type",
       post: {
         path: "src/content/notes/{slug}.md",
         url: "notes/{slug}/",
@@ -46,7 +47,7 @@ export const testConfig = async (options) => {
     ],
     publication: {
       me: options?.publication?.me || process.env.TEST_PUBLICATION_URL,
-      postTypes,
+      ...(options.usePostTypes && { postTypes }),
       timeZone: "UTC",
       tokenEndpoint: options?.publication?.tokenEndpoint,
     },

--- a/packages/indiekit/lib/publication.js
+++ b/packages/indiekit/lib/publication.js
@@ -83,22 +83,20 @@ export const getPostTemplate = (publication) => {
  * Get merged preset and custom post types
  *
  * @param {object} publication - Publication configuration
+ * @param {Array} publication.postTypes - Publication post types
+ * @param {object} publication.preset - Publication preset
  * @returns {object} Merged configuration
  */
-export const getPostTypes = (publication) => {
-  const hasPresetPostTypes = publication.preset && publication.preset.postTypes;
-  const hasCustomPostTypes = publication.postTypes;
-
-  if (hasPresetPostTypes && hasCustomPostTypes) {
-    const mergedPostTypes = _.values(
-      _.merge(
-        _.keyBy(publication.preset.postTypes, "type"),
-        _.keyBy(publication.postTypes, "type")
-      )
+export const getPostTypes = ({ postTypes, preset }) => {
+  if (preset?.postTypes && postTypes) {
+    return _.values(
+      _.merge(_.keyBy(preset.postTypes, "type"), _.keyBy(postTypes, "type"))
     );
-
-    return mergedPostTypes;
   }
 
-  return [];
+  if (preset?.postTypes) {
+    return preset.postTypes;
+  }
+
+  return postTypes;
 };

--- a/packages/indiekit/tests/unit/publication.js
+++ b/packages/indiekit/tests/unit/publication.js
@@ -107,53 +107,54 @@ test("Gets default post template", (t) => {
   t.is(result, '{"published":"2021-01-21"}');
 });
 
-test("Merges values from custom and preset post types", (t) => {
-  t.context.publication.postTypes = [
-    {
-      type: "note",
-      name: "Journal entry",
-      post: {
-        path: "_entries/{T}.md",
-        url: "entries/{T}",
-      },
-    },
-    {
-      type: "photo",
-      name: "Picture",
-      post: {
-        path: "_pictures/{T}.md",
-        url: "_pictures/{T}",
-      },
-      media: {
-        path: "src/media/pictures/{T}.{ext}",
-        url: "media/pictures/{T}.{ext}",
-      },
-    },
-  ];
-  const result = getPostTypes(t.context.publication);
+test("Merges values from custom and preset post types", async (t) => {
+  const config = await testConfig({
+    usePostTypes: true,
+    usePreset: true,
+  });
+  const indiekit = new Indiekit({ config });
+  const { publication } = await indiekit.bootstrap();
 
-  t.deepEqual(result[1], {
-    type: "note",
-    name: "Journal entry",
-    post: {
-      path: "_entries/{T}.md",
-      url: "entries/{T}",
-    },
-  });
-  t.deepEqual(result[2], {
-    type: "photo",
-    name: "Picture",
-    post: {
-      path: "_pictures/{T}.md",
-      url: "_pictures/{T}",
-    },
-    media: {
-      path: "src/media/pictures/{T}.{ext}",
-      url: "media/pictures/{T}.{ext}",
-    },
-  });
+  const result = getPostTypes(publication);
+
+  t.is(result[0].name, "Article");
+  t.is(result[1].name, "Custom note post type");
 });
 
-test("Returns array if no preset or custom post types", (t) => {
-  t.deepEqual(getPostTypes({}), []);
+test("Returns preset post types", async (t) => {
+  const config = await testConfig({
+    usePostTypes: false,
+    usePreset: true,
+  });
+  const indiekit = new Indiekit({ config });
+  const { publication } = await indiekit.bootstrap();
+
+  const result = getPostTypes(publication);
+
+  t.is(result[0].name, "Article");
+  t.is(result[1].name, "Note");
+});
+
+test("Returns custom post types", async (t) => {
+  const config = await testConfig({
+    usePostTypes: true,
+    usePreset: false,
+  });
+  const indiekit = new Indiekit({ config });
+  const { publication } = await indiekit.bootstrap();
+
+  const result = getPostTypes(publication);
+
+  t.is(result[0].name, "Custom note post type");
+});
+
+test("Returns array if no preset or custom post types", async (t) => {
+  const config = await testConfig({
+    usePostTypes: false,
+    usePreset: false,
+  });
+  const indiekit = new Indiekit({ config });
+  const { publication } = await indiekit.bootstrap();
+
+  t.deepEqual(getPostTypes(publication), []);
 });


### PR DESCRIPTION
Previously, custom post types would only be used if a preset was being used also. However, a preset is optional, so not having a preset shouldn’t stop other values being set.