### PR TITLE
Warn about database requirement when attempting to get post count

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Publish content to your website using apps like [iAWriter](https://ia.net/writer
 
 - Node.js v18+
 
+A [MongoDB](https://www.mongodb.com) database is optional, but required for many features to work.
+
 ## Install
 
 Learn how to [set up an Indiekit server](https://getindiekit.com/get-started) and view an [example server configuration](https://github.com/paulrobertlloyd/paulrobertlloyd-indiekit/blob/main/index.js).

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,3 +1,4 @@
+import markdownFootnote from "markdown-it-footnote";
 import { version } from "../../packages/indiekit/package.json" assert { type: "json" };
 
 const sidebar = [
@@ -80,6 +81,9 @@ export default {
   cleanUrls: "without-subfolders",
   markdown: {
     linkify: false,
+    config: (md) => {
+      md.use(markdownFootnote);
+    },
   },
   outDir: "../_site",
   themeConfig: {

--- a/docs/configuration/post-types.md
+++ b/docs/configuration/post-types.md
@@ -75,10 +75,12 @@ Values for `*.path` and `*.url` can be customised using the following tokens:
 | `T` | `post` `media` | UNIX epoch milliseconds, eg <samp>51296952000</samp> |
 | `uuid` | `post` `media` | A [random UUID][uuid] |
 | `slug` | `post` | Provided slug, slugified `name` or a 5 character string, eg <samp>ycf9o</samp> |
-| `n` | `post` | Incremental count of posts (for type) in the same day, eg <samp>1</samp> |
+| `n`[^1] | `post` | Incremental count of posts (for type) in the same day, eg <samp>1</samp> |
 | `basename` | `media` | 5 character alpha-numeric string, eg <samp>w9gwi</samp> |
 | `ext` | `media` | File extension of uploaded file, eg <samp>jpg</samp> |
 | `filename` | `media` | `basename` plus `ext`, eg <samp>w9gwi.jpg</samp> |
 | `originalname` | `media` | Original name of uploaded file, eg <samp>flower.jpg</samp> |
+
+[^1]: Using the `n` token requires a [database to be configured](https://getindiekit.com/configuration/#application-mongodburl-url).
 
 [uuid]: https://www.rfc-editor.org/rfc/rfc4122.html#section-4.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "create-indiekit": "*",
         "eslint-plugin-jsdoc": "^39.0.0",
         "jsdom": "^20.0.0",
+        "markdown-it-footnote": "^3.0.3",
         "mock-fs": "^5.1.2",
         "mock-req-res": "^1.2.0",
         "mock-session": "^0.0.5",
@@ -11386,6 +11387,12 @@
     "node_modules/markdown-it-deflist": {
       "version": "2.1.0",
       "license": "MIT"
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
+      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w==",
+      "dev": true
     },
     "node_modules/markdown-it-prism": {
       "version": "2.3.0",
@@ -26974,6 +26981,12 @@
     },
     "markdown-it-deflist": {
       "version": "2.1.0"
+    },
+    "markdown-it-footnote": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
+      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w==",
+      "dev": true
     },
     "markdown-it-prism": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "create-indiekit": "*",
     "eslint-plugin-jsdoc": "^39.0.0",
     "jsdom": "^20.0.0",
+    "markdown-it-footnote": "^3.0.3",
     "mock-fs": "^5.1.2",
     "mock-req-res": "^1.2.0",
     "mock-session": "^0.0.5",

--- a/packages/endpoint-micropub/lib/post-type-count.js
+++ b/packages/endpoint-micropub/lib/post-type-count.js
@@ -1,5 +1,3 @@
-import { IndiekitError } from "@indiekit/error";
-
 export const postTypeCount = {
   /**
    * Count the number of posts of a given type
@@ -10,7 +8,12 @@ export const postTypeCount = {
    */
   async get(publication, properties) {
     if (!publication.posts || !publication.posts.count()) {
-      throw new IndiekitError("No database configuration provided");
+      console.warn("No database configuration provided");
+      console.info(
+        "See https://getindiekit.com/configuration/#application-mongodburl-url"
+      );
+
+      return;
     }
 
     // Post type


### PR DESCRIPTION
Indiekit currently throws an error when attempting to create a post if no database has been configured (see: #502). Yet the documentation says a database is optional.

Resolve this ambiguity by:

* Not throwing an error, but instead logging a warning to the console
* Adding a footnote to [list of tokens](https://getindiekit.com/configuration/post-types#path-and-url-tokens) that `n` requires a database configured.
  * The above requiring adding `markdown-it-footnote` support to VitePress
* Add a note to the requirements section in the README