### PR TITLE
Correct Micropub source URL query

### DIFF
--- a/packages/endpoint-micropub/lib/controllers/query.js
+++ b/packages/endpoint-micropub/lib/controllers/query.js
@@ -63,7 +63,7 @@ export const queryController = async (request, response, next) => {
       case "source": {
         // Return mf2 for a given source URL (optionally filtered by properties)
         if (url) {
-          const mf2 = { items: [jf2ToMf2(item.properties)] };
+          const mf2 = jf2ToMf2(item.properties);
           return response.json(getMf2Properties(mf2, properties));
         }
 

--- a/packages/endpoint-micropub/lib/mf2.js
+++ b/packages/endpoint-micropub/lib/mf2.js
@@ -10,12 +10,7 @@ export const getMf2Properties = (mf2, requestedProperties) => {
     return mf2;
   }
 
-  const mf2HasItems = mf2.items && mf2.items.length > 0;
-  if (!mf2HasItems) {
-    return {};
-  }
-
-  const item = mf2.items[0];
+  const item = mf2.items ? mf2.items[0] : mf2;
   const { properties } = item;
 
   // Return requested properties

--- a/packages/endpoint-micropub/tests/integration/200-query-source-url-property.js
+++ b/packages/endpoint-micropub/tests/integration/200-query-source-url-property.js
@@ -20,14 +20,10 @@ test("Returns previously published post", async (t) => {
     .auth("JWT", { type: "bearer" })
     .set("accept", "application/json")
     .query({ q: "source" })
+    .query({ "properties[]": "name" })
     .query({ url: response.headers.location });
 
-  t.is(result.body.type[0], "h-entry");
-  t.is(result.body.properties.name[0], "Foobar");
-  t.is(result.body.properties["mp-slug"][0], "foobar");
-  t.is(result.body.properties["post-type"][0], "note");
-  t.truthy(result.body.properties.published[0]);
-  t.truthy(result.body.properties.url[0]);
+  t.deepEqual(result.body, { properties: { name: ["Foobar"] } });
 
   server.close(t);
 });

--- a/packages/endpoint-micropub/tests/integration/200-query-source.js
+++ b/packages/endpoint-micropub/tests/integration/200-query-source.js
@@ -1,18 +1,28 @@
 import test from "ava";
 import supertest from "supertest";
+import { mockAgent } from "@indiekit-test/mock-agent";
 import { testServer } from "@indiekit-test/server";
 import { testToken } from "@indiekit-test/token";
+
+await mockAgent("store");
 
 test("Returns list of previously published posts", async (t) => {
   const server = await testServer();
   const request = supertest.agent(server);
+  const response = await request
+    .post("/micropub")
+    .auth(testToken(), { type: "bearer" })
+    .set("accept", "application/json")
+    .send("h=entry")
+    .send("name=Foobar");
   const result = await request
     .get("/micropub")
     .auth(testToken(), { type: "bearer" })
     .set("accept", "application/json")
     .query({ q: "source" });
 
-  t.truthy(result.body.items);
+  t.is(result.body.items.length, 1);
+  t.is(result.body.items[0].properties.url[0], response.headers.location);
 
   server.close(t);
 });

--- a/packages/endpoint-posts/lib/utils.js
+++ b/packages/endpoint-posts/lib/utils.js
@@ -33,7 +33,7 @@ export const getPostData = async (id, micropubEndpoint, accessToken) => {
   }
 
   const body = await micropubResponse.json();
-  const postData = mf2tojf2(body);
+  const postData = mf2tojf2({ items: [body] });
 
   return postData;
 };


### PR DESCRIPTION
Tripped over during the difficult dance between JF2 and mf2. Fixed so that:

* `q=source` returns an `items` `Array`
* `q=source&url=*` returns an mf2 `object`

Added tests and made existing ones a bit stricter.

(See https://github.com/barryf/micropublish/issues/111#issuecomment-1345506312)