### PR TITLE
Enrich post data with Microformats from referenced URLs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -216,6 +216,57 @@ Example, using a URL:
 
 ---
 
+### publication.enrichPostData `boolean`
+
+Fetch and append data about URLs referenced in new posts.
+
+_Optional_, defaults to `false`. For example:
+
+```json
+{
+  "publication": {
+    "enrichPostData": true
+  }
+}
+```
+
+When enabled, Indiekit will try to fetch Microformats data for any URL in a new post (for example URLs for `bookmark-of`, `like-of`, `repost-of`, `in-reply-to`).
+
+If any data is found, a `references` property will be included in the resulting post data. For example, given the following Micropub request:
+
+```http
+POST /micropub HTTP/1.1
+Host: indiekit.mywebsite.com
+Content-type: application/x-www-form-urlencoded
+Authorization: Bearer XXXXXXX
+
+h=entry
+&content=This+made+me+very+hungry.
+&bookmark-of=https://website.example/notes/123
+```
+
+should the note post at `https://website.example/notes/123` include Microformats, the following post data would be generated:
+
+```js
+{
+  date: "2022-11-03T22:00:00",
+  "bookmark-of": "https://website.example/notes/123",
+  content: "This made me very hungry.",
+  references: {
+    "https://website.example/notes/123": {
+      type: "entry",
+      published: "2013-03-07",
+      content: "I ate a cheese sandwich, which was nice.",
+      url: "https://website.example/notes/123"
+    }
+  }
+}
+```
+
+This referenced Microformats data could then be used in the design of your website to provide extra information about the content you are linking to.
+
+---
+
 ### publication.locale `string`
 
 Your publication’s locale. Currently used to format dates.

--- a/helpers/mock-agent/website.js
+++ b/helpers/mock-agent/website.js
@@ -10,9 +10,13 @@ export function mockClient() {
   agent.disableNetConnect();
 
   const client = agent.get("https://website.example");
-  const photo = getFixture("file-types/photo.jpg", false);
+
+  // Get post
+  const post = getFixture("html/post.html");
+  client.intercept({ path: "/post.html" }).reply(200, post);
 
   // Get media files
+  const photo = getFixture("file-types/photo.jpg", false);
   for (let path of [1, 2, 3, 4, 5, 6]) {
     path = `/photo${path}.jpg`;
     client.intercept({ path }).reply(200, photo);

--- a/packages/endpoint-micropub/lib/controllers/action.js
+++ b/packages/endpoint-micropub/lib/controllers/action.js
@@ -43,8 +43,12 @@ export const actionController = async (request, response, next) => {
     switch (action) {
       case "create":
         // Create and normalise JF2 data
+        jf2 = request.is("json")
+          ? await mf2ToJf2(body, publication.enrichPostData)
+          : formEncodedToJf2(body);
+
+        // Attach files
         // TODO: Attached photos don’t appear with correct alt text
-        jf2 = request.is("json") ? mf2ToJf2(body) : formEncodedToJf2(body);
         jf2 = files ? await uploadMedia(token, publication, jf2, files) : jf2;
 
         data = await postData.create(publication, jf2);

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -1,4 +1,4 @@
-import { mf2tojf2 } from "@paulrobertlloyd/mf2tojf2";
+import { mf2tojf2, mf2tojf2referenced } from "@paulrobertlloyd/mf2tojf2";
 import { striptags } from "striptags";
 import { getDate } from "./date.js";
 import { markdownToHtml, htmlToMarkdown } from "./markdown.js";
@@ -47,12 +47,17 @@ export const formEncodedToJf2 = (body) => {
  * Convert mf2 to JF2
  *
  * @param {string} body - Form-encoded request body
+ * @param {boolean} requestReferences - Request data for any referenced URLs
  * @returns {string} Micropub action
  */
-export const mf2ToJf2 = (body) => {
+export const mf2ToJf2 = async (body, requestReferences) => {
   const mf2 = {
     items: [body],
   };
+
+  if (requestReferences) {
+    return mf2tojf2referenced(mf2);
+  }
 
   return mf2tojf2(mf2);
 };

--- a/packages/endpoint-micropub/lib/post.js
+++ b/packages/endpoint-micropub/lib/post.js
@@ -23,7 +23,9 @@ export const post = {
       postData.lastAction = metaData.action;
 
       if (posts) {
-        await posts.insertOne(postData);
+        await posts.insertOne(postData, {
+          checkKeys: false,
+        });
       }
 
       return {
@@ -66,7 +68,10 @@ export const post = {
           {
             "properties.url": postData.properties.url,
           },
-          postData
+          postData,
+          {
+            checkKeys: false,
+          }
         );
       }
 
@@ -111,7 +116,10 @@ export const post = {
           {
             "properties.url": postData.properties.url,
           },
-          postData
+          postData,
+          {
+            checkKeys: false,
+          }
         );
       }
 
@@ -158,7 +166,10 @@ export const post = {
           {
             "properties.url": postData.properties.url,
           },
-          postData
+          postData,
+          {
+            checkKeys: false,
+          }
         );
       }
 

--- a/packages/preset-hugo/index.js
+++ b/packages/preset-hugo/index.js
@@ -244,6 +244,7 @@ export default class HugoPreset {
       ...(properties.mpSyndicateTo && {
         mpSyndicateTo: properties.mpSyndicateTo,
       }),
+      ...(properties.references && { references: properties.references }),
     };
 
     const frontMatter = this.#frontMatter(properties);

--- a/packages/preset-jekyll/index.js
+++ b/packages/preset-jekyll/index.js
@@ -176,6 +176,7 @@ export default class JekyllPreset {
       ...(properties["mp-syndicate-to"] && {
         "mp-syndicate-to": properties["mp-syndicate-to"],
       }),
+      ...(properties.references && { references: properties.references }),
     };
     let frontMatter = YAML.stringify(properties, { lineWidth: 0 });
     frontMatter = `---\n${frontMatter}---\n`;


### PR DESCRIPTION
Disabled by default, this PR adds a new option `publication.enrichPostData`. If enabled, Indiekit will try to fetch Microformats data for any URL given in a new post (for example URLs for `bookmark-of`, `like-of`, `repost-of`, `in-reply-to`).

This has been sitting around in a branch since the discussion first arose in #147. In retrospect, it’s a perfectly fine advanced feature to include (although certainly not something to enable by default). Anyway, with the benefit of time and given subsequent refactors that have happened around post data in the interim, happy with how this is now incorporated into the overall flow of things.

Have tried to document this feature as best as possible, but like all things IndieWeb, it’s complicated 😒