### PR TITLE
Refactor Micropub delete/undelete behaviour

### DIFF
--- a/helpers/post-data/index.js
+++ b/helpers/post-data/index.js
@@ -8,3 +8,21 @@ export const postData = {
     url: "https://website.example/foo",
   },
 };
+
+export const deletedPostData = {
+  path: "foo.md",
+  properties: {
+    deleted: "2020-01-02T00:00:00+00:00",
+    name: "note",
+    "post-type": "note",
+    published: "2020-01-01T00:00:00+00:00",
+    url: "https://website.example/foo",
+  },
+  _deletedProperties: {
+    name: "note",
+    "post-status": "published",
+    "post-type": "note",
+    published: "2020-01-01T00:00:00+00:00",
+    url: "https://website.example/foo",
+  },
+};

--- a/packages/endpoint-micropub/lib/controllers/action.js
+++ b/packages/endpoint-micropub/lib/controllers/action.js
@@ -55,8 +55,8 @@ export const actionController = async (request, response, next) => {
           ? await uploadMedia(application.mediaEndpoint, token, jf2, files)
           : jf2;
 
-        data = await postData.create(publication, jf2);
-        published = await post.create(publication, data, draftMode);
+        data = await postData.create(publication, jf2, draftMode);
+        published = await post.create(publication, data);
         break;
       }
 
@@ -73,7 +73,7 @@ export const actionController = async (request, response, next) => {
 
         data = await postData.update(publication, url, body);
 
-        // Can only update draft posts with `draft` scope
+        // Draft mode: Only update posts that have `draft` post status
         if (draftMode && data.properties["post-status"] !== "draft") {
           throw IndiekitError.insufficientScope(
             response.__("ForbiddenError.insufficientScope"),
@@ -86,14 +86,14 @@ export const actionController = async (request, response, next) => {
       }
 
       case "delete": {
-        data = await postData.read(publication, url);
+        data = await postData.delete(publication, url);
         published = await post.delete(publication, data);
         break;
       }
 
       case "undelete": {
-        data = await postData.read(publication, url);
-        published = await post.undelete(publication, data, draftMode);
+        data = await postData.undelete(publication, url, draftMode);
+        published = await post.undelete(publication, data);
         break;
       }
 

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -1,6 +1,5 @@
 import { mf2tojf2, mf2tojf2referenced } from "@paulrobertlloyd/mf2tojf2";
 import { striptags } from "striptags";
-import { getDate } from "./date.js";
 import { markdownToHtml, htmlToMarkdown } from "./markdown.js";
 import { reservedProperties } from "./reserved-properties.js";
 import {
@@ -71,9 +70,7 @@ export const mf2ToJf2 = async (body, requestReferences) => {
  * @returns {object} Normalised JF2 properties
  */
 export const normaliseProperties = (publication, properties) => {
-  const { me, slugSeparator, timeZone } = publication;
-
-  properties.published = getPublishedProperty(properties, timeZone);
+  const { me, slugSeparator } = publication;
 
   if (properties.name) {
     properties.name = properties.name.trim();
@@ -227,16 +224,6 @@ export const getVideoProperty = (properties, me) => {
     url: relativeMediaPath(item.url || item, me),
   }));
 };
-
-/**
- * Get published date (using current date if none given)
- *
- * @param {object} properties - JF2 properties
- * @param {object} timeZone - Publication time zone
- * @returns {Array} `published` property
- */
-export const getPublishedProperty = (properties, timeZone) =>
-  getDate(timeZone, properties.published);
 
 /**
  * Get slug

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -1,5 +1,6 @@
 import { IndiekitError } from "@indiekit/error";
 import { getPostType } from "./post-type-discovery.js";
+import { getDate } from "./date.js";
 import { getSyndicateToProperty, normaliseProperties } from "./jf2.js";
 import * as update from "./update.js";
 import { getPermalink, getPostTypeConfig, renderPath } from "./utils.js";
@@ -10,9 +11,10 @@ export const postData = {
    *
    * @param {object} publication - Publication configuration
    * @param {object} properties - JF2 properties
+   * @param {boolean} [draftMode=false] - Draft mode
    * @returns {object} Post data
    */
-  async create(publication, properties) {
+  async create(publication, properties, draftMode = false) {
     const { me, postTypes, syndicationTargets } = publication;
 
     // Add syndication targets
@@ -23,6 +25,9 @@ export const postData = {
 
     // Normalise properties
     properties = normaliseProperties(publication, properties);
+
+    // Add published date (or use that provided by client)
+    properties.published = getDate(publication.timeZone, properties.published);
 
     // Post type
     const type = getPostType(properties);
@@ -42,6 +47,12 @@ export const postData = {
     );
     const url = await renderPath(typeConfig.post.url, properties, publication);
     properties.url = getPermalink(me, url);
+
+    // Post status
+    // Draft mode: Only create post with a `draft` post-status
+    properties["post-status"] = draftMode
+      ? "draft"
+      : properties["post-status"] || "published";
 
     // Post data
     const postData = { path, properties };
@@ -70,6 +81,7 @@ export const postData = {
 
   /**
    * Update post data
+   * Add, delete or replace properties and/or replace property values
    *
    * @param {object} publication - Publication configuration
    * @param {string} url - URL of existing post
@@ -102,6 +114,9 @@ export const postData = {
     // Normalise properties
     properties = normaliseProperties(publication, properties);
 
+    // Add updated date
+    properties.updated = getDate(publication.timeZone);
+
     // Post type
     const type = getPostType(properties);
     const typeConfig = getPostTypeConfig(type, postTypes);
@@ -120,8 +135,89 @@ export const postData = {
     );
     properties.url = getPermalink(me, updatedUrl);
 
+    // Return updated post data
+    const postData = { path, properties };
+    return postData;
+  },
+
+  /**
+   * Delete post data
+   * Delete (most) properties, keeping a record of deleted for later retrieval
+   *
+   * @param {object} publication - Publication configuration
+   * @param {string} url - URL of existing post
+   * @returns {object} Post data
+   */
+  async delete(publication, url) {
+    const { postTypes } = publication;
+
+    // Read properties
+    const { properties } = await this.read(publication, url);
+
+    // Make a copy of existing properties
+    const _deletedProperties = structuredClone(properties);
+
+    // Delete all properties, except those required for path creation
+    for (const key in _deletedProperties) {
+      if (!["mp-slug", "post-type", "published", "type", "url"].includes(key)) {
+        delete properties[key];
+      }
+    }
+
+    // Add deleted date
+    properties.deleted = getDate(publication.timeZone);
+
+    // Post type
+    const typeConfig = getPostTypeConfig(properties["post-type"], postTypes);
+
+    // Post paths
+    const path = await renderPath(
+      typeConfig.post.path,
+      properties,
+      publication
+    );
+
     // Return post data
-    const updatedPostData = { path, properties };
-    return updatedPostData;
+    const postData = { path, properties, _deletedProperties };
+    return postData;
+  },
+
+  /**
+   * Undelete post data
+   * Restore previously deleted properties
+   *
+   * @param {object} publication - Publication configuration
+   * @param {string} url - URL of existing post
+   * @param {boolean} [draftMode=false] - Draft mode
+   * @returns {object} Post data
+   */
+  async undelete(publication, url, draftMode) {
+    const { postTypes } = publication;
+
+    // Read deleted properties
+    const { _deletedProperties } = await this.read(publication, url);
+
+    // Restore previously deleted properties
+    const properties = _deletedProperties;
+
+    // Post type
+    const typeConfig = getPostTypeConfig(properties["post-type"], postTypes);
+
+    // Post paths
+    const path = await renderPath(
+      typeConfig.post.path,
+      properties,
+      publication
+    );
+
+    // Post status
+    // Draft mode: Only restore post with a `draft` post-status
+    properties["post-status"] = draftMode
+      ? "draft"
+      : properties["post-status"] || "published";
+
+    // Return post data
+    const postData = { path, properties, _deletedProperties };
+    return postData;
   },
 };

--- a/packages/endpoint-micropub/lib/post.js
+++ b/packages/endpoint-micropub/lib/post.js
@@ -4,10 +4,9 @@ export const post = {
    *
    * @param {object} publication - Publication configuration
    * @param {object} postData - Post data
-   * @param {boolean} [draftMode=false] - Draft mode
    * @returns {object} Response data
    */
-  async create(publication, postData, draftMode = false) {
+  async create(publication, postData) {
     const { posts, postTemplate, store, storeMessageTemplate } = publication;
     const metaData = {
       action: "create",
@@ -20,10 +19,6 @@ export const post = {
     const published = await store.createFile(postData.path, content, message);
 
     if (published) {
-      postData.properties["post-status"] = draftMode
-        ? "draft"
-        : postData.properties["post-status"] || "published";
-
       if (posts) {
         await posts.insertOne(postData, {
           checkKeys: false,
@@ -62,8 +57,6 @@ export const post = {
     const updated = await store.updateFile(postData.path, content, message);
 
     if (updated) {
-      postData.properties.updated = new Date();
-
       if (posts) {
         await posts.replaceOne(
           {
@@ -98,20 +91,18 @@ export const post = {
    * @returns {object} Response data
    */
   async delete(publication, postData) {
-    const { posts, store, storeMessageTemplate } = publication;
+    const { posts, postTemplate, store, storeMessageTemplate } = publication;
     const metaData = {
       action: "delete",
       result: "deleted",
       fileType: "post",
       postType: postData.properties["post-type"],
     };
+    const content = postTemplate(postData.properties);
     const message = storeMessageTemplate(metaData);
-    const deleted = await store.deleteFile(postData.path, message);
+    const deleted = await store.updateFile(postData.path, content, message);
 
     if (deleted) {
-      postData.properties["post-status"] = "deleted";
-      postData.properties.updated = new Date();
-
       if (posts) {
         await posts.replaceOne(
           {
@@ -139,13 +130,12 @@ export const post = {
    *
    * @param {object} publication - Publication configuration
    * @param {object} postData - Post data
-   * @param {boolean} [draftMode=false] - Draft mode
    * @returns {object} Response data
    */
-  async undelete(publication, postData, draftMode = false) {
+  async undelete(publication, postData) {
     const { posts, postTemplate, store, storeMessageTemplate } = publication;
 
-    if (postData.properties?.["post-status"] !== "deleted") {
+    if (!postData._deletedProperties) {
       throw new Error("Post was not previously deleted");
     }
 
@@ -157,15 +147,11 @@ export const post = {
     };
     const content = postTemplate(postData.properties);
     const message = storeMessageTemplate(metaData);
-    const undeleted = await store.createFile(postData.path, content, message);
+    const undeleted = await store.updateFile(postData.path, content, message);
 
     if (undeleted) {
-      postData.properties["post-status"] = draftMode
-        ? "draft"
-        : postData.properties["post-status"] || "published";
-      postData.properties.updated = new Date();
-
       if (posts) {
+        delete postData._deletedProperties;
         await posts.replaceOne(
           {
             "properties.url": postData.properties.url,

--- a/packages/endpoint-micropub/lib/post.js
+++ b/packages/endpoint-micropub/lib/post.js
@@ -59,9 +59,9 @@ export const post = {
     };
     const content = postTemplate(postData.properties);
     const message = storeMessageTemplate(metaData);
-    const published = await store.updateFile(postData.path, content, message);
+    const updated = await store.updateFile(postData.path, content, message);
 
-    if (published) {
+    if (updated) {
       postData.properties.updated = new Date();
 
       if (posts) {
@@ -106,9 +106,9 @@ export const post = {
       postType: postData.properties["post-type"],
     };
     const message = storeMessageTemplate(metaData);
-    const published = await store.deleteFile(postData.path, message);
+    const deleted = await store.deleteFile(postData.path, message);
 
-    if (published) {
+    if (deleted) {
       postData.properties["post-status"] = "deleted";
       postData.properties.updated = new Date();
 
@@ -157,9 +157,9 @@ export const post = {
     };
     const content = postTemplate(postData.properties);
     const message = storeMessageTemplate(metaData);
-    const published = await store.createFile(postData.path, content, message);
+    const undeleted = await store.createFile(postData.path, content, message);
 
-    if (published) {
+    if (undeleted) {
       postData.properties["post-status"] = draftMode
         ? "draft"
         : postData.properties["post-status"] || "published";

--- a/packages/endpoint-micropub/tests/unit/jf2.js
+++ b/packages/endpoint-micropub/tests/unit/jf2.js
@@ -1,5 +1,4 @@
 import test from "ava";
-import dateFns from "date-fns";
 import { getFixture } from "@indiekit-test/fixtures";
 import { mockAgent } from "@indiekit-test/mock-agent";
 import {
@@ -10,13 +9,10 @@ import {
   getLocationProperty,
   getPhotoProperty,
   getVideoProperty,
-  getPublishedProperty,
   getSlugProperty,
   getSyndicateToProperty,
   normaliseProperties,
 } from "../../lib/jf2.js";
-
-const { isValid, parseISO } = dateFns;
 
 await mockAgent("website");
 
@@ -308,32 +304,6 @@ test("Gets normalised video property", (t) => {
   t.deepEqual(result, [{ url: "baz.mp4" }, { url: "https://foo.bar/qux.mp4" }]);
 });
 
-test("Gets date from `published` property", (t) => {
-  const properties = JSON.parse(getFixture("jf2/note-published-provided.jf2"));
-
-  const result = getPublishedProperty(properties);
-
-  t.is(result, "2019-01-02T03:04:05.678Z");
-});
-
-test("Gets date from `published` property (short date)", (t) => {
-  const properties = JSON.parse(
-    getFixture("jf2/note-published-provided-short.jf2")
-  );
-
-  const result = getPublishedProperty(properties);
-
-  t.is(result, "2019-01-02T00:00:00.000Z");
-});
-
-test("Gets date by using current date", (t) => {
-  const properties = JSON.parse(getFixture("jf2/note-published-missing.jf2"));
-
-  const result = getPublishedProperty(properties);
-
-  t.true(isValid(parseISO(result)));
-});
-
 test("Derives slug from `mp-slug` property", (t) => {
   const properties = JSON.parse(getFixture("jf2/note-slug-provided.jf2"));
 
@@ -516,7 +486,6 @@ test("Normalises JF2 (few properties)", (t) => {
   t.falsy(result.audio);
   t.falsy(result.photo);
   t.falsy(result.video);
-  t.true(isValid(parseISO(result.published)));
 });
 
 test("Normalises JF2 (all properties)", (t) => {
@@ -536,7 +505,6 @@ test("Normalises JF2 (all properties)", (t) => {
   ]);
   t.deepEqual(result.video, [{ url: "https://website.example/video.mp4" }]);
   t.deepEqual(result.category, ["lunch", "food"]);
-  t.true(isValid(parseISO(result.published)));
   t.deepEqual(result["mp-syndicate-to"], ["https://social.example"]);
 });
 

--- a/packages/endpoint-micropub/tests/unit/post.js
+++ b/packages/endpoint-micropub/tests/unit/post.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { publication } from "@indiekit-test/publication";
-import { postData } from "@indiekit-test/post-data";
+import { deletedPostData, postData } from "@indiekit-test/post-data";
 import { post } from "../../lib/post.js";
 
 await mockAgent("store");
@@ -63,15 +63,12 @@ test("Deletes a post", async (t) => {
 
 test("Throws error deleting a post", async (t) => {
   await t.throwsAsync(post.delete(false, postData), {
-    message: "storeMessageTemplate is not a function",
+    message: "postTemplate is not a function",
   });
 });
 
 test("Undeletes a post", async (t) => {
-  await post.create(publication, postData);
-  await post.delete(publication, postData);
-
-  const result = await post.undelete(publication, postData);
+  const result = await post.undelete(publication, deletedPostData);
 
   t.deepEqual(result, {
     location: "https://website.example/foo",
@@ -84,7 +81,7 @@ test("Undeletes a post", async (t) => {
 });
 
 test("Throws error undeleting a post", async (t) => {
-  await t.throwsAsync(post.undelete(publication, false), {
+  await t.throwsAsync(post.undelete(publication, postData), {
     message: "Post was not previously deleted",
   });
 });

--- a/packages/endpoint-posts/lib/controllers/post.js
+++ b/packages/endpoint-posts/lib/controllers/post.js
@@ -13,7 +13,6 @@ export const postController = async (request, response) => {
     response.locals;
 
   const postEditable = draftMode ? postStatus === "draft" : true;
-  const postDeleted = postStatus === "deleted";
 
   response.render("post", {
     title: postName,
@@ -22,14 +21,14 @@ export const postController = async (request, response) => {
       text: response.__("posts.posts.title"),
     },
     actions: [
-      scope && checkScope(scope, "update") && !postDeleted && postEditable
+      scope && checkScope(scope, "update") && !post.deleted && postEditable
         ? {
             href: path.join(request.originalUrl, "/update"),
             icon: "updatePost",
             text: response.__("posts.update.action"),
           }
         : {},
-      scope && checkScope(scope, "delete") && !postDeleted
+      scope && checkScope(scope, "delete") && !post.deleted
         ? {
             classes: "actions__link--warning",
             href: path.join(request.originalUrl, "/delete"),
@@ -37,7 +36,7 @@ export const postController = async (request, response) => {
             text: response.__("posts.delete.action"),
           }
         : {},
-      scope && checkScope(scope, "undelete") && postDeleted
+      scope && checkScope(scope, "undelete") && post.deleted
         ? {
             href: path.join(request.originalUrl, "/undelete"),
             icon: "undelete",

--- a/packages/endpoint-posts/lib/controllers/posts.js
+++ b/packages/endpoint-posts/lib/controllers/posts.js
@@ -40,9 +40,7 @@ export const postsController = async (request, response, next) => {
       const items = jf2.children || [jf2];
 
       posts = items.map((item) => {
-        item.classes = item["post-status"]
-          ? `file-list__item--${item["post-status"]}`
-          : "";
+        item.classes = item.deleted ? "file-list__item--deleted" : "";
         item.id = Buffer.from(item.url).toString("base64url");
         return item;
       });

--- a/packages/endpoint-posts/views/post.njk
+++ b/packages/endpoint-posts/views/post.njk
@@ -7,6 +7,11 @@
   }) if postStatus }}
 
   {{ badge({
+    classes: "badge--" + status.deleted.color,
+    text: __(status.deleted.text)
+  }) if post.deleted }}
+
+  {{ badge({
     classes: "badge--" + status.syndicated.color,
     icon: status.syndicated.icon,
     text: __(status.syndicated.text)

--- a/packages/frontend/components/file-list/template.njk
+++ b/packages/frontend/components/file-list/template.njk
@@ -14,6 +14,10 @@
           text: __(status[item["post-status"]].text)
         }) if item["post-status"] }}
         {{ badge({
+          classes: "badge--small badge--" + status.deleted.color,
+          text: __(status.deleted.text)
+        }) if item.deleted }}
+        {{ badge({
           classes: "badge--small badge--" + status.syndicated.color,
           icon:  status.syndicated.icon,
           text: __(status.syndicated.text)

--- a/packages/preset-hugo/index.js
+++ b/packages/preset-hugo/index.js
@@ -230,6 +230,7 @@ export default class HugoPreset {
       date: properties.published,
       publishDate: properties.published,
       ...(properties.updated && { lastmod: properties.updated }),
+      ...(properties.deleted && { expiryDate: properties.deleted }),
       ...(properties.name && { title: properties.name }),
       ...(properties.summary && { summary: properties.summary }),
       ...(properties.category && { category: properties.category }),

--- a/packages/preset-hugo/tests/index.js
+++ b/packages/preset-hugo/tests/index.js
@@ -35,6 +35,7 @@ test("Renders post template without content", (t) => {
   const result = hugo.postTemplate({
     published: "2020-02-02",
     updated: "2022-12-11",
+    deleted: "2022-12-12",
     name: "What I had for lunch",
   });
 
@@ -44,6 +45,7 @@ test("Renders post template without content", (t) => {
 date: 2020-02-02
 publishDate: 2020-02-02
 lastmod: 2022-12-11
+expiryDate: 2022-12-12
 title: What I had for lunch
 ---
 `

--- a/packages/preset-jekyll/index.js
+++ b/packages/preset-jekyll/index.js
@@ -152,6 +152,7 @@ export default class JekyllPreset {
     properties = {
       date: properties.published,
       ...(properties.updated && { updated: properties.updated }),
+      ...(properties.deleted && { deleted: properties.deleted }),
       ...(properties.name && { title: properties.name }),
       ...(properties.summary && { excerpt: properties.summary }),
       ...(properties.category && { category: properties.category }),

--- a/packages/preset-jekyll/tests/index.js
+++ b/packages/preset-jekyll/tests/index.js
@@ -31,6 +31,7 @@ test("Renders post template without content", (t) => {
   const result = jekyll.postTemplate({
     published: "2020-02-02",
     updated: "2022-12-11",
+    deleted: "2022-12-12",
     name: "Lunchtime",
   });
 
@@ -39,6 +40,7 @@ test("Renders post template without content", (t) => {
     `---
 date: 2020-02-02
 updated: 2022-12-11
+deleted: 2022-12-12
 title: Lunchtime
 ---
 `


### PR DESCRIPTION
Changes behaviour such that:

* Deleting posts no longer delete files (more of a soft delete… or soft*er* delete). 

  Now properties are deleted (except for those used in permalink creation) and a `deleted` date time is added. This means it’s possible to keep pages on a publication with a `401 Gone` status, and possibly a message about the page having been deleted, rather than respond with `404 Not Found` (See *[deleted](https://indieweb.org/deleted)* on the IndieWeb wiki).
* Deleted properties are now storied in a private `_deletedProperties` object, meaning deleted properties are no longer exposed when querying the Micropub endpoint 