### PR TITLE
Homepage widgets

### DIFF
--- a/packages/endpoint-json-feed/includes/endpoint-json-feed-widget.njk
+++ b/packages/endpoint-json-feed/includes/endpoint-json-feed-widget.njk
@@ -1,5 +1,6 @@
 {%- set feedUrl = application.url + application.jsonFeed -%}
-{{ section({
+{{ widget({
+  image: "/assets/" + plugin.id + "/icon.svg",
   title: "JSON Feed",
   text: "<a rel=\"alternate\" href=\"" + feedUrl + "\" type=\"application/feed+json\">" + feedUrl + "</a>"
 }) }}

--- a/packages/endpoint-posts/includes/endpoint-posts-widget.njk
+++ b/packages/endpoint-posts/includes/endpoint-posts-widget.njk
@@ -1,0 +1,13 @@
+{% call widget({
+  title: __("posts.new.title"),
+  image: "/assets/" + plugin.id + "/icon.svg"
+}) %}
+  <div class="button-grid">{% for config in publication.postTypes %}
+    {{ button({
+      classes: "button--secondary-on-offset button--inline",
+      href: application.postsEndpoint + "/new/?type=" + config.type,
+      icon: config.type,
+      text: config.name
+    }) }}
+  {% endfor %}</div>
+{% endcall %}

--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -34,5 +34,6 @@ export default class PostsEndpoint {
 
   init(Indiekit) {
     Indiekit.addEndpoint(this);
+    Indiekit.config.application.postsEndpoint = this.mountPath;
   }
 }

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -6,6 +6,10 @@
       "cancel": "No, return to post",
       "submit": "Yes, delete this post"
     },
+    "new": {
+      "action": "New post",
+      "title": "Create a new post"
+    },
     "post": {
       "properties": "Properties"
     },

--- a/packages/endpoint-posts/package.json
+++ b/packages/endpoint-posts/package.json
@@ -19,6 +19,7 @@
   "type": "module",
   "main": "index.js",
   "files": [
+    "includes",
     "lib",
     "locales",
     "views",

--- a/packages/endpoint-share/assets/icon.svg
+++ b/packages/endpoint-share/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <path fill="#FA0" d="M0 0h96v96H0z"/>
+  <path fill="#FFF" d="m24 53 7-7 7 7V13h38c2 0 4 2 4 4v62c0 2-2 4-4 4H20c-2 0-4-2-4-4V17c0-2 2-4 4-4h4v40Zm48 16H24v6h48v-6Zm0-12H24v6h48v-6Zm0-12H44v6h28v-6Zm0-12H44v6h28v-6Zm0-12H44v6h28v-6Z"/>
+</svg>

--- a/packages/endpoint-share/includes/endpoint-share-widget.njk
+++ b/packages/endpoint-share/includes/endpoint-share-widget.njk
@@ -15,7 +15,7 @@
       new_window=window.open(
         '{{ application.url }}{{ application.shareEndpoint }}/bookmarklet?name='+name+'&content='+content+'&url='+encodeURIComponent(document.location.href),
         'Sharer',
-        'resizable,scrollbars,status=0,toolbar=0,menubar=0,titlebar=0,width=560,height=720,location=0'
+        'resizable,scrollbars,status=0,toolbar=0,menubar=0,titlebar=0,width=560,height=660,location=0'
       );
     })();
   {%- endset -%}
@@ -26,7 +26,8 @@
   }) }}
 {%- endset -%}
 
-{{ section({
+{{ widget({
+  image: "/assets/" + plugin.id + "/icon.svg",
   title: __("status.bookmarklet.title"),
   text: __("status.bookmarklet.guidance", bookmarklet)
 }) }}

--- a/packages/endpoint-share/index.js
+++ b/packages/endpoint-share/index.js
@@ -14,13 +14,6 @@ export default class ShareEndpoint {
     this.mountPath = this.options.mountPath;
   }
 
-  get navigationItems() {
-    return {
-      href: this.options.mountPath,
-      text: "share.title",
-    };
-  }
-
   get routes() {
     router.get("/:path?", shareController.get);
     router.post("/:path?", validate, shareController.post);

--- a/packages/endpoint-share/package.json
+++ b/packages/endpoint-share/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "main": "index.js",
   "files": [
+    "assets",
     "includes",
     "lib",
     "locales",

--- a/packages/frontend/components/bookmarklet/styles.css
+++ b/packages/frontend/components/bookmarklet/styles.css
@@ -2,6 +2,7 @@
   --anchor-color: var(--color-on-offset);
   --anchor-decoration-line: none;
   background-color: var(--color-offset);
+  border: var(--border-width-thin) solid var(--color-shadow);
   border-radius: var(--border-radius-small);
   display: inline-block;
   font: var(--font-caption);

--- a/packages/frontend/components/button/styles.css
+++ b/packages/frontend/components/button/styles.css
@@ -1,5 +1,6 @@
 .button,
 ::file-selector-button {
+  --anchor-decoration-line: none;
   background-color: var(--button-background-color, var(--color-primary));
   border: var(--border-width-thick) solid transparent;
   border-block-end-color: var(--color-shadow);
@@ -26,6 +27,15 @@
   );
 }
 
+.button--secondary-on-offset {
+  --button-color: var(--color-on-background);
+  --button-background-color: var(--color-background);
+
+  &:hover {
+    background-color: var(--color-offset-variant);
+  }
+}
+
 .button--warning {
   background-color: var(--color-error);
 
@@ -36,4 +46,21 @@
 
 .button--block {
   inline-size: 100%;
+}
+
+.button--inline {
+  --icon-margin: 0;
+  --icon-size: 2em;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+  justify-content: center;
+  padding-block: var(--space-m);
+}
+
+.button-grid {
+  display: grid;
+  gap: var(--space-xs);
+  grid-template-columns: repeat(auto-fill, minmax(6em, 1fr));
 }

--- a/packages/frontend/components/button/template.njk
+++ b/packages/frontend/components/button/template.njk
@@ -7,10 +7,12 @@
 {%- set buttonAttributes %}{% if opts.name %} name="{{ opts.name }}"{% endif %}{% if opts.disabled %} disabled="disabled" aria-disabled="true"{% endif %}{% endset -%}
 {%- if element == "a" -%}
 <a href="{{ opts.href if opts.href else "#" }}" role="button" draggable="false"{{- commonAttributes | safe }}>
+  {{- icon(opts.icon) if opts.icon -}}
   {{- opts.text | safe -}}
 </a>
 {%- elseif element == "button" -%}
 <button{%- if opts.value %} value="{{ opts.value }}"{% endif %}{%- if opts.type %} type="{{ opts.type }}"{% endif %} {{- buttonAttributes | safe }}{{- commonAttributes | safe }}>
+  {{- icon(opts.icon) if opts.icon -}}
   {{- opts.text | safe -}}
 </button>
 {%- endif %}

--- a/packages/frontend/components/fieldset/styles.css
+++ b/packages/frontend/components/fieldset/styles.css
@@ -1,7 +1,7 @@
 .fieldset {
   font: var(--font-body);
 
-  & > * + * {
+  & > *:not(.-\!-visually-hidden) + * {
     margin-block-start: var(--space-l);
   }
 

--- a/packages/frontend/components/fieldset/template.njk
+++ b/packages/frontend/components/fieldset/template.njk
@@ -1,7 +1,7 @@
 {%- from "../heading/macro.njk" import heading with context -%}
 {%- set legend %}
   {%- if opts.legend.text %}
-  <legend class="{{ classes("fieldset__legend", opts.legend.classes) }}">
+  <legend class="{{ classes("fieldset__legend", opts.legend) }}">
   {%- if opts.legend.isPageHeading %}
     {{ heading(opts.legend) }}
   {%- else %}

--- a/packages/frontend/components/widget/macro.njk
+++ b/packages/frontend/components/widget/macro.njk
@@ -1,0 +1,3 @@
+{% macro widget(opts) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/frontend/components/widget/styles.css
+++ b/packages/frontend/components/widget/styles.css
@@ -1,0 +1,28 @@
+.widget-grid {
+  columns: 20rem auto;
+  gap: var(--space-l);
+}
+
+.widget {
+  background-color: var(--color-offset);
+  border-radius: var(--border-radius-small);
+  color: var(--color-on-offset);
+  display: inline-block;
+  margin-block-end: var(--space-l);
+  min-inline-size: 100%;
+  padding: var(--space-s);
+}
+
+.widget__header {
+  --icon-size: 1.5rem;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-s);
+  justify-content: space-between;
+  padding-block-end: var(--space-s);
+}
+
+.widget__title {
+  font: var(--font-label);
+}

--- a/packages/frontend/components/widget/template.njk
+++ b/packages/frontend/components/widget/template.njk
@@ -1,0 +1,19 @@
+{%- from "../actions/macro.njk" import actions with context -%}
+{%- set id = opts.id or opts.title | slugify -%}
+<section class="{{ classes("widget", opts) }}" aria-labelledby="{{ id }}">
+  {%- if opts.title or opts.actions %}
+  <header class="widget__header">
+  {%- if opts.title %}
+    <h2 class="widget__title" id="{{ id }}">
+      <img class="icon icon--rounded" src="{{ opts.image }}" alt="" onerror="this.src='/assets/plug-in.svg'">
+      {{- opts.title | safe -}}
+    </h2>
+  {%- endif %}
+  {{- actions({ items: opts.actions }) if opts.actions.length }}
+  </header>
+  {%- endif %}
+  <div class="widget__main">
+    {{- prose({ text: opts.text }) if opts.text }}
+    {{- caller() if caller }}
+  </div>
+</section>

--- a/packages/frontend/layouts/default.njk
+++ b/packages/frontend/layouts/default.njk
@@ -21,6 +21,7 @@
 {%- from "summary/macro.njk" import summary with context -%}
 {%- from "textarea/macro.njk" import textarea with context -%}
 {%- from "warning-text/macro.njk" import warningText with context -%}
+{%- from "widget/macro.njk" import widget with context -%}
 {%- set appClasses = "app" + (" " + appClasses if appClasses) + (" app--minimalui" if minimalui) -%}
 {%- set mainClasses = "main" + (" " + mainClasses if mainClasses) -%}
 <!DOCTYPE html>

--- a/packages/indiekit/views/homepage.njk
+++ b/packages/indiekit/views/homepage.njk
@@ -16,8 +16,10 @@
     text: discovery
   }) }}
 
+<div class="widget-grid">
 {% for plugin in application.installedPlugins -%}
-  {% include plugin.id + "-status.njk" ignore missing %}
+  {% include plugin.id + "-widget.njk" ignore missing %}
 {%- endfor %}
+</div>
 
 {% endblock %}

--- a/packages/preset-hugo/index.js
+++ b/packages/preset-hugo/index.js
@@ -168,7 +168,7 @@ export default class HugoPreset {
       },
       {
         type: "rsvp",
-        name: "Reply with RSVP",
+        name: "RSVP",
         post: {
           path: "content/replies/{slug}.md",
           url: "replies/{slug}",

--- a/packages/preset-jekyll/index.js
+++ b/packages/preset-jekyll/index.js
@@ -98,7 +98,7 @@ export default class JekyllPreset {
       },
       {
         type: "rsvp",
-        name: "Reply with RSVP",
+        name: "RSVP",
         post: {
           path: "_replies/{yyyy}-{MM}-{dd}-{slug}.md",
           url: "replies/{yyyy}/{MM}/{dd}/{slug}",


### PR DESCRIPTION
I couldn’t help myself… There was already a sorta-widget system on the status page, but it wasn’t really that obvious or useful. Now that we’ve finally created a homepage, separate from the status page (f4782db19ef1245ca4c1f7f879783482e2b27f80), can go to town a bit here.

3 plug-ins with widgets so far:

* Share bookmarklet
* JSON Feed
* Posts – links to create different posts types, which is cart-before-horse stuff as that functionality doesn’t exist yet :blush:

<img width="980" alt="Screenshot 2022-12-06 at 01 11 57" src="https://user-images.githubusercontent.com/813383/205782936-4bc7c27f-0176-4eaa-b326-9481a217acc6.png">
