### PR TITLE
Refactor application endpoints

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -17,6 +17,20 @@ The `.indiekitrc` file (without extension) can be in JSON or YAML format. You ca
 
 ## application
 
+### application.authorizationEndpoint `URL`
+
+Indiekit uses its own authorization endpoint, but you can use a third-party service by setting a value for this option.
+
+_Optional_, defaults to `"[application.url]/auth"`. For example:
+
+```json
+{
+  "application": {
+    "authorizationEndpoint": "https://indieauth.com/auth"
+  }
+}
+```
+
 ### application.locale `string`
 
 The language used in the application interface.
@@ -32,6 +46,34 @@ _Optional_, defaults to system language if supported, else `"en"` (English). For
 ```
 
 See [Localisation →](localisation.md)
+
+### application.mediaEndpoint `URL`
+
+Indiekit uses its own [Micropub media endpoint](https://micropub.spec.indieweb.org/#media-endpoint), but you can use a third-party service by setting a value for this option.
+
+_Optional_, defaults to `"[application.url]/media"`. For example:
+
+```json
+{
+  "application": {
+    "mediaEndpoint": "https://website.example/media"
+  }
+}
+```
+
+### application.micropubEndpoint `URL`
+
+Indiekit uses its own Micropub endpoint, but you can use a third-party service by setting a value for this option.
+
+_Optional_, defaults to `"[application.url]/micropub"`. For example:
+
+```json
+{
+  "application": {
+    "micropubEndpoint ": "https://website.example/micropub"
+  }
+}
+```
 
 ### application.mongodbUrl `URL`
 
@@ -87,6 +129,20 @@ _Optional_, defaults to `"automatic"`. For example:
 {
   "application": {
     "themeColorScheme": "dark"
+  }
+}
+```
+
+### application.tokenEndpoint `URL`
+
+Indiekit uses its own token endpoint, but you can use a third-party service by setting a value for this option.
+
+_Optional_, defaults to `"[application.url]/auth/token"`. For example:
+
+```json
+{
+  "application": {
+    "tokenEndpoint": "https://tokens.indieauth.com/token"
   }
 }
 ```
@@ -149,20 +205,6 @@ Each plug-in may accept its own configuration options, and these should be provi
 Learn more about Indiekit’s [plug-in API](../plugins/api/index.md).
 
 ## publication
-
-### publication.authorizationEndpoint `URL`
-
-Authorization endpoint.
-
-_Optional_, defaults to `"https://indieauth.com/auth"`. For example:
-
-```json
-{
-  "publication": {
-    "authorizationEndpoint": "https://example.org/auth"
-  }
-}
-```
 
 ### publication.categories `Array | URL`
 
@@ -267,20 +309,6 @@ _Required_. For example:
 }
 ```
 
-### publication.mediaEndpoint `URL`
-
-Indiekit provides a [media endpoint](https://micropub.spec.indieweb.org/#media-endpoint), but you can use a third-party endpoint by setting a value for this option.
-
-_Optional_. For example:
-
-```json
-{
-  "publication": {
-    "mediaEndpoint": "https://media.website.example"
-  }
-}
-```
-
 ### publication.postTemplate `Function`
 
 A post template is a function that takes post properties received and parsed by the Micropub endpoint and renders them in a given file format, for example, a Markdown file with YAML front matter.
@@ -371,17 +399,3 @@ _Optional_, defaults to `"UTC"`. For example:
 ```
 
 See [customising the time zone →](time-zone.md)
-
-### publication.tokenEndpoint `URL`
-
-An IndieAuth token endpoint.
-
-_Optional_, defaults to `"[application.url]/token"`. For example:
-
-```json
-{
-  "publication": {
-    "tokenEndpoint": "https://server.website.example/token"
-  }
-}
-```

--- a/helpers/config/index.js
+++ b/helpers/config/index.js
@@ -39,6 +39,7 @@ export const testConfig = async (options) => {
         name: "test",
         secret: process.env.TEST_SESSION_SECRET,
       }),
+      tokenEndpoint: options?.application?.tokenEndpoint,
     },
     plugins: [
       "@indiekit-test/store",
@@ -49,7 +50,6 @@ export const testConfig = async (options) => {
       me: options?.publication?.me || process.env.TEST_PUBLICATION_URL,
       ...(options.usePostTypes && { postTypes }),
       timeZone: "UTC",
-      tokenEndpoint: options?.publication?.tokenEndpoint,
     },
     "@indiekit-test/store": {
       user: "user",

--- a/packages/endpoint-auth/index.js
+++ b/packages/endpoint-auth/index.js
@@ -60,8 +60,13 @@ export default class AuthorizationEndpoint {
 
   init(Indiekit) {
     Indiekit.addEndpoint(this);
-    Indiekit.config.application.authorizationEndpoint = this.options.mountPath;
-    Indiekit.config.application.tokenEndpoint =
+
+    // Use private value to register IndieAuth authorization endpoint path
+    Indiekit.config.application._authorizationEndpointPath =
+      this.options.mountPath;
+
+    // Use private value to register IndieAuth token endpoint path
+    Indiekit.config.application._tokenEndpointPath =
       this.options.mountPath + "/token";
   }
 }

--- a/packages/endpoint-auth/lib/controllers/metadata.js
+++ b/packages/endpoint-auth/lib/controllers/metadata.js
@@ -2,16 +2,16 @@
 import { scopes } from "../scope.js";
 
 export const metadataController = (request, response) => {
-  const { application, publication } = request.app.locals;
+  const { application } = request.app.locals;
 
   const metadata = {
     issuer: application.url,
-    authorization_endpoint: publication.authorizationEndpoint,
-    token_endpoint: publication.tokenEndpoint,
+    authorization_endpoint: application.authorizationEndpoint,
+    token_endpoint: application.tokenEndpoint,
     code_challenge_methods_supported: ["S256"],
     response_types_supported: ["code"],
     scopes_supported: scopes,
-    service_documentation: publication.authorizationEndpoint,
+    service_documentation: application.authorizationEndpoint,
     ui_locales_supported: application.localeUsed,
   };
 

--- a/packages/endpoint-auth/views/auth.njk
+++ b/packages/endpoint-auth/views/auth.njk
@@ -4,8 +4,8 @@
 {{ __("auth.guidance.discovery") | safe }}
 
 ```html
-<link rel="authorization_endpoint" href="{{ publication.authorizationEndpoint }}">
-<link rel="token_endpoint" href="{{ publication.tokenEndpoint }}">
+<link rel="authorization_endpoint" href="{{ application.authorizationEndpoint }}">
+<link rel="token_endpoint" href="{{ application.tokenEndpoint }}">
 <link rel="indieauth-metadata" href="{{ application.url }}/.well-known/oauth-authorization-server">
 ```
 
@@ -14,7 +14,7 @@
 ### {{ __("auth.guidance.authorization.requestCode") }}
 
 ```http
-GET {{ publication.authorizationEndpoint }}
+GET {{ application.authorizationEndpoint }}
 Content-type: application/x-www-form-urlencoded
 
 response_type=code
@@ -38,7 +38,7 @@ Location: {{ application.url }}/session/auth?code=xxxxxxxx
 ### {{ __("auth.guidance.authorization.redeemCode") }}
 
 ```http
-POST {{ publication.authorizationEndpoint }}
+POST {{ application.authorizationEndpoint }}
 Content-type: application/x-www-form-urlencoded
 Accept: application/json
 
@@ -63,7 +63,7 @@ Content-Type: application/json
 ### {{ __("auth.guidance.authentication.redeemCode") }}
 
 ```http
-POST {{ publication.tokenEndpoint }}
+POST {{ application.tokenEndpoint }}
 Content-type: application/x-www-form-urlencoded
 Accept: application/json
 
@@ -89,7 +89,7 @@ Content-Type: application/json
 ### {{ __("auth.guidance.authentication.verifyToken") }}
 
 ```http
-GET {{ publication.tokenEndpoint }}
+GET {{ application.tokenEndpoint }}
 Accept: application/json
 Authorization: Bearer xxxxxxxx
 ```

--- a/packages/endpoint-files/lib/controllers/file.js
+++ b/packages/endpoint-files/lib/controllers/file.js
@@ -12,11 +12,11 @@ import { fetch } from "undici";
  */
 export const fileController = async (request, response, next) => {
   try {
-    const { publication } = request.app.locals;
+    const { application } = request.app.locals;
     const { id } = request.params;
     const url = Buffer.from(id, "base64url").toString("utf8");
 
-    const mediaUrl = new URL(publication.mediaEndpoint);
+    const mediaUrl = new URL(application.mediaEndpoint);
     mediaUrl.searchParams.append("q", "source");
     mediaUrl.searchParams.append("url", url);
 

--- a/packages/endpoint-files/lib/controllers/files.js
+++ b/packages/endpoint-files/lib/controllers/files.js
@@ -12,14 +12,14 @@ import { fetch } from "undici";
  */
 export const filesController = async (request, response, next) => {
   try {
-    const { publication } = request.app.locals;
+    const { application } = request.app.locals;
 
     let { page, limit, offset, success } = request.query;
     page = Number.parseInt(page, 10) || 1;
     limit = Number.parseInt(limit, 10) || 12;
     offset = Number.parseInt(offset, 10) || (page - 1) * limit;
 
-    const mediaUrl = new URL(publication.mediaEndpoint);
+    const mediaUrl = new URL(application.mediaEndpoint);
     mediaUrl.searchParams.append("q", "source");
     mediaUrl.searchParams.append("page", page);
     mediaUrl.searchParams.append("limit", limit);

--- a/packages/endpoint-files/lib/controllers/upload.js
+++ b/packages/endpoint-files/lib/controllers/upload.js
@@ -25,7 +25,7 @@ export const uploadController = {
    * @returns {object} HTTP response
    */
   async post(request, response) {
-    const { publication } = request.app.locals;
+    const { application } = request.app.locals;
 
     const errors = validationResult(request);
     if (!errors.isEmpty()) {
@@ -43,7 +43,7 @@ export const uploadController = {
      * @todo Third-party media endpoints may require a separate bearer token
      */
     try {
-      const mediaResponse = await fetch(publication.mediaEndpoint, {
+      const mediaResponse = await fetch(application.mediaEndpoint, {
         method: "POST",
         headers: {
           accept: "application/json",

--- a/packages/endpoint-media/index.js
+++ b/packages/endpoint-media/index.js
@@ -23,6 +23,8 @@ export default class MediaEndpoint {
 
   init(Indiekit) {
     Indiekit.addEndpoint(this);
-    Indiekit.config.application.mediaEndpoint = this.options.mountPath;
+
+    // Use private value to register Micropub media endpoint path
+    Indiekit.config.application._mediaEndpointPath = this.options.mountPath;
   }
 }

--- a/packages/endpoint-micropub/index.js
+++ b/packages/endpoint-micropub/index.js
@@ -23,6 +23,8 @@ export default class MicropubEndpoint {
 
   init(Indiekit) {
     Indiekit.addEndpoint(this);
-    Indiekit.config.application.micropubEndpoint = this.options.mountPath;
+
+    // Use private value to register Micropub endpoint path
+    Indiekit.config.application._micropubEndpointPath = this.options.mountPath;
   }
 }

--- a/packages/endpoint-micropub/lib/config.js
+++ b/packages/endpoint-micropub/lib/config.js
@@ -6,10 +6,8 @@
  * @returns {object} Queryable configuration
  */
 export const getConfig = (application, publication) => {
-  const { url } = application;
-
-  const { categories, mediaEndpoint, postTypes, syndicationTargets } =
-    publication;
+  const { mediaEndpoint, url } = application;
+  const { categories, postTypes, syndicationTargets } = publication;
 
   // Supported queries
   const q = [

--- a/packages/endpoint-micropub/lib/controllers/action.js
+++ b/packages/endpoint-micropub/lib/controllers/action.js
@@ -17,7 +17,7 @@ export const actionController = async (request, response, next) => {
   const { body, files, query } = request;
   const action = query.action || body.action || "create";
   const url = query.url || body.url;
-  const { publication } = request.app.locals;
+  const { application, publication } = request.app.locals;
 
   try {
     // Check provided scope
@@ -48,7 +48,7 @@ export const actionController = async (request, response, next) => {
           : formEncodedToJf2(body);
 
         // Attach files
-        jf2 = files ? await uploadMedia(token, publication, jf2, files) : jf2;
+        jf2 = files ? await uploadMedia(token, application, jf2, files) : jf2;
 
         data = await postData.create(publication, jf2);
         published = await post.create(publication, data);

--- a/packages/endpoint-micropub/lib/media.js
+++ b/packages/endpoint-micropub/lib/media.js
@@ -5,13 +5,13 @@ import { fetch, FormData } from "undici";
  * Upload attached file(s) via media endpoint
  *
  * @param {string} token - Bearer token
- * @param {object} publication - Publication configuration
+ * @param {object} application - Application configuration
  * @param {object} properties - JF2 properties
  * @param {object} files - Files to upload
  * @returns {Array} Uploaded file locations
  */
-export const uploadMedia = async (token, publication, properties, files) => {
-  const { mediaEndpoint } = publication;
+export const uploadMedia = async (token, application, properties, files) => {
+  const { mediaEndpoint } = application;
 
   for await (let [mediaProperty, media] of Object.entries(files)) {
     // Media property may contain one or many media files

--- a/packages/endpoint-micropub/tests/integration/404-query-source-url-not-found.js
+++ b/packages/endpoint-micropub/tests/integration/404-query-source-url-not-found.js
@@ -7,9 +7,11 @@ await mockAgent("token-endpoint");
 
 test("Returns 404 error source URL can’t be found", async (t) => {
   const server = await testServer({
+    application: {
+      tokenEndpoint: "https://token-endpoint.example",
+    },
     publication: {
       me: "https://website.example",
-      tokenEndpoint: "https://token-endpoint.example",
     },
   });
   const request = supertest.agent(server);

--- a/packages/endpoint-micropub/tests/unit/media.js
+++ b/packages/endpoint-micropub/tests/unit/media.js
@@ -8,6 +8,9 @@ await mockAgent("media-endpoint");
 
 test.beforeEach((t) => {
   t.context = {
+    application: {
+      mediaEndpoint: "https://media-endpoint.example",
+    },
     bearerToken: process.env.TEST_TOKEN,
     files: {
       photo: {
@@ -15,9 +18,6 @@ test.beforeEach((t) => {
         name: "photo",
         originalname: "photo1.jpg",
       },
-    },
-    publication: {
-      mediaEndpoint: "https://media-endpoint.example",
     },
     properties: {
       type: "entry",
@@ -29,14 +29,14 @@ test.beforeEach((t) => {
 });
 
 test("Uploads attached file via media endpoint", async (t) => {
-  const { bearerToken, publication, properties, files } = t.context;
-  const result = await uploadMedia(bearerToken, publication, properties, files);
+  const { bearerToken, application, properties, files } = t.context;
+  const result = await uploadMedia(bearerToken, application, properties, files);
 
   t.deepEqual(result.photo, ["https://website.example/media/photo1.jpg"]);
 });
 
 test("Uploads attached files via media endpoint", async (t) => {
-  const { bearerToken, publication, properties } = t.context;
+  const { bearerToken, application, properties } = t.context;
   const files = {
     photo: [
       {
@@ -49,7 +49,7 @@ test("Uploads attached files via media endpoint", async (t) => {
       },
     ],
   };
-  const result = await uploadMedia(bearerToken, publication, properties, files);
+  const result = await uploadMedia(bearerToken, application, properties, files);
 
   t.deepEqual(result.photo, [
     "https://website.example/media/photo2.jpg",
@@ -66,9 +66,9 @@ test("Throws error no media endpoint URL", async (t) => {
 });
 
 test("Throws error uploading attached file", async (t) => {
-  const { publication, properties, files } = t.context;
+  const { application, properties, files } = t.context;
 
-  await t.throwsAsync(uploadMedia("foobar", publication, properties, files), {
+  await t.throwsAsync(uploadMedia("foobar", application, properties, files), {
     message: "The token provided was malformed",
   });
 });

--- a/packages/endpoint-posts/lib/controllers/post.js
+++ b/packages/endpoint-posts/lib/controllers/post.js
@@ -13,11 +13,11 @@ import { fetch } from "undici";
  */
 export const postController = async (request, response, next) => {
   try {
-    const { publication } = request.app.locals;
+    const { application } = request.app.locals;
     const { id } = request.params;
     const url = Buffer.from(id, "base64url").toString("utf8");
 
-    const micropubUrl = new URL(publication.micropubEndpoint);
+    const micropubUrl = new URL(application.micropubEndpoint);
     micropubUrl.searchParams.append("q", "source");
     micropubUrl.searchParams.append("url", url);
 

--- a/packages/endpoint-posts/lib/controllers/posts.js
+++ b/packages/endpoint-posts/lib/controllers/posts.js
@@ -13,14 +13,14 @@ import { fetch } from "undici";
  */
 export const postsController = async (request, response, next) => {
   try {
-    const { publication } = request.app.locals;
+    const { application } = request.app.locals;
 
     let { page, limit, offset, success } = request.query;
     page = Number.parseInt(page, 10) || 1;
     limit = Number.parseInt(limit, 10) || 12;
     offset = Number.parseInt(offset, 10) || (page - 1) * limit;
 
-    const micropubUrl = new URL(publication.micropubEndpoint);
+    const micropubUrl = new URL(application.micropubEndpoint);
     micropubUrl.searchParams.append("q", "source");
     micropubUrl.searchParams.append("page", page);
     micropubUrl.searchParams.append("limit", limit);

--- a/packages/endpoint-share/lib/controllers/share.js
+++ b/packages/endpoint-share/lib/controllers/share.js
@@ -30,7 +30,7 @@ export const shareController = {
    * @returns {object} HTTP response
    */
   async post(request, response) {
-    const { publication } = request.app.locals;
+    const { application } = request.app.locals;
     const { content, name } = request.body;
     const bookmarkOf = request.body.url || request.body["bookmark-of"];
 
@@ -47,7 +47,7 @@ export const shareController = {
     }
 
     try {
-      const micropubResponse = await fetch(publication.micropubEndpoint, {
+      const micropubResponse = await fetch(application.micropubEndpoint, {
         method: "POST",
         headers: {
           accept: "application/json",

--- a/packages/endpoint-syndicate/lib/controllers/syndicate.js
+++ b/packages/endpoint-syndicate/lib/controllers/syndicate.js
@@ -69,7 +69,7 @@ export const syndicateController = {
       }
 
       // Update post with syndicated URL(s) and removal of syndication target(s)
-      const micropubResponse = await fetch(publication.micropubEndpoint, {
+      const micropubResponse = await fetch(application.micropubEndpoint, {
         method: "POST",
         headers: {
           accept: "application/json",

--- a/packages/endpoint-syndicate/tests/unit/utils.js
+++ b/packages/endpoint-syndicate/tests/unit/utils.js
@@ -3,7 +3,6 @@ import { getPostData } from "../../lib/utils.js";
 
 test.beforeEach((t) => {
   t.context.publication = {
-    micropubEndpoint: "/micropub",
     posts: {
       find: () => ({
         toArray: async () => [

--- a/packages/indiekit/lib/endpoints.js
+++ b/packages/indiekit/lib/endpoints.js
@@ -1,14 +1,13 @@
 import { isUrl, getUrl } from "./utils.js";
 
 /**
- * Get endpoint URLs from publication configuration or server derived value
+ * Get endpoint URLs from application configuration or default plug-ins
  *
- * @param {object} indiekitConfig - Indiekit configuration
+ * @param {object} application - Application configuration
  * @param {object} request - HTTP request
  * @returns {object} Endpoint URLs
  */
-export const getEndpoints = (indiekitConfig, request) => {
-  const { application, publication } = indiekitConfig;
+export const getEndpoints = (application, request) => {
   const endpoints = {};
 
   for (const endpoint of [
@@ -17,13 +16,14 @@ export const getEndpoints = (indiekitConfig, request) => {
     "micropubEndpoint",
     "tokenEndpoint",
   ]) {
-    // Use endpoint URL in publication config
-    if (publication[endpoint] && isUrl(publication[endpoint])) {
-      endpoints[endpoint] = publication[endpoint];
+    // Use endpoint URL in application config
+    if (application[endpoint] && isUrl(application[endpoint])) {
+      endpoints[endpoint] = application[endpoint];
     } else {
-      // Else, use endpoint path provided by application
+      // Else, use private path value provided by default endpoint plug-in
+      // to construct a fully resolvable URL mounted on application URL
       endpoints[endpoint] = new URL(
-        application[endpoint],
+        application[`_${endpoint}Path`],
         getUrl(request)
       ).href;
     }

--- a/packages/indiekit/lib/indieauth.js
+++ b/packages/indiekit/lib/indieauth.js
@@ -83,7 +83,7 @@ export const IndieAuth = class {
   login() {
     return async (request, response) => {
       try {
-        const { application, publication } = request.app.locals;
+        const { application } = request.app.locals;
         this.clientId = getCanonicalUrl(application.url);
 
         const callbackUrl = `${application.url}/session/auth`;
@@ -94,7 +94,7 @@ export const IndieAuth = class {
 
         const state = generateState(this.clientId, this.iv);
         const authUrl = await this.getAuthUrl(
-          publication.authorizationEndpoint,
+          application.authorizationEndpoint,
           state
         );
 
@@ -117,7 +117,7 @@ export const IndieAuth = class {
   authorize() {
     return async (request, response) => {
       try {
-        const { publication } = request.app.locals;
+        const { application } = request.app.locals;
         const { code, redirect, state } = request.query;
 
         // Check redirect is to a local path
@@ -152,7 +152,7 @@ export const IndieAuth = class {
 
         // Request access token
         const authorizedToken = await this.authorizationCodeGrant(
-          publication.tokenEndpoint,
+          application.tokenEndpoint,
           code
         );
 
@@ -204,10 +204,10 @@ export const IndieAuth = class {
 
       // Validate bearer token sent in request
       try {
-        const { tokenEndpoint } = request.app.locals.publication;
+        const { application } = request.app.locals;
         const bearerToken = findBearerToken(request);
         const tokenValues = await requestTokenValues(
-          tokenEndpoint,
+          application.tokenEndpoint,
           bearerToken
         );
 

--- a/packages/indiekit/lib/middleware/locals.js
+++ b/packages/indiekit/lib/middleware/locals.js
@@ -13,6 +13,9 @@ export const locals = (indiekitConfig) =>
     try {
       const { application, publication } = indiekitConfig;
 
+      // Application
+      request.app.locals.application = application;
+
       // Application locale
       application.localeUsed = request.getLocale();
 
@@ -25,13 +28,14 @@ export const locals = (indiekitConfig) =>
         application.navigation = getNavigation(application, request, response);
       }
 
-      request.app.locals.application = application;
+      // Application endpoints
+      request.app.locals.application = {
+        ...application,
+        ...getEndpoints(application, request),
+      };
 
       // Publication
-      request.app.locals.publication = {
-        ...publication,
-        ...getEndpoints(indiekitConfig, request),
-      };
+      request.app.locals.publication = publication;
 
       // Session
       request.app.locals.session = request.session;

--- a/packages/indiekit/locales/en.json
+++ b/packages/indiekit/locales/en.json
@@ -29,7 +29,11 @@
         "light": "Light",
         "dark": "Dark"
       },
-      "installedPlugins": "Installed plug-ins"
+      "installedPlugins": "Installed plug-ins",
+      "authorizationEndpoint": "Authorization endpoint",
+      "mediaEndpoint": "Media endpoint",
+      "micropubEndpoint": "Micropub endpoint",
+      "tokenEndpoint": "Token endpoint"
     },
     "publication": {
       "summaryTitle": "Publication settings",
@@ -39,11 +43,7 @@
       "store": "Content store",
       "preset": "Preset",
       "postTypes": "Post types",
-      "syndicationTargets": "Syndication targets",
-      "authorizationEndpoint": "Authorization endpoint",
-      "mediaEndpoint": "Media endpoint",
-      "micropubEndpoint": "Micropub endpoint",
-      "tokenEndpoint": "Token endpoint"
+      "syndicationTargets": "Syndication targets"
     }
   }
 }

--- a/packages/indiekit/tests/integration/200-session-auth.js
+++ b/packages/indiekit/tests/integration/200-session-auth.js
@@ -7,9 +7,11 @@ await mockAgent("token-endpoint");
 
 test("Returns authenticated session", async (t) => {
   const server = await testServer({
+    application: {
+      tokenEndpoint: "https://token-endpoint.example",
+    },
     publication: {
       me: "https://website.example",
-      tokenEndpoint: "https://token-endpoint.example",
     },
   });
   const request = supertest.agent(server);

--- a/packages/indiekit/tests/integration/401-session-auth-invalid-token.js
+++ b/packages/indiekit/tests/integration/401-session-auth-invalid-token.js
@@ -7,9 +7,11 @@ await mockAgent("token-endpoint");
 
 test("Returns authenticated session", async (t) => {
   const server = await testServer({
+    application: {
+      tokenEndpoint: "https://token-endpoint.example",
+    },
     publication: {
       me: "https://website.example",
-      tokenEndpoint: "https://token-endpoint.example",
     },
   });
   const request = supertest.agent(server);

--- a/packages/indiekit/tests/unit/endpoints.js
+++ b/packages/indiekit/tests/unit/endpoints.js
@@ -1,19 +1,10 @@
 import test from "ava";
-import { testConfig } from "@indiekit-test/config";
-import { Indiekit } from "../../index.js";
 import { getEndpoints } from "../../lib/endpoints.js";
 
-test.beforeEach(async (t) => {
-  const config = await testConfig();
-  const indiekit = new Indiekit({ config });
-  const { publication } = await indiekit.bootstrap();
-
+test.beforeEach((t) => {
   t.context = {
-    application: {
-      mediaEndpoint: "/media",
-      tokenEndpoint: "/token",
-    },
-    publication,
+    _mediaEndpointPath: "/media",
+    _tokenEndpointPath: "/token",
   };
 });
 
@@ -28,7 +19,7 @@ test("Gets endpoints from server derived values", (t) => {
 });
 
 test("Gets endpoints from publication configuration", (t) => {
-  t.context.publication.mediaEndpoint = "https://website.example/media";
+  t.context.mediaEndpoint = "https://website.example/media";
   const result = getEndpoints(t.context, {
     headers: { host: "server.example" },
     protocol: "https",

--- a/packages/indiekit/tests/unit/indieauth.js
+++ b/packages/indiekit/tests/unit/indieauth.js
@@ -56,8 +56,7 @@ test("Checks if user is authenticated", async (t) => {
   const request = mockRequest({
     app: {
       locals: {
-        application: {},
-        publication: {
+        application: {
           tokenEndpoint: "https://token-endpoint.example",
         },
       },
@@ -84,7 +83,7 @@ test("Development mode bypasses authentication", async (t) => {
   const request = mockRequest({
     app: {
       locals: {
-        publication: {
+        application: {
           tokenEndpoint: "https://token-endpoint.example",
         },
       },
@@ -105,7 +104,7 @@ test("Throws error authenticating invalid token", async (t) => {
   const request = mockRequest({
     app: {
       locals: {
-        publication: {
+        application: {
           tokenEndpoint: "https://token-endpoint.example",
         },
       },
@@ -128,7 +127,7 @@ test("Throws error authenticating token with URL mismatch", async (t) => {
   const request = mockRequest({
     app: {
       locals: {
-        publication: {
+        application: {
           tokenEndpoint: "https://token-endpoint.example",
         },
       },

--- a/packages/indiekit/views/status.njk
+++ b/packages/indiekit/views/status.njk
@@ -4,9 +4,9 @@
 {{ __("guidance.discovery", application.name) | safe }}
 
 ```html
-<link rel="micropub" href="{{ publication.micropubEndpoint }}">
-<link rel="authorization_endpoint" href="{{ publication.authorizationEndpoint }}">
-<link rel="token_endpoint" href="{{ publication.tokenEndpoint }}">
+<link rel="micropub" href="{{ application.micropubEndpoint }}">
+<link rel="authorization_endpoint" href="{{ application.authorizationEndpoint }}">
+<link rel="token_endpoint" href="{{ application.tokenEndpoint }}">
 ```
 {% endset %}
 
@@ -108,33 +108,33 @@
       }
     } if publication.syndicationTargets.length > 0, {
       key: {
-        text: __("status.publication.micropubEndpoint")
+        text: __("status.application.micropubEndpoint")
       },
       value: {
-        text: publication.micropubEndpoint | urlize
+        text: application.micropubEndpoint | urlize
       }
-    } if publication.micropubEndpoint, {
+    } if application.micropubEndpoint, {
       key: {
-        text: __("status.publication.mediaEndpoint")
+        text: __("status.application.mediaEndpoint")
       },
       value: {
-        text: publication.mediaEndpoint | urlize
+        text: application.mediaEndpoint | urlize
       }
-    } if publication.mediaEndpoint, {
+    } if application.mediaEndpoint, {
       key: {
-        text: __("status.publication.tokenEndpoint")
+        text: __("status.application.tokenEndpoint")
       },
       value: {
-        text: publication.tokenEndpoint | urlize
+        text: application.tokenEndpoint | urlize
       }
-    } if publication.tokenEndpoint, {
+    } if application.tokenEndpoint, {
       key: {
-        text: __("status.publication.authorizationEndpoint")
+        text: __("status.application.authorizationEndpoint")
       },
       value: {
-        text: publication.authorizationEndpoint | urlize
+        text: application.authorizationEndpoint | urlize
       }
-    } if publication.authorizationEndpoint]
+    } if application.authorizationEndpoint]
   }) }}
 
   {{ summary({


### PR DESCRIPTION
Fixes #507. Am using a private variable in the default endpoint plugins, but I think this is fine. Default endpoints can either be overwritten by a user’s config (documentation updated), or by a subsequent plugin providing a fully resolved URL for these values (I think… not tested, but not important right now).