### PR TITLE
docs: fix README link to example server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A [MongoDB](https://www.mongodb.com) database is optional, but required for many
 
 ## Install
 
-Learn how to [set up an Indiekit server](https://getindiekit.com/get-started) and view an [example server configuration](https://github.com/paulrobertlloyd/paulrobertlloyd-indiekit/blob/main/index.js).
+Learn how to [set up an Indiekit server](https://getindiekit.com/get-started) and view an [example server configuration](https://github.com/paulrobertlloyd/paulrobertlloyd-indiekit/blob/main/indiekit.config.cjs).
 
 ## Documentation website
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A [MongoDB](https://www.mongodb.com) database is optional, but required for many
 
 ## Install
 
-Learn how to [set up an Indiekit server](https://getindiekit.com/get-started) and view an [example server configuration](https://github.com/paulrobertlloyd/paulrobertlloyd-indiekit/blob/main/indiekit.config.cjs).
+Learn how to [set up an Indiekit server](https://getindiekit.com/get-started) and view an [example server configuration](https://github.com/getindiekit/example-config).
 
 ## Documentation website
 


### PR DESCRIPTION
Found your sample configuration very handy, thanks for this. With the move to v1.x, it seems your config file went from `index.js` to `indiekit.config.cjs`.