### PR TITLE
Delete a post

### DIFF
--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -1,4 +1,5 @@
 import express from "express";
+import { deleteController } from "./lib/controllers/delete.js";
 import { postController } from "./lib/controllers/post.js";
 import { postsController } from "./lib/controllers/posts.js";
 
@@ -25,6 +26,8 @@ export default class PostsEndpoint {
   get routes() {
     router.get("/", postsController);
     router.get("/:id", postController);
+    router.get("/:id/delete", deleteController.get);
+    router.post("/:id/delete", deleteController.post);
 
     return router;
   }

--- a/packages/endpoint-posts/lib/controllers/delete.js
+++ b/packages/endpoint-posts/lib/controllers/delete.js
@@ -1,0 +1,88 @@
+import path from "node:path";
+import { IndiekitError } from "@indiekit/error";
+import { fetch } from "undici";
+import { getPostData, getPostName } from "../utils.js";
+
+export const deleteController = {
+  /**
+   * Confirm post to delete
+   *
+   * @param {object} request - HTTP request
+   * @param {object} response - HTTP response
+   * @returns {object} HTTP response
+   */
+  async get(request, response) {
+    const { access_token, scope } = request.session;
+    const back = path.dirname(request.baseUrl + request.path);
+
+    if (scope.includes("delete")) {
+      const { application, publication } = request.app.locals;
+      const { id } = request.params;
+      const post = await getPostData(
+        id,
+        application.micropubEndpoint,
+        access_token
+      );
+
+      return response.render("delete-post", {
+        title: response.__("posts.delete.title"),
+        back,
+        parent: { text: getPostName(post, publication) },
+      });
+    }
+
+    response.redirect(back);
+  },
+
+  /**
+   * Post delete action to Micropub endpoint
+   *
+   * @param {object} request - HTTP request
+   * @param {object} response - HTTP response
+   * @returns {object} HTTP response
+   */
+  async post(request, response) {
+    const { access_token } = request.session;
+    const { application } = request.app.locals;
+    const { id } = request.params;
+
+    try {
+      const post = await getPostData(
+        id,
+        application.micropubEndpoint,
+        access_token
+      );
+
+      const micropubUrl = new URL(application.micropubEndpoint);
+      micropubUrl.searchParams.append("action", "delete");
+      micropubUrl.searchParams.append("url", post.url);
+
+      /**
+       * @todo Third-party Micropub endpoints may require a separate bearer token
+       */
+      const micropubResponse = await fetch(micropubUrl.href, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${request.session.access_token}`,
+        },
+      });
+
+      if (!micropubResponse.ok) {
+        throw await IndiekitError.fromFetch(micropubResponse);
+      }
+
+      const body = await micropubResponse.json();
+      const message = encodeURIComponent(body.success_description);
+
+      response.redirect(`${request.baseUrl}?success=${message}`);
+    } catch (error) {
+      response.status(error.status || 500);
+      response.render("delete-post", {
+        title: response.__("posts.delete.title"),
+        back: path.dirname(request.baseUrl + request.path),
+        error: error.message,
+      });
+    }
+  },
+};

--- a/packages/endpoint-posts/lib/controllers/posts.js
+++ b/packages/endpoint-posts/lib/controllers/posts.js
@@ -27,7 +27,7 @@ export const postsController = async (request, response, next) => {
     micropubUrl.searchParams.append("offset", offset);
 
     /**
-     * @todo Third-party media endpoints may require a separate bearer token
+     * @todo Third-party Micropub endpoints may require a separate bearer token
      */
     const micropubResponse = await fetch(micropubUrl.href, {
       headers: {
@@ -40,12 +40,16 @@ export const postsController = async (request, response, next) => {
       throw await IndiekitError.fromFetch(micropubResponse);
     }
 
-    const body = await micropubResponse.json();
     let posts;
+    const body = await micropubResponse.json();
     if (body?.items?.length > 0) {
-      const mf2 = mf2tojf2(body);
-      const items = mf2.children || [mf2];
+      const jf2 = mf2tojf2(body);
+      const items = jf2.children || [jf2];
+
       posts = items.map((item) => {
+        item.classes = item["post-status"]
+          ? `file-list__item--${item["post-status"]}`
+          : "";
         item.id = Buffer.from(item.url).toString("base64url");
         return item;
       });

--- a/packages/endpoint-posts/lib/utils.js
+++ b/packages/endpoint-posts/lib/utils.js
@@ -1,0 +1,57 @@
+import { Buffer } from "node:buffer";
+import { IndiekitError } from "@indiekit/error";
+import { mf2tojf2 } from "@paulrobertlloyd/mf2tojf2";
+import { fetch } from "undici";
+
+/**
+ * Query Micropub endpoint for post data
+ *
+ * @param {string} id - Post ID
+ * @param {string} micropubEndpoint - Micropub endpoint
+ * @param {string} accessToken - Access token
+ * @returns {object} JF2 properties
+ */
+export const getPostData = async (id, micropubEndpoint, accessToken) => {
+  const url = Buffer.from(id, "base64").toString("utf8");
+
+  const micropubUrl = new URL(micropubEndpoint);
+  micropubUrl.searchParams.append("q", "source");
+  micropubUrl.searchParams.append("url", url);
+
+  /**
+   * @todo Third-party Micropub endpoints may require a separate bearer token
+   */
+  const micropubResponse = await fetch(micropubUrl.href, {
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!micropubResponse.ok) {
+    throw await IndiekitError.fromFetch(micropubResponse);
+  }
+
+  const body = await micropubResponse.json();
+  const postData = mf2tojf2(body);
+
+  return postData;
+};
+
+/**
+ * Get post name or post type name
+ *
+ * @param {string} post - Post properties
+ * @param {string} publication - Publication configuration
+ * @returns {string} Post name or post type name
+ */
+export const getPostName = (post, publication) => {
+  if (post.name) {
+    return post.name;
+  }
+
+  const { postTypes } = publication;
+  const postType = post["post-type"];
+  const postTypeConfig = postTypes.find((item) => item.type === postType);
+  return postTypeConfig.name;
+};

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -1,5 +1,11 @@
 {
   "posts": {
+    "delete": {
+      "action": "Delete post",
+      "title": "Are you sure you want to delete this post?",
+      "cancel": "No, return to post",
+      "submit": "Yes, delete this post"
+    },
     "post": {
       "properties": "Properties"
     },

--- a/packages/endpoint-posts/tests/integration/200-get-delete.js
+++ b/packages/endpoint-posts/tests/integration/200-get-delete.js
@@ -1,13 +1,13 @@
 import test from "ava";
-import { JSDOM } from "jsdom";
 import supertest from "supertest";
+import { JSDOM } from "jsdom";
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { testServer } from "@indiekit-test/server";
 import { testToken } from "@indiekit-test/token";
 
 await mockAgent("store");
 
-test("Returns previously published post", async (t) => {
+test("Gets delete confirmation page", async (t) => {
   // Create post
   const server = await testServer();
   const request = supertest.agent(server);
@@ -22,17 +22,16 @@ test("Returns previously published post", async (t) => {
   const postsResponse = await request.get("/posts");
   const postsDom = new JSDOM(postsResponse.text);
   const postLink = postsDom.window.document.querySelector(".file-list a");
-  const postName = postLink.textContent;
   const postId = postLink.href.split("/").pop();
 
-  // Visit post page
-  const postResponse = await request.get(`/posts/${postId}`);
-  const postDom = new JSDOM(postResponse.text);
-  const result = postDom.window.document;
+  // Confirm deletion page
+  const response = await request.get(`/posts/${postId}/delete`);
+  const dom = new JSDOM(response.text);
+  const result = dom.window.document.querySelector("title").textContent;
 
   t.is(
-    result.querySelector("title").textContent,
-    `${postName} - Test configuration`
+    result,
+    "Are you sure you want to delete this post? - Test configuration"
   );
 
   server.close(t);

--- a/packages/endpoint-posts/tests/integration/302-post-delete.js
+++ b/packages/endpoint-posts/tests/integration/302-post-delete.js
@@ -1,13 +1,13 @@
 import test from "ava";
-import { JSDOM } from "jsdom";
 import supertest from "supertest";
+import { JSDOM } from "jsdom";
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { testServer } from "@indiekit-test/server";
 import { testToken } from "@indiekit-test/token";
 
 await mockAgent("store");
 
-test("Returns previously published post", async (t) => {
+test("Deletes post and redirects to posts page", async (t) => {
   // Create post
   const server = await testServer();
   const request = supertest.agent(server);
@@ -22,18 +22,13 @@ test("Returns previously published post", async (t) => {
   const postsResponse = await request.get("/posts");
   const postsDom = new JSDOM(postsResponse.text);
   const postLink = postsDom.window.document.querySelector(".file-list a");
-  const postName = postLink.textContent;
   const postId = postLink.href.split("/").pop();
 
-  // Visit post page
-  const postResponse = await request.get(`/posts/${postId}`);
-  const postDom = new JSDOM(postResponse.text);
-  const result = postDom.window.document;
+  // Delete post
+  const result = await request.post(`/posts/${postId}/delete`);
 
-  t.is(
-    result.querySelector("title").textContent,
-    `${postName} - Test configuration`
-  );
+  t.is(result.status, 302);
+  t.regex(result.text, /Found. Redirecting to \/posts\?success/);
 
   server.close(t);
 });

--- a/packages/endpoint-posts/tests/integration/400-post-delete.js
+++ b/packages/endpoint-posts/tests/integration/400-post-delete.js
@@ -1,0 +1,17 @@
+import test from "ava";
+import supertest from "supertest";
+import { testServer } from "@indiekit-test/server";
+import { cookie } from "@indiekit-test/session";
+
+test("Returns 404 error deleting post with no record", async (t) => {
+  const server = await testServer();
+  const request = supertest.agent(server);
+  const result = await request
+    .post(`/posts/foobar/delete`)
+    .set("cookie", [cookie()]);
+
+  t.is(result.status, 404);
+  t.true(result.text.includes("No post was found at this URL"));
+
+  server.close(t);
+});

--- a/packages/endpoint-posts/tests/unit/utils.js
+++ b/packages/endpoint-posts/tests/unit/utils.js
@@ -1,0 +1,27 @@
+import test from "ava";
+import { getPostName } from "../../lib/utils.js";
+
+test.beforeEach((t) => {
+  t.context.publication = {
+    postTypes: [
+      {
+        type: "article",
+        name: "Journal entry",
+      },
+    ],
+  };
+});
+
+test("Gets post name", (t) => {
+  const post = {
+    name: "My favourite sandwich",
+  };
+  t.is(getPostName(post, t.context.publication), "My favourite sandwich");
+});
+
+test("Gets post type name", (t) => {
+  const post = {
+    "post-type": "article",
+  };
+  t.is(getPostName(post, t.context.publication), "Journal entry");
+});

--- a/packages/endpoint-posts/views/delete-post.njk
+++ b/packages/endpoint-posts/views/delete-post.njk
@@ -1,0 +1,9 @@
+{% extends "form.njk" %}
+
+{% block fieldset %}
+  {{ button({
+    classes: "button--warning",
+    text: __("posts.delete.submit")
+  }) }}
+  <p><a href="{{ back }}">{{ __("posts.delete.cancel") }}</a></p>
+{% endblock %}

--- a/packages/endpoint-posts/views/post.njk
+++ b/packages/endpoint-posts/views/post.njk
@@ -1,7 +1,5 @@
 {% extends "document.njk" %}
 
-{% set title = title or post["post-type"] | capitalize %}
-
 {% block content %}
   {{ prose({ html: post.content.html }) }}
 

--- a/packages/frontend/components/file-list/styles.css
+++ b/packages/frontend/components/file-list/styles.css
@@ -12,6 +12,15 @@
   display: flex;
 }
 
+.file-list__item--deleted {
+  --anchor-decoration-line: line-through;
+  --anchor-decoration-color: currentcolor;
+
+  .icon {
+    opacity: 0.5;
+  }
+}
+
 .file__title {
   font: var(--font-label);
 }

--- a/packages/frontend/components/file-list/template.njk
+++ b/packages/frontend/components/file-list/template.njk
@@ -1,6 +1,6 @@
 <ol class="{{ classes("file-list", opts) }}" role="list">
   {%- for item in opts.items %}
-  <li class="file-list__item">
+  <li class="{{ classes("file-list__item", item) }}">
     {{ icon(item["post-type"]) }}
     <div class="file__body">
       <h2 class="file__title">


### PR DESCRIPTION
Following on from #514, this PR implements the same action but for deleting posts.

Deleting posts is a bit different as, while they do get deleted in the content store, the post remains in the database so that it can be undeleted in the future. It also remains queryable via Micropub, with it’s `post-status` updated to `deleted` (see 6350d7faebb9a1b50e01a9e3cb9f26e619f0b465).

I’ve added an initial deleted file style, but more work needs to be done on the design of this component:

<img width="380" alt="Screenshot 2022-12-05 at 22 25 51" src="https://user-images.githubusercontent.com/813383/205756322-8dd3e437-8bdc-4e2b-8516-14bd498ac06b.png">
 