### PR TITLE
Update status page, move scope translations to core module

### DIFF
--- a/packages/endpoint-auth/lib/scope.js
+++ b/packages/endpoint-auth/lib/scope.js
@@ -12,8 +12,8 @@ export const scopes = ["create", "delete", "media", "update"];
  */
 export function getScopeItems(scope, response) {
   return scopes.map((value) => ({
-    text: response.__(`auth.consent.scope.${value}.label`),
-    hint: { text: response.__(`auth.consent.scope.${value}.hint`) },
+    text: response.__(`scope.${value}.label`),
+    hint: { text: response.__(`scope.${value}.hint`) },
     value,
     checked: scope?.includes(value),
   }));

--- a/packages/endpoint-auth/locales/de.json
+++ b/packages/endpoint-auth/locales/de.json
@@ -17,30 +17,7 @@
       "pkce": {
         "text": "{{client}} verwendet keinen Proof of Key Code Exchange (PKCE), der sicherer ist."
       },
-      "redirect": "Nach der Autorisierung dieser Anwendung werden Sie zu %s weitergeleitet",
-      "scope": {
-        "create": {
-          "hint": "Die Anwendung kann Beiträge veröffentlichen und Medien hochladen",
-          "label": "Erstellen"
-        },
-        "delete": {
-          "hint": "Die Anwendung kann Beiträge löschen",
-          "label": "Löschen"
-        },
-        "draft": {
-          "hint": "Beiträge, die mit dieser Anwendung erstellt wurden, werden als Entwurf markiert",
-          "label": "Entwurf"
-        },
-        "label": "Veröffentlichungsberechtigungen",
-        "media": {
-          "hint": "Die Anwendung kann Medien hochladen",
-          "label": "Medien"
-        },
-        "update": {
-          "hint": "Die Anwendung kann Beiträge aktualisieren",
-          "label": "Aktualisierung"
-        }
-      }
+      "redirect": "Nach der Autorisierung dieser Anwendung werden Sie zu %s weitergeleitet"
     },
     "error": {
       "password": {

--- a/packages/endpoint-auth/locales/en.json
+++ b/packages/endpoint-auth/locales/en.json
@@ -23,30 +23,7 @@
       "pkce": {
         "text": "{{client}} is not using Proof of Key Code Exchange (PKCE), which is more secure."
       },
-      "redirect": "After authorizing this application you will be redirected to %s",
-      "scope": {
-        "label": "Publishing permissions",
-        "create": {
-          "label": "Create",
-          "hint": "Application can publish posts and upload media"
-        },
-        "delete": {
-          "label": "Delete",
-          "hint": "Application can delete posts"
-        },
-        "draft": {
-          "label": "Draft",
-          "hint": "Posts created by this application will be marked as draft"
-        },
-        "media": {
-          "label": "Media",
-          "hint": "Application can upload media"
-        },
-        "update": {
-          "label": "Update",
-          "hint": "Application can update posts"
-        }
-      }
+      "redirect": "After authorizing this application you will be redirected to %s"
     },
     "newPassword": {
       "title": "New password",

--- a/packages/endpoint-auth/locales/es.json
+++ b/packages/endpoint-auth/locales/es.json
@@ -17,30 +17,7 @@
       "pkce": {
         "text": "{{client}} no utiliza Proof of Key Code Exchange (PKCE), que es más seguro."
       },
-      "redirect": "Tras autorizar esta aplicación, se le redirigirá a %s",
-      "scope": {
-        "create": {
-          "hint": "La aplicación puede publicar publicaciones y subir contenido multimedia",
-          "label": "Crear"
-        },
-        "delete": {
-          "hint": "La aplicación puede eliminar publicaciones",
-          "label": "Borrar"
-        },
-        "draft": {
-          "hint": "Las publicaciones creadas por esta aplicación se marcarán como borrador",
-          "label": "Borrador"
-        },
-        "label": "Permisos de publicación",
-        "media": {
-          "hint": "La aplicación puede subir archivos multimedia",
-          "label": "Multimedia"
-        },
-        "update": {
-          "hint": "La aplicación puede actualizar publicaciones",
-          "label": "Actualizar"
-        }
-      }
+      "redirect": "Tras autorizar esta aplicación, se le redirigirá a %s"
     },
     "error": {
       "password": {

--- a/packages/endpoint-auth/locales/fr.json
+++ b/packages/endpoint-auth/locales/fr.json
@@ -17,30 +17,7 @@
       "pkce": {
         "text": "{{client}} n'utilise pas le Proof of Key Code Exchange (PKCE), qui est plus sécurisé."
       },
-      "redirect": "Après avoir autorisé cette application, vous serez redirigé vers %s",
-      "scope": {
-        "create": {
-          "hint": "L'application peut publier des publications et télécharger des médias",
-          "label": "Créer"
-        },
-        "delete": {
-          "hint": "L'application peut supprimer des publications",
-          "label": "Supprimer"
-        },
-        "draft": {
-          "hint": "Les publications créées par cette application seront marquées comme brouillon",
-          "label": "Brouillon"
-        },
-        "label": "Autorisations de publication",
-        "media": {
-          "hint": "L'application peut télécharger des médias",
-          "label": "Médias"
-        },
-        "update": {
-          "hint": "L'application peut mettre à jour les publications",
-          "label": "Mettre à jour"
-        }
-      }
+      "redirect": "Après avoir autorisé cette application, vous serez redirigé vers %s"
     },
     "error": {
       "password": {

--- a/packages/endpoint-auth/locales/id.json
+++ b/packages/endpoint-auth/locales/id.json
@@ -17,30 +17,7 @@
       "pkce": {
         "text": "{{client}} tidak menggunakan Proof of Key Code Exchange (PKCE), yang lebih aman."
       },
-      "redirect": "Setelah mengotorisasi aplikasi ini Anda akan diarahkan ke %s",
-      "scope": {
-        "create": {
-          "hint": "Aplikasi dapat menerbitkan posting dan mengunggah media",
-          "label": "Membuat"
-        },
-        "delete": {
-          "hint": "Aplikasi dapat menghapus posting",
-          "label": "Hapus"
-        },
-        "draft": {
-          "hint": "Postingan yang dibuat oleh aplikasi ini akan ditandai sebagai draf",
-          "label": "Draf"
-        },
-        "label": "Izin publikasi",
-        "media": {
-          "hint": "Aplikasi dapat mengunggah media",
-          "label": "Média"
-        },
-        "update": {
-          "hint": "Aplikasi dapat memperbarui postingan",
-          "label": "Perbarui"
-        }
-      }
+      "redirect": "Setelah mengotorisasi aplikasi ini Anda akan diarahkan ke %s"
     },
     "error": {
       "password": {

--- a/packages/endpoint-auth/locales/nl.json
+++ b/packages/endpoint-auth/locales/nl.json
@@ -17,30 +17,7 @@
       "pkce": {
         "text": "{{client}} gebruikt niet Proof of Key Code Exchange (PKCE), wat veiliger is."
       },
-      "redirect": "Na het autoriseren van deze toepassing wordt u omgeleid naar %s",
-      "scope": {
-        "create": {
-          "hint": "Applicatie kan berichten publiceren en media uploaden",
-          "label": "Creëren"
-        },
-        "delete": {
-          "hint": "Applicatie kan berichten verwijderen",
-          "label": "Verwijderen"
-        },
-        "draft": {
-          "hint": "Berichten die door deze applicatie worden gemaakt, worden gemarkeerd als concept",
-          "label": "Concept"
-        },
-        "label": "Machtigingen voor publicatie",
-        "media": {
-          "hint": "Applicatie kan media uploaden",
-          "label": "Media"
-        },
-        "update": {
-          "hint": "Applicatie kan berichten bijwerken",
-          "label": "Updaten"
-        }
-      }
+      "redirect": "Na het autoriseren van deze toepassing wordt u omgeleid naar %s"
     },
     "error": {
       "password": {

--- a/packages/endpoint-auth/locales/pl.json
+++ b/packages/endpoint-auth/locales/pl.json
@@ -17,30 +17,7 @@
       "pkce": {
         "text": "{{client}} nie używa Proof of Key Code Exchange (PKCE), który jest bezpieczniejszy."
       },
-      "redirect": "Po autoryzacji tej aplikacji nastąpi przekierowanie do %s",
-      "scope": {
-        "create": {
-          "hint": "Aplikacja może publikować posty i przesyłać multimedia",
-          "label": "Utwórz"
-        },
-        "delete": {
-          "hint": "Aplikacja może usuwać posty",
-          "label": "Usuń"
-        },
-        "draft": {
-          "hint": "Posty utworzone przez tę aplikację zostaną oznaczone jako wersja robocza",
-          "label": "Projekt"
-        },
-        "label": "Uprawnienia do publikowania",
-        "media": {
-          "hint": "Aplikacja może przesyłać multimedia",
-          "label": "Multimedia"
-        },
-        "update": {
-          "hint": "Aplikacja może aktualizować posty",
-          "label": "Aktualizuj"
-        }
-      }
+      "redirect": "Po autoryzacji tej aplikacji nastąpi przekierowanie do %s"
     },
     "error": {
       "password": {

--- a/packages/endpoint-auth/locales/pt.json
+++ b/packages/endpoint-auth/locales/pt.json
@@ -17,30 +17,7 @@
       "pkce": {
         "text": "{{client}} não está usando o Proof of Key Code Exchange (PKCE), que é mais seguro."
       },
-      "redirect": "Depois de autorizar este aplicativo, você será redirecionado para %s",
-      "scope": {
-        "create": {
-          "hint": "Aplicativo pode publicar postagens e fazer upload de mídia",
-          "label": "Criar"
-        },
-        "delete": {
-          "hint": "Aplicativo pode excluir postagens",
-          "label": "Eliminar"
-        },
-        "draft": {
-          "hint": "As postagens criadas por este aplicativo serão marcadas como rascunho",
-          "label": "Rascunho"
-        },
-        "label": "Permissões de publicação",
-        "media": {
-          "hint": "Aplicativo pode fazer upload de mídia",
-          "label": "Multimédia"
-        },
-        "update": {
-          "hint": "Aplicativo pode atualizar postagens",
-          "label": "Atualizar"
-        }
-      }
+      "redirect": "Depois de autorizar este aplicativo, você será redirecionado para %s"
     },
     "error": {
       "password": {

--- a/packages/endpoint-auth/locales/sr.json
+++ b/packages/endpoint-auth/locales/sr.json
@@ -17,30 +17,7 @@
       "pkce": {
         "text": "{{client}} ne koristi Proof of Key Code Exchange (PKCE), što je bezbednije."
       },
-      "redirect": "Nakon autorizacije ove aplikacije bićete preusmereni na %s",
-      "scope": {
-        "create": {
-          "hint": "Aplikacija može objavljivati poruke i otpremiti medije",
-          "label": "Kreiraj"
-        },
-        "delete": {
-          "hint": "Aplikacija može da briše postove",
-          "label": "Izbriši"
-        },
-        "draft": {
-          "hint": "Poruke kreirane ovom aplikacijom biće označene kao nacrt",
-          "label": "Nacrt"
-        },
-        "label": "Dozvole za objavljivanje",
-        "media": {
-          "hint": "Aplikacija može da otpremi medije",
-          "label": "Mediji"
-        },
-        "update": {
-          "hint": "Aplikacija može ažurirati postove",
-          "label": "Ažuriranje"
-        }
-      }
+      "redirect": "Nakon autorizacije ove aplikacije bićete preusmereni na %s"
     },
     "error": {
       "password": {

--- a/packages/endpoint-auth/views/consent.njk
+++ b/packages/endpoint-auth/views/consent.njk
@@ -25,7 +25,7 @@
     name: "scope",
     fieldset: {
       legend: {
-        text: __("auth.consent.scope.label")
+        text: __("scope.label")
       }
     },
     items: scopeItems,

--- a/packages/endpoint-files/locales/de.json
+++ b/packages/endpoint-files/locales/de.json
@@ -15,8 +15,7 @@
     "upload": {
       "file": "Datei",
       "submit": "Hochladen",
-      "title": "Laden Sie eine neue Datei hoch",
-      "unauthorized": "Sie haben keine Veröffentlichungsberechtigungen."
+      "title": "Laden Sie eine neue Datei hoch"
     }
   }
 }

--- a/packages/endpoint-files/locales/en.json
+++ b/packages/endpoint-files/locales/en.json
@@ -15,7 +15,6 @@
     "upload": {
       "file": "File",
       "submit": "Upload",
-      "unauthorized": "You don’t have any publishing permissions.",
       "title": "Upload a new file"
     }
   }

--- a/packages/endpoint-files/locales/es.json
+++ b/packages/endpoint-files/locales/es.json
@@ -15,8 +15,7 @@
     "upload": {
       "file": "Archivo",
       "submit": "Cargar",
-      "title": "Cargar un archivo nuevo",
-      "unauthorized": "No tienes ningún permiso de publicación"
+      "title": "Cargar un archivo nuevo"
     }
   }
 }

--- a/packages/endpoint-files/locales/fr.json
+++ b/packages/endpoint-files/locales/fr.json
@@ -15,8 +15,7 @@
     "upload": {
       "file": "Fichier",
       "submit": "Téléverser",
-      "title": "Téléverser un nouveau fichier",
-      "unauthorized": "Vous n'avez aucune autorisation pour publier"
+      "title": "Téléverser un nouveau fichier"
     }
   }
 }

--- a/packages/endpoint-files/locales/id.json
+++ b/packages/endpoint-files/locales/id.json
@@ -15,8 +15,7 @@
     "upload": {
       "file": "Berkas",
       "submit": "Unggah",
-      "title": "Unggah file baru",
-      "unauthorized": "Anda tidak memiliki izin penerbitan"
+      "title": "Unggah file baru"
     }
   }
 }

--- a/packages/endpoint-files/locales/nl.json
+++ b/packages/endpoint-files/locales/nl.json
@@ -15,8 +15,7 @@
     "upload": {
       "file": "Bestand",
       "submit": "Uploaden",
-      "title": "Upload een nieuw bestand",
-      "unauthorized": "Je hebt geen publicatierechten"
+      "title": "Upload een nieuw bestand"
     }
   }
 }

--- a/packages/endpoint-files/locales/pl.json
+++ b/packages/endpoint-files/locales/pl.json
@@ -15,8 +15,7 @@
     "upload": {
       "file": "Plik",
       "submit": "Prześlij",
-      "title": "Prześlij nowy plik",
-      "unauthorized": "Nie masz żadnych uprawnień do publikowania"
+      "title": "Prześlij nowy plik"
     }
   }
 }

--- a/packages/endpoint-files/locales/pt.json
+++ b/packages/endpoint-files/locales/pt.json
@@ -15,8 +15,7 @@
     "upload": {
       "file": "Arquivo",
       "submit": "Upload",
-      "title": "Fazer upload de um novo arquivo",
-      "unauthorized": "Você não tem nenhuma permissão de publicação"
+      "title": "Fazer upload de um novo arquivo"
     }
   }
 }

--- a/packages/endpoint-files/locales/sr.json
+++ b/packages/endpoint-files/locales/sr.json
@@ -15,8 +15,7 @@
     "upload": {
       "file": "Datoteka",
       "submit": "Otpremiti",
-      "title": "Otpremite novu datoteku",
-      "unauthorized": "Nemate dozvole za objavljivanje"
+      "title": "Otpremite novu datoteku"
     }
   }
 }

--- a/packages/endpoint-files/views/upload.njk
+++ b/packages/endpoint-files/views/upload.njk
@@ -20,6 +20,6 @@
       formenctype: "multipart/form-data"
     }
   }) if session.access_token else warningText({
-    text: __("files.upload.unauthorized")
+    text: __("scope.none.label")
   }) }}
 {% endblock %}

--- a/packages/endpoint-share/locales/de.json
+++ b/packages/endpoint-share/locales/de.json
@@ -8,8 +8,7 @@
     },
     "name": "Titel",
     "submit": "Veröffentlichen",
-    "title": "Teilen",
-    "unauthorized": "Sie haben keine Veröffentlichungsberechtigungen"
+    "title": "Teilen"
   },
   "status": {
     "bookmarklet": {

--- a/packages/endpoint-share/locales/en.json
+++ b/packages/endpoint-share/locales/en.json
@@ -5,7 +5,6 @@
     "name": "Title",
     "content": "Content",
     "submit": "Publish",
-    "unauthorized": "You don’t have any publishing permissions",
     "error": {
       "bookmark-of": "Enter a web address like https://example.org",
       "name": "Enter a title"

--- a/packages/endpoint-share/locales/es.json
+++ b/packages/endpoint-share/locales/es.json
@@ -8,8 +8,7 @@
     },
     "name": "Título",
     "submit": "Publicar",
-    "title": "Compartir",
-    "unauthorized": "No tienes ningún permiso de publicación"
+    "title": "Compartir"
   },
   "status": {
     "bookmarklet": {

--- a/packages/endpoint-share/locales/fr.json
+++ b/packages/endpoint-share/locales/fr.json
@@ -8,8 +8,7 @@
     },
     "name": "Titre",
     "submit": "Publier",
-    "title": "Partager",
-    "unauthorized": "Vous n'avez aucune autorisation pour publier"
+    "title": "Partager"
   },
   "status": {
     "bookmarklet": {

--- a/packages/endpoint-share/locales/id.json
+++ b/packages/endpoint-share/locales/id.json
@@ -8,8 +8,7 @@
     },
     "name": "Judul",
     "submit": "Terbitkan",
-    "title": "Bagikan",
-    "unauthorized": "Anda tidak memiliki izin penerbitan"
+    "title": "Bagikan"
   },
   "status": {
     "bookmarklet": {

--- a/packages/endpoint-share/locales/nl.json
+++ b/packages/endpoint-share/locales/nl.json
@@ -8,8 +8,7 @@
     },
     "name": "Titel",
     "submit": "Publiceer",
-    "title": "Delen",
-    "unauthorized": "Je hebt geen publicatierechten"
+    "title": "Delen"
   },
   "status": {
     "bookmarklet": {

--- a/packages/endpoint-share/locales/pl.json
+++ b/packages/endpoint-share/locales/pl.json
@@ -8,8 +8,7 @@
     },
     "name": "Tytuł",
     "submit": "Publikuj",
-    "title": "Udostępnij",
-    "unauthorized": "Nie masz żadnych uprawnień do publikowania"
+    "title": "Udostępnij"
   },
   "status": {
     "bookmarklet": {

--- a/packages/endpoint-share/locales/pt.json
+++ b/packages/endpoint-share/locales/pt.json
@@ -8,8 +8,7 @@
     },
     "name": "Título",
     "submit": "Publicar",
-    "title": "Compartilhar",
-    "unauthorized": "Você não tem nenhuma permissão de publicação"
+    "title": "Compartilhar"
   },
   "status": {
     "bookmarklet": {

--- a/packages/endpoint-share/locales/sr.json
+++ b/packages/endpoint-share/locales/sr.json
@@ -8,8 +8,7 @@
     },
     "name": "Naslov",
     "submit": "Objaviti",
-    "title": "Podeli",
-    "unauthorized": "Nemate dozvole za objavljivanje"
+    "title": "Podeli"
   },
   "status": {
     "bookmarklet": {

--- a/packages/endpoint-share/views/share.njk
+++ b/packages/endpoint-share/views/share.njk
@@ -82,6 +82,6 @@
   {{ button({
     text: __("share.submit")
   }) if session.access_token else warningText({
-    text: __("share.unauthorized")
+    text: __("scope.none.label")
   }) }}
 {% endblock %}

--- a/packages/frontend/styles/scopes/linear.css
+++ b/packages/frontend/styles/scopes/linear.css
@@ -68,6 +68,8 @@
 .s-linear code,
 .s-linear samp {
   border-radius: var(--border-radius-small);
+  font-weight: 400;
+  margin-inline: 0.2em;
 }
 
 .s-linear code.property {

--- a/packages/indiekit/lib/controllers/status.js
+++ b/packages/indiekit/lib/controllers/status.js
@@ -1,4 +1,8 @@
-export const viewStatus = (request, response) =>
+export const viewStatus = (request, response) => {
+  const { scope } = request.session;
+
   response.render("status", {
     title: response.__("status.title"),
+    scope: scope?.split(" "),
   });
+};

--- a/packages/indiekit/locales/de.json
+++ b/packages/indiekit/locales/de.json
@@ -2,6 +2,32 @@
   "guidance": {
     "discovery": "Fügen Sie dem `<head>` Ihrer Website die folgenden Werte hinzu, damit Micropub-Clients %s erkennen und um Erlaubnis bitten, auf Ihrer Website posten zu dürfen:"
   },
+  "scope": {
+    "create": {
+      "hint": "Die Anwendung kann Beiträge veröffentlichen und Medien hochladen",
+      "label": "Erstellen"
+    },
+    "delete": {
+      "hint": "Die Anwendung kann Beiträge löschen",
+      "label": "Löschen"
+    },
+    "draft": {
+      "hint": "Beiträge, die mit dieser Anwendung erstellt wurden, werden als Entwurf markiert",
+      "label": "Entwurf"
+    },
+    "label": "Veröffentlichungsberechtigungen",
+    "media": {
+      "hint": "Die Anwendung kann Medien hochladen",
+      "label": "Medien"
+    },
+    "none": {
+      "label": "Sie haben keine Veröffentlichungsberechtigungen"
+    },
+    "update": {
+      "hint": "Die Anwendung kann Beiträge aktualisieren",
+      "label": "Aktualisierung"
+    }
+  },
   "session": {
     "login": {
       "description": "Melde dich mit IndieAuth an, um zu verifizieren, dass du %s besitzt",
@@ -23,7 +49,6 @@
       "mediaEndpoint": "Media-Endpunkte",
       "micropubEndpoint": "Micropub-Endpunkt",
       "name": "Name",
-      "scope": "Bereitgestellt scope",
       "summaryTitle": "Anwendungseinstellungen",
       "themeColor": "Themenfarbe",
       "themeColorScheme": "Thema",

--- a/packages/indiekit/locales/en.json
+++ b/packages/indiekit/locales/en.json
@@ -29,11 +29,7 @@
         "light": "Light",
         "dark": "Dark"
       },
-      "installedPlugins": "Installed plug-ins",
-      "authorizationEndpoint": "Authorization endpoint",
-      "mediaEndpoint": "Media endpoint",
-      "micropubEndpoint": "Micropub endpoint",
-      "tokenEndpoint": "Token endpoint"
+      "installedPlugins": "Installed plug-ins"
     },
     "publication": {
       "summaryTitle": "Publication settings",

--- a/packages/indiekit/locales/en.json
+++ b/packages/indiekit/locales/en.json
@@ -13,12 +13,37 @@
       "title": "Sign out"
     }
   },
+  "scope": {
+    "label": "Publishing permissions",
+    "create": {
+      "hint": "Application can publish posts and upload media",
+      "label": "Create"
+    },
+    "delete": {
+      "hint": "Application can delete posts",
+      "label": "Delete"
+    },
+    "draft": {
+      "hint": "Posts created by this application will be marked as draft",
+      "label": "Draft"
+    },
+    "media": {
+      "hint": "Application can upload media",
+      "label": "Media"
+    },
+    "none": {
+      "label": "You don’t have any publishing permissions"
+    },
+    "update": {
+      "hint": "Application can update posts",
+      "label": "Update"
+    }
+  },
   "status": {
     "title": "Server status",
     "application": {
       "summaryTitle": "Application settings",
       "accessToken": "Access token",
-      "scope": "Provided scope",
       "name": "Name",
       "locale": "Language",
       "localeNotAvailable": "{{app}} has not been translated into {{locale}} yet",

--- a/packages/indiekit/locales/es.json
+++ b/packages/indiekit/locales/es.json
@@ -2,6 +2,32 @@
   "guidance": {
     "discovery": "Para que los clientes de Micropub puedan descubrir %s y solicitar permiso para publicar en su sitio web, agregue los siguientes valores a `<head>` de su sitio web:"
   },
+  "scope": {
+    "create": {
+      "hint": "La aplicación puede publicar publicaciones y subir contenido multimedia",
+      "label": "Crear"
+    },
+    "delete": {
+      "hint": "La aplicación puede eliminar publicaciones",
+      "label": "Borrar"
+    },
+    "draft": {
+      "hint": "Las publicaciones creadas por esta aplicación se marcarán como borrador",
+      "label": "Borrador"
+    },
+    "label": "Permisos de publicación",
+    "media": {
+      "hint": "La aplicación puede subir archivos multimedia",
+      "label": "Multimedia"
+    },
+    "none": {
+      "label": "No tienes ningún permiso de publicación"
+    },
+    "update": {
+      "hint": "La aplicación puede actualizar publicaciones",
+      "label": "Actualizar"
+    }
+  },
   "session": {
     "login": {
       "description": "Inicia sesión con IndieAuth para verificar que eres propietario de %s",
@@ -23,7 +49,6 @@
       "mediaEndpoint": "Punto final de medios",
       "micropubEndpoint": "Punto final de Micropub",
       "name": "Nombre",
-      "scope": "Alcance proporcionado",
       "summaryTitle": "Ajustes de la aplicación",
       "themeColor": "Color del tema",
       "themeColorScheme": "Tema",

--- a/packages/indiekit/locales/fr.json
+++ b/packages/indiekit/locales/fr.json
@@ -2,6 +2,32 @@
   "guidance": {
     "discovery": "Pour que %s puisse être découvert par les clients Micropub et demander l'autorisation de publier sur votre site Web, ajoutez les valeurs suivantes à la valeur `<head>` de votre site Web:"
   },
+  "scope": {
+    "create": {
+      "hint": "L'application peut publier des publications et télécharger des médias",
+      "label": "Créer"
+    },
+    "delete": {
+      "hint": "L'application peut supprimer des publications",
+      "label": "Supprimer"
+    },
+    "draft": {
+      "hint": "Les publications créées par cette application seront marquées comme brouillon",
+      "label": "Brouillon"
+    },
+    "label": "Autorisations de publication",
+    "media": {
+      "hint": "L'application peut télécharger des médias",
+      "label": "Médias"
+    },
+    "none": {
+      "label": "Vous n'avez aucune autorisation pour publier"
+    },
+    "update": {
+      "hint": "L'application peut mettre à jour les publications",
+      "label": "Mettre à jour"
+    }
+  },
   "session": {
     "login": {
       "description": "Connectez-vous avec IndieAuth pour vérifier que vous possédez %s",
@@ -23,7 +49,6 @@
       "mediaEndpoint": "Endpoint de média",
       "micropubEndpoint": "Endpoint de Micropub",
       "name": "Nom",
-      "scope": "Portée fournie",
       "summaryTitle": "Paramètres d'application",
       "themeColor": "Couleur du Thème",
       "themeColorScheme": "Schéma de couleurs du Thème",

--- a/packages/indiekit/locales/id.json
+++ b/packages/indiekit/locales/id.json
@@ -2,6 +2,32 @@
   "guidance": {
     "discovery": "Sehingga %s dapat ditemukan oleh klien Micropub dan meminta izin untuk memposting ke situs web Anda, tambahkan nilai berikut ke situs web Anda `<head>`:"
   },
+  "scope": {
+    "create": {
+      "hint": "Aplikasi dapat menerbitkan posting dan mengunggah media",
+      "label": "Membuat"
+    },
+    "delete": {
+      "hint": "Aplikasi dapat menghapus posting",
+      "label": "Hapus"
+    },
+    "draft": {
+      "hint": "Postingan yang dibuat oleh aplikasi ini akan ditandai sebagai draf",
+      "label": "Draf"
+    },
+    "label": "Izin publikasi",
+    "media": {
+      "hint": "Aplikasi dapat mengunggah media",
+      "label": "Média"
+    },
+    "none": {
+      "label": "Anda tidak memiliki izin penerbitan"
+    },
+    "update": {
+      "hint": "Aplikasi dapat memperbarui postingan",
+      "label": "Perbarui"
+    }
+  },
   "session": {
     "login": {
       "description": "Masuk dengan IndieAuth untuk memverifikasi bahwa Anda memiliki %s",
@@ -23,7 +49,6 @@
       "mediaEndpoint": "Titik akhir media",
       "micropubEndpoint": "Titik akhir Micropub",
       "name": "Nama",
-      "scope": "Ruang lingkup yang disediakan",
       "summaryTitle": "Pengaturan aplikasi",
       "themeColor": "Warna tema",
       "themeColorScheme": "Tema",

--- a/packages/indiekit/locales/nl.json
+++ b/packages/indiekit/locales/nl.json
@@ -2,6 +2,32 @@
   "guidance": {
     "discovery": "Om ervoor te zorgen dat %s kan worden ontdekt door Micropub-clients en toestemming kan vragen om op uw website te posten, voegt u de volgende waarden toe aan de `<head>` van uw website:"
   },
+  "scope": {
+    "create": {
+      "hint": "Applicatie kan berichten publiceren en media uploaden",
+      "label": "Creëren"
+    },
+    "delete": {
+      "hint": "Applicatie kan berichten verwijderen",
+      "label": "Verwijderen"
+    },
+    "draft": {
+      "hint": "Berichten die door deze applicatie worden gemaakt, worden gemarkeerd als concept",
+      "label": "Concept"
+    },
+    "label": "Machtigingen voor publicatie",
+    "media": {
+      "hint": "Applicatie kan media uploaden",
+      "label": "Media"
+    },
+    "none": {
+      "label": "Je hebt geen publicatierechten"
+    },
+    "update": {
+      "hint": "Applicatie kan berichten bijwerken",
+      "label": "Updaten"
+    }
+  },
   "session": {
     "login": {
       "description": "Meld u aan met IndieAuth om te controleren of u eigenaar bent van %s",
@@ -23,7 +49,6 @@
       "mediaEndpoint": "Media-endpoint",
       "micropubEndpoint": "Micropub-eindpunt",
       "name": "Naam",
-      "scope": "Geleverde reikwijdte",
       "summaryTitle": "Applicatie-instellingen",
       "themeColor": "Themakleur",
       "themeColorScheme": "Thema",

--- a/packages/indiekit/locales/pl.json
+++ b/packages/indiekit/locales/pl.json
@@ -2,6 +2,32 @@
   "guidance": {
     "discovery": "Aby %s mógł zostać wykryty przez klientów Micropub i poprosić o pozwolenie na publikowanie w Twojej witrynie, dodaj następujące wartości do `<head>` witryny:"
   },
+  "scope": {
+    "create": {
+      "hint": "Aplikacja może publikować posty i przesyłać multimedia",
+      "label": "Utwórz"
+    },
+    "delete": {
+      "hint": "Aplikacja może usuwać posty",
+      "label": "Usuń"
+    },
+    "draft": {
+      "hint": "Posty utworzone przez tę aplikację zostaną oznaczone jako wersja robocza",
+      "label": "Projekt"
+    },
+    "label": "Uprawnienia do publikowania",
+    "media": {
+      "hint": "Aplikacja może przesyłać multimedia",
+      "label": "Multimedia"
+    },
+    "none": {
+      "label": "Nie masz żadnych uprawnień do publikowania"
+    },
+    "update": {
+      "hint": "Aplikacja może aktualizować posty",
+      "label": "Aktualizuj"
+    }
+  },
   "session": {
     "login": {
       "description": "Zaloguj się za pomocą IndieAuth, aby sprawdzić, czy posiadasz %s",
@@ -23,7 +49,6 @@
       "mediaEndpoint": "Punkt końcowy mediów",
       "micropubEndpoint": "Punkt końcowy Micropub",
       "name": "Nazwa",
-      "scope": "Dostarczony zakres",
       "summaryTitle": "Ustawienia aplikacji",
       "themeColor": "Kolor motywu",
       "themeColorScheme": "Motyw",

--- a/packages/indiekit/locales/pt.json
+++ b/packages/indiekit/locales/pt.json
@@ -2,6 +2,32 @@
   "guidance": {
     "discovery": "Para que %s possa ser descoberto pelos clientes da Micropub e solicitar permissão para postar em seu site, adicione os seguintes valores ao `<head>` do seu site:"
   },
+  "scope": {
+    "create": {
+      "hint": "Aplicativo pode publicar postagens e fazer upload de mídia",
+      "label": "Criar"
+    },
+    "delete": {
+      "hint": "Aplicativo pode excluir postagens",
+      "label": "Eliminar"
+    },
+    "draft": {
+      "hint": "As postagens criadas por este aplicativo serão marcadas como rascunho",
+      "label": "Rascunho"
+    },
+    "label": "Permissões de publicação",
+    "media": {
+      "hint": "Aplicativo pode fazer upload de mídia",
+      "label": "Multimédia"
+    },
+    "none": {
+      "label": "Você não tem nenhuma permissão de publicação"
+    },
+    "update": {
+      "hint": "Aplicativo pode atualizar postagens",
+      "label": "Atualizar"
+    }
+  },
   "session": {
     "login": {
       "description": "Faça login com IndieAuth para verificar se você possui %s",
@@ -23,7 +49,6 @@
       "mediaEndpoint": "Endpoint de mídia",
       "micropubEndpoint": "Endpoint de Micropub",
       "name": "Nome",
-      "scope": "Scope fornecido",
       "summaryTitle": "Configurações de aplicação",
       "themeColor": "Cor do tema",
       "themeColorScheme": "Tema",

--- a/packages/indiekit/locales/sr.json
+++ b/packages/indiekit/locales/sr.json
@@ -2,6 +2,32 @@
   "guidance": {
     "discovery": "Tako da ti %s mogu biti otkriveni preko Micropub klijenata i potraže dozvolu da objave na vašem vebsajtu, dodajte sledeće vrednosti na vaš vebsajt `<head>`:"
   },
+  "scope": {
+    "create": {
+      "hint": "Aplikacija može objavljivati poruke i otpremiti medije",
+      "label": "Kreiraj"
+    },
+    "delete": {
+      "hint": "Aplikacija može da briše postove",
+      "label": "Izbriši"
+    },
+    "draft": {
+      "hint": "Poruke kreirane ovom aplikacijom biće označene kao nacrt",
+      "label": "Nacrt"
+    },
+    "label": "Dozvole za objavljivanje",
+    "media": {
+      "hint": "Aplikacija može da otpremi medije",
+      "label": "Mediji"
+    },
+    "none": {
+      "label": "Nemate dozvole za objavljivanje"
+    },
+    "update": {
+      "hint": "Aplikacija može ažurirati postove",
+      "label": "Ažuriranje"
+    }
+  },
   "session": {
     "login": {
       "description": "Prijavi se pomoću IndieAuth da potvrdiš da poseduješ %s",
@@ -23,7 +49,6 @@
       "mediaEndpoint": "Medijska krajnja tačka",
       "micropubEndpoint": "Micropub krajnja tačka",
       "name": "Ime",
-      "scope": "Pod uslovom opseg",
       "summaryTitle": "Podešavanja aplikacije",
       "themeColor": "Boja teme",
       "themeColorScheme": "Tema",

--- a/packages/indiekit/views/status.njk
+++ b/packages/indiekit/views/status.njk
@@ -106,35 +106,7 @@
       value: {
         text: syndicationTargetsHtml | indent(2)
       }
-    } if publication.syndicationTargets.length > 0, {
-      key: {
-        text: __("status.application.micropubEndpoint")
-      },
-      value: {
-        text: application.micropubEndpoint | urlize
-      }
-    } if application.micropubEndpoint, {
-      key: {
-        text: __("status.application.mediaEndpoint")
-      },
-      value: {
-        text: application.mediaEndpoint | urlize
-      }
-    } if application.mediaEndpoint, {
-      key: {
-        text: __("status.application.tokenEndpoint")
-      },
-      value: {
-        text: application.tokenEndpoint | urlize
-      }
-    } if application.tokenEndpoint, {
-      key: {
-        text: __("status.application.authorizationEndpoint")
-      },
-      value: {
-        text: application.authorizationEndpoint | urlize
-      }
-    } if application.authorizationEndpoint]
+    } if publication.syndicationTargets.length > 0]
   }) }}
 
   {{ summary({

--- a/packages/indiekit/views/status.njk
+++ b/packages/indiekit/views/status.njk
@@ -48,6 +48,17 @@
   {% endif %}
 {% endset -%}
 
+{%- set permissionsHtml %}
+<dl class="s-linear">{% for scope in scope -%}
+  <dt>
+    {{ __("scope." + scope + ".label") }}
+    <small><code class="token attr-name">{{ scope }}</code></small>
+  <dt>
+  <dd>{{ __("scope." + scope + ".hint") }}</dd>
+{%- endfor %}
+</dl>
+{% endset -%}
+
 {% block content %}
   {{ discovery | markdown | safe }}
 
@@ -132,12 +143,12 @@
       }
     } if session.access_token, {
       key: {
-        text: __("status.application.scope")
+        text: __("scope.label")
       },
       value: {
-        text: session.scope
+        text: permissionsHtml if scope else __("scope.none.label")
       }
-    } if session.scope, {
+    }, {
       key: {
         text: __("status.application.name")
       },

--- a/packages/indiekit/views/status.njk
+++ b/packages/indiekit/views/status.njk
@@ -11,7 +11,10 @@
 {% endset %}
 
 {%- set postTypesHtml %}<ul>{% for config in publication.postTypes -%}
-  <li>{{ icon(config.type) }}{{ config.name }}</li>
+  <li>
+    {{ icon(config.type) }}{{ config.name }}
+    <small><code class="token attr-name">{{ config.type }}</code></small>
+  </li>
 {%- endfor %}</ul>{% endset -%}
 
 {%- set storeHtml %}

--- a/packages/indiekit/views/status.njk
+++ b/packages/indiekit/views/status.njk
@@ -124,6 +124,27 @@
     title: __("status.application.summaryTitle"),
     rows: [{
       key: {
+        text: __("status.application.name")
+      },
+      value: {
+        text: application.name
+      }
+    }, {
+      key: {
+        text: __("status.application.locale")
+      },
+      value: {
+        text: localeHtml
+      }
+    }, {
+      key: {
+        text: __("scope.label")
+      },
+      value: {
+        text: permissionsHtml if scope else __("scope.none.label")
+      }
+    }, {
+      key: {
         text: __("status.application.accessToken")
       },
       value: {
@@ -142,27 +163,6 @@
         })
       }
     } if session.access_token, {
-      key: {
-        text: __("scope.label")
-      },
-      value: {
-        text: permissionsHtml if scope else __("scope.none.label")
-      }
-    }, {
-      key: {
-        text: __("status.application.name")
-      },
-      value: {
-        text: application.name
-      }
-    }, {
-      key: {
-        text: __("status.application.locale")
-      },
-      value: {
-        text: localeHtml
-      }
-    }, {
       key: {
         text: __("status.application.themeColorScheme")
       },


### PR DESCRIPTION
Now that we have more readable and localised names and descriptions for different scopes, we should use these on the status page.

In doing this, it seems sensible to move these localisations to the core module, which in turn reduces the number of localised strings needed (and repetition there of).

In addition:

* remove list of endpoints (we show those that matter in the guidance at the top of the page)
* like we do for scopes, so the Micropub post type name alongside each supported post type
* Change the ordering of rows in the application section