### PR TITLE
Allow posts to include a location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10149,6 +10149,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formatcoords": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/formatcoords/-/formatcoords-1.1.3.tgz",
+      "integrity": "sha512-Ittg5/AsYFCOtcFGPLSmVpP56a8Ionmv4Ys69UmCAdvBnqVzvVVbkZMnjWEmXrZvnmoGQE8YI3RhnxbMQFdYSw=="
+    },
     "node_modules/formidable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
@@ -21927,6 +21932,7 @@
         "@paulrobertlloyd/mf2tojf2": "^1.0.0",
         "express": "^4.17.1",
         "express-validator": "^6.14.1",
+        "formatcoords": "^1.1.3",
         "undici": "^5.2.0"
       },
       "engines": {
@@ -23994,6 +24000,7 @@
         "@paulrobertlloyd/mf2tojf2": "^1.0.0",
         "express": "^4.17.1",
         "express-validator": "^6.14.1",
+        "formatcoords": "^1.1.3",
         "undici": "^5.2.0"
       }
     },
@@ -30162,6 +30169,11 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "formatcoords": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/formatcoords/-/formatcoords-1.1.3.tgz",
+      "integrity": "sha512-Ittg5/AsYFCOtcFGPLSmVpP56a8Ionmv4Ys69UmCAdvBnqVzvVVbkZMnjWEmXrZvnmoGQE8YI3RhnxbMQFdYSw=="
     },
     "formidable": {
       "version": "2.1.1",

--- a/packages/endpoint-posts/lib/controllers/form.js
+++ b/packages/endpoint-posts/lib/controllers/form.js
@@ -1,7 +1,8 @@
-import { validationResult } from "express-validator";
 import { checkScope } from "@indiekit/endpoint-micropub/lib/scope.js";
 import { jf2ToMf2 } from "@indiekit/endpoint-micropub/lib/mf2.js";
+import { validationResult } from "express-validator";
 import { endpoint } from "../endpoint.js";
+import { getLocationProperty } from "../utils.js";
 
 export const formController = {
   /**
@@ -49,6 +50,12 @@ export const formController = {
       if (values.items) {
         values.category = values.items;
         delete values.items;
+      }
+
+      // Convert geo string into object
+      if (values.geo) {
+        values.location = getLocationProperty(values.geo);
+        delete values.geo;
       }
 
       // Delete empty values

--- a/packages/endpoint-posts/lib/middleware/post-data.js
+++ b/packages/endpoint-posts/lib/middleware/post-data.js
@@ -22,7 +22,7 @@ export const postData = {
 
     // Only show advanced options if one of those fields has been updated
     const showAdvancedOptions =
-      post.category || post["mp-slug"] || post.visibility;
+      post.category || post.geo || post["mp-slug"] || post.visibility;
 
     response.locals = {
       accessToken: access_token,

--- a/packages/endpoint-posts/lib/middleware/validation.js
+++ b/packages/endpoint-posts/lib/middleware/validation.js
@@ -1,4 +1,5 @@
 import { check } from "express-validator";
+import { LAT_LONG_RE } from "../utils.js";
 
 export const validate = [
   check("bookmark-of")
@@ -42,4 +43,10 @@ export const validate = [
     )
     .notEmpty()
     .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+  check("geo")
+    .if((value, { req }) => req.body?.geo)
+    .custom((value) => value.match(LAT_LONG_RE))
+    .withMessage((value, { req, path }) =>
+      req.__(`posts.error.${path}.invalid`)
+    ),
 ];

--- a/packages/endpoint-posts/lib/utils.js
+++ b/packages/endpoint-posts/lib/utils.js
@@ -1,6 +1,29 @@
 import { Buffer } from "node:buffer";
 import { mf2tojf2 } from "@paulrobertlloyd/mf2tojf2";
+import formatcoords from "formatcoords";
 import { endpoint } from "./endpoint.js";
+
+export const LAT_LONG_RE =
+  /^(?<latitude>(?:-?|\+?)?\d+(?:\.\d+)?),\s*(?<longitude>(?:-?|\+?)?\d+(?:\.\d+)?)$/;
+
+/**
+ * Get location property
+ *
+ * @param {string} geo - Latitude and longitude, comma separated
+ * @returns {object} JF2 location property
+ */
+export const getLocationProperty = (geo) => {
+  const { latitude, longitude } = geo.match(LAT_LONG_RE).groups;
+
+  return {
+    type: "geo",
+    latitude,
+    longitude,
+    name: formatcoords(geo).format({
+      decimalPlaces: 2,
+    }),
+  };
+};
 
 /**
  * Get post ID from URL

--- a/packages/endpoint-posts/locales/de.json
+++ b/packages/endpoint-posts/locales/de.json
@@ -17,6 +17,9 @@
       "content": {
         "empty": "Geben Sie einige Inhalte ein"
       },
+      "geo": {
+        "invalid": "Geben Sie gültige Koordinaten ein"
+      },
       "in-reply-to": {
         "empty": "Geben Sie eine Webadresse wie https://example.org"
       },
@@ -41,6 +44,10 @@
       },
       "content": {
         "label": "Inhalt"
+      },
+      "geo": {
+        "hint": "Breitengrad und Längengrad, zum Beispiel %s",
+        "label": "Koordinaten des Standorts"
       },
       "in-reply-to": {
         "label": "Als Antwort auf"

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -7,6 +7,9 @@
       "content": {
         "empty": "Enter some content"
       },
+      "geo": {
+        "invalid": "Enter valid coordinates"
+      },
       "in-reply-to": {
         "empty": "Enter a web address like https://example.org"
       },
@@ -63,6 +66,10 @@
       },
       "content": {
         "label": "Content"
+      },
+      "geo": {
+        "label": "Location coordinates",
+        "hint": "Latitude and longitude, for example %s"
       },
       "in-reply-to": {
         "label": "In reply to"

--- a/packages/endpoint-posts/locales/es.json
+++ b/packages/endpoint-posts/locales/es.json
@@ -17,6 +17,9 @@
       "content": {
         "empty": "Introducir algún contenido"
       },
+      "geo": {
+        "invalid": "Introduce coordenadas válidas"
+      },
       "in-reply-to": {
         "empty": "Ingrese una dirección web como https://example.org"
       },
@@ -41,6 +44,10 @@
       },
       "content": {
         "label": "Contenido"
+      },
+      "geo": {
+        "hint": "Latitud y longitud, por ejemplo %s",
+        "label": "Coordenadas de ubicación"
       },
       "in-reply-to": {
         "label": "En respuesta a"

--- a/packages/endpoint-posts/locales/fr.json
+++ b/packages/endpoint-posts/locales/fr.json
@@ -17,6 +17,9 @@
       "content": {
         "empty": "Entrez du contenu"
       },
+      "geo": {
+        "invalid": "Entrez des coordonnées valides"
+      },
       "in-reply-to": {
         "empty": "Entrez une adresse Web telle que https://example.org"
       },
@@ -41,6 +44,10 @@
       },
       "content": {
         "label": "Contenu"
+      },
+      "geo": {
+        "hint": "Latitude et longitude, par exemple %s",
+        "label": "Coordonnées de localisation"
       },
       "in-reply-to": {
         "label": "En réponse à"

--- a/packages/endpoint-posts/locales/id.json
+++ b/packages/endpoint-posts/locales/id.json
@@ -17,6 +17,9 @@
       "content": {
         "empty": "Masukkan beberapa konten"
       },
+      "geo": {
+        "invalid": "Masukkan koordinat yang valid"
+      },
       "in-reply-to": {
         "empty": "Masukkan alamat web misalnya https://example.org"
       },
@@ -41,6 +44,10 @@
       },
       "content": {
         "label": "Konten"
+      },
+      "geo": {
+        "hint": "Lintang dan bujur, misalnya %s",
+        "label": "Koordinat lokasi"
       },
       "in-reply-to": {
         "label": "Sebagai balasan"

--- a/packages/endpoint-posts/locales/nl.json
+++ b/packages/endpoint-posts/locales/nl.json
@@ -17,6 +17,9 @@
       "content": {
         "empty": "Voer wat inhoud in"
       },
+      "geo": {
+        "invalid": "Voer geldige coördinaten in"
+      },
       "in-reply-to": {
         "empty": "Voer een webadres in zoals https://example.org"
       },
@@ -41,6 +44,10 @@
       },
       "content": {
         "label": "Inhoud"
+      },
+      "geo": {
+        "hint": "Lengte- en breedtegraad, bijvoorbeeld %s",
+        "label": "Locatiecoördinaten"
       },
       "in-reply-to": {
         "label": "Als antwoord op"

--- a/packages/endpoint-posts/locales/pl.json
+++ b/packages/endpoint-posts/locales/pl.json
@@ -17,6 +17,9 @@
       "content": {
         "empty": "Wprowadź jakąś zawartość"
       },
+      "geo": {
+        "invalid": "Wprowadź poprawne współrzędne"
+      },
       "in-reply-to": {
         "empty": "Wpisz adres internetowy, taki jak https://example.org"
       },
@@ -41,6 +44,10 @@
       },
       "content": {
         "label": "Zawartość"
+      },
+      "geo": {
+        "hint": "Szerokość i długość geograficzna, na przykład %s",
+        "label": "Współrzędne lokalizacji"
       },
       "in-reply-to": {
         "label": "W odpowiedzi na"

--- a/packages/endpoint-posts/locales/pt.json
+++ b/packages/endpoint-posts/locales/pt.json
@@ -17,6 +17,9 @@
       "content": {
         "empty": "Insira algum conteúdo"
       },
+      "geo": {
+        "invalid": "Insira coordenadas válidas"
+      },
       "in-reply-to": {
         "empty": "Insira um endereço da web como https://example.org"
       },
@@ -41,6 +44,10 @@
       },
       "content": {
         "label": "Conteúdo"
+      },
+      "geo": {
+        "hint": "Latitude e longitude, por exemplo %s",
+        "label": "Coordenadas de localização"
       },
       "in-reply-to": {
         "label": "Em resposta a"

--- a/packages/endpoint-posts/locales/sr.json
+++ b/packages/endpoint-posts/locales/sr.json
@@ -17,6 +17,9 @@
       "content": {
         "empty": "Unesite neki sadržaj"
       },
+      "geo": {
+        "invalid": "Unesite važeće koordinate"
+      },
       "in-reply-to": {
         "empty": "Unesite veb adresu kao što je https://example.org"
       },
@@ -41,6 +44,10 @@
       },
       "content": {
         "label": "Sadržaj"
+      },
+      "geo": {
+        "hint": "Geografska širina i dužina, na primer %s",
+        "label": "Koordinate lokacije"
       },
       "in-reply-to": {
         "label": "U odgovoru na"

--- a/packages/endpoint-posts/package.json
+++ b/packages/endpoint-posts/package.json
@@ -40,6 +40,7 @@
     "@paulrobertlloyd/mf2tojf2": "^1.0.0",
     "express": "^4.17.1",
     "express-validator": "^6.14.1",
+    "formatcoords": "^1.1.3",
     "undici": "^5.2.0"
   },
   "publishConfig": {

--- a/packages/endpoint-posts/tests/unit/utils.js
+++ b/packages/endpoint-posts/tests/unit/utils.js
@@ -1,5 +1,6 @@
 import test from "ava";
 import {
+  getLocationProperty,
   getPostId,
   getPostName,
   getPostTypeName,
@@ -29,6 +30,15 @@ test.beforeEach((t) => {
       },
     ],
   };
+});
+
+test("Gets location property", (t) => {
+  t.deepEqual(getLocationProperty("12.3456, -65.4321"), {
+    type: "geo",
+    latitude: "12.3456",
+    longitude: "-65.4321",
+    name: "12° 20′ 44.16″ N 65° 25′ 55.56″ W",
+  });
 });
 
 test("Gets post ID", (t) => {

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -17,6 +17,8 @@
   postType === "rsvp"
 %}
 
+{% set geo = [post.location.latitude, post.location.longitude] | join(",") if post.location %}
+
 {% block fieldset %}
   {{ input({
     name: "type",
@@ -166,6 +168,22 @@
         "data-controller": "token-input",
         "data-token-input-items-value": publication.categories
       }
+    }) | indent(4) }}
+
+    {{ geoInput({
+      id: "geo",
+      name: "geo",
+      value: errors.geo.value or geo,
+      label: {
+        text: __("posts.form.geo.label")
+      },
+      hint: {
+        text: __("posts.form.geo.hint", "50.8211, -0.1452")
+      },
+      optional: true,
+      errorMessage: {
+        text: errors.geo.msg
+      } if errors.geo
     }) | indent(4) }}
 
     {{ input({

--- a/packages/frontend/components/button/styles.css
+++ b/packages/frontend/components/button/styles.css
@@ -34,7 +34,11 @@
   --button-font-weight: normal;
 }
 
-.button:hover,
+.button:disabled {
+  opacity: 0.5;
+}
+
+.button:hover:not:disabled,
 ::file-selector-button:hover {
   background-color: var(--button-background-hover-color, var(--color-primary));
 }

--- a/packages/frontend/components/geo-input/index.js
+++ b/packages/frontend/components/geo-input/index.js
@@ -1,0 +1,97 @@
+/* global document, navigator */
+import { Controller } from "@hotwired/stimulus";
+
+export const GeoInputController = class extends Controller {
+  static targets = ["errorMessage", "geo"];
+
+  static values = {
+    denied: String,
+    failed: String,
+  };
+
+  initialize() {
+    if (!navigator.geolocation) {
+      return;
+    }
+
+    // Create group to hold input and button
+    const inputButtonGroup = document.createElement("div");
+    inputButtonGroup.classList.add("input-button-group");
+
+    // Create and display find location button
+    const buttonTemplate = document.querySelector("#geo-input-button");
+    const button = buttonTemplate.content.cloneNode(true);
+    const input = this.element.querySelector(".input");
+
+    // Move input into group, and append find location button
+    input.parentNode.insertBefore(inputButtonGroup, input);
+    inputButtonGroup.append(input, button);
+  }
+
+  showError(element, message) {
+    const input = element.querySelector(".input");
+    const inputButtonGroup = element.querySelector(".input-button-group");
+    const inputField = element.querySelector(".field");
+
+    // Create error message
+    const errorMessageTemplate = document.querySelector(
+      "#geo-input-error-message"
+    );
+    const errorMessageElement = errorMessageTemplate.content.cloneNode(true);
+    inputButtonGroup.before(errorMessageElement);
+    const errorMessage = element.querySelector(".error-message");
+    const errorMessageText = element.querySelector(".error-message__text");
+
+    // Add field error class
+    inputField.classList.add("field--error");
+
+    // Add error message text
+    errorMessageText.textContent = message;
+
+    // Update `aria-describedby` on input element to reference error message
+    const inputAttributes = input.getAttribute("aria-describedby") || "";
+    input.setAttribute(
+      "aria-describedby",
+      [inputAttributes, errorMessage.id].join(" ")
+    );
+  }
+
+  /**
+   * @typedef GeolocationPosition
+   * @property {object} position - Position
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition}
+   * @typedef GeolocationPositionError
+   * @property {object} error - Error
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError}
+   */
+  find() {
+    const { element, geoTarget, deniedValue, failedValue, showError } = this;
+
+    /**
+     * @param {Object<GeolocationPosition>} position - Position
+     */
+    function success(position) {
+      const latitude = position.coords.latitude.toFixed(5);
+      const longitude = position.coords.longitude.toFixed(5);
+      geoTarget.value = [latitude, longitude].join(",");
+    }
+
+    /**
+     * @param {Object<GeolocationPositionError>} error - Position error
+     */
+    function error(error) {
+      element.querySelector(".button").disabled = true;
+
+      if (error.PERMISSION_DENIED) {
+        showError(element, deniedValue);
+      } else if (error.POSITION_UNAVAILABLE) {
+        showError(element, failedValue);
+      }
+    }
+
+    navigator.geolocation.getCurrentPosition(success, error, {
+      enableHighAccuracy: true,
+      timeout: 5000,
+    });
+  }
+};

--- a/packages/frontend/components/geo-input/macro.njk
+++ b/packages/frontend/components/geo-input/macro.njk
@@ -1,0 +1,3 @@
+{% macro geoInput(opts) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/frontend/components/geo-input/template.njk
+++ b/packages/frontend/components/geo-input/template.njk
@@ -1,0 +1,38 @@
+{%- from "../error-message/macro.njk" import errorMessage with context -%}
+{%- from "../button/macro.njk" import button with context -%}
+{%- from "../input/macro.njk" import input with context -%}
+{{ input({
+  field: {
+    attributes: {
+      "data-controller": "geo-input",
+      "data-geo-input-denied-value": __("geoInput.denied"),
+      "data-geo-input-failed-value": __("geoInput.failed")
+    }
+  },
+  classes: opts.classes,
+  id: opts.id,
+  name: opts.name,
+  value: opts.value,
+  label: opts.label,
+  hint: opts.hint,
+  optional: opts.optional,
+  attributes: {
+    "data-geo-input-target": "geo"
+  },
+  errorMessage: opts.errorMessage
+}) }}
+<template id="geo-input-button">
+  {{ button({
+    classes: "button--secondary",
+    type: "button",
+    text: __("geoInput.getCurrentPosition"),
+    attributes: {
+      "data-action": "geo-input#find"
+    }
+  }) }}
+</template>
+<template id="geo-input-error-message">
+  {{ errorMessage({
+    id: opts.id + "-error"
+  }) }}
+</template>

--- a/packages/frontend/components/input/styles.css
+++ b/packages/frontend/components/input/styles.css
@@ -66,3 +66,28 @@
 .input--width-2 {
   max-width: 3ch;
 }
+
+/* Show an input and button combined */
+.input-button-group {
+  align-items: end;
+  display: flex;
+  gap: 0;
+
+  & .input {
+    border-end-end-radius: 0;
+    border-start-end-radius: 0;
+    inline-size: auto;
+    margin-inline-end: calc(var(--input-border-width) * -1);
+    position: relative;
+    z-index: 1;
+  }
+
+  & .input:focus-visible {
+    margin-inline-end: calc(var(--input-border-width-focus) * -1);
+  }
+
+  & .button {
+    border-end-start-radius: 0;
+    border-start-start-radius: 0;
+  }
+}

--- a/packages/frontend/layouts/default.njk
+++ b/packages/frontend/layouts/default.njk
@@ -8,6 +8,7 @@
 {%- from "error-summary/macro.njk" import errorSummary with context -%}
 {%- from "fieldset/macro.njk" import fieldset with context -%}
 {%- from "footer/macro.njk" import footer with context -%}
+{%- from "geo-input/macro.njk" import geoInput with context -%}
 {%- from "header/macro.njk" import header with context -%}
 {%- from "heading/macro.njk" import heading with context -%}
 {%- from "hint/macro.njk" import hint with context -%}

--- a/packages/frontend/locales/de.json
+++ b/packages/frontend/locales/de.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "Es gibt ein Problem"
   },
+  "geoInput": {
+    "denied": "Die Erlaubnis zur Nutzung Ihres aktuellen Standorts konnte nicht eingeholt werden",
+    "failed": "Ihr aktueller Standort kann nicht abgerufen werden",
+    "getCurrentPosition": "Meinen aktuellen Standort verwenden"
+  },
   "important": "Wichtig",
   "noValue": "Nicht festgelegt",
   "optionalValue": "(fakultativ)",

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "There is a problem"
   },
+  "geoInput": {
+    "denied": "Unable to get permission to use your current location",
+    "failed": "Unable to get your current location",
+    "getCurrentPosition": "Use my current location"
+  },
   "important": "Important",
   "skipLink": {
     "text": "Skip to content"

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "Hay un problema"
   },
+  "geoInput": {
+    "denied": "No se puede obtener permiso para usar su ubicación actual",
+    "failed": "No se puede obtener su ubicación actual",
+    "getCurrentPosition": "Usar mi ubicación actual"
+  },
   "important": "Importante",
   "noValue": "No establecido",
   "optionalValue": "(opcional)",

--- a/packages/frontend/locales/fr.json
+++ b/packages/frontend/locales/fr.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "Il y a un problème"
   },
+  "geoInput": {
+    "denied": "Impossible d'obtenir l'autorisation d'utiliser votre position actuelle",
+    "failed": "Impossible d'obtenir votre position actuelle",
+    "getCurrentPosition": "Utiliser ma position actuelle"
+  },
   "important": "Important",
   "noValue": "Non définie",
   "optionalValue": "(facultatif)",

--- a/packages/frontend/locales/id.json
+++ b/packages/frontend/locales/id.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "Ada masalah"
   },
+  "geoInput": {
+    "denied": "Tidak dapat memperoleh izin untuk menggunakan lokasi Anda saat ini",
+    "failed": "Tidak bisa mendapatkan lokasi Anda saat ini",
+    "getCurrentPosition": "Gunakan lokasi sekarang"
+  },
   "important": "Penting",
   "noValue": "Tidak ada",
   "optionalValue": "(opsional)",

--- a/packages/frontend/locales/nl.json
+++ b/packages/frontend/locales/nl.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "Er is een Probleem"
   },
+  "geoInput": {
+    "denied": "Kan geen toestemming krijgen om je huidige locatie te gebruiken",
+    "failed": "Kan uw huidige locatie niet ophalen",
+    "getCurrentPosition": "Mijn huidige locatie gebruiken"
+  },
   "important": "Belangrijk",
   "noValue": "Niet ingesteld",
   "optionalValue": "(optioneel)",

--- a/packages/frontend/locales/pl.json
+++ b/packages/frontend/locales/pl.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "Wystąpił problem"
   },
+  "geoInput": {
+    "denied": "Nie można uzyskać uprawnień do korzystania z bieżącej lokalizacji",
+    "failed": "Nie można uzyskać bieżącej lokalizacji",
+    "getCurrentPosition": "Użyj mojej obecnej lokalizacji"
+  },
   "important": "Ważne",
   "noValue": "Nie ustawiono",
   "optionalValue": "(opcjonalnie)",

--- a/packages/frontend/locales/pt.json
+++ b/packages/frontend/locales/pt.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "Há um problema"
   },
+  "geoInput": {
+    "denied": "Não foi possível obter permissão para usar sua localização atual",
+    "failed": "Não foi possível obter sua localização atual",
+    "getCurrentPosition": "Usar minha localização atual"
+  },
   "important": "Importante",
   "noValue": "Não definido",
   "optionalValue": "(opcional)",

--- a/packages/frontend/locales/sr.json
+++ b/packages/frontend/locales/sr.json
@@ -6,6 +6,11 @@
   "errorSummary": {
     "title": "Postoji problem"
   },
+  "geoInput": {
+    "denied": "Nije moguće dobiti dozvolu za korišćenje vaše trenutne lokacije",
+    "failed": "Nije moguće dobiti vašu trenutnu lokaciju",
+    "getCurrentPosition": "Koristi moju trenutnu lokaciju"
+  },
   "important": "Važno",
   "noValue": "Nije rešeno",
   "optionalValue": "(opcionalno)",

--- a/packages/frontend/scripts/app.js
+++ b/packages/frontend/scripts/app.js
@@ -2,6 +2,7 @@
 import { Application } from "@hotwired/stimulus";
 
 import { ErrorSummaryController } from "../components/error-summary/index.js";
+import { GeoInputController } from "../components/geo-input/index.js";
 import { PreviewController } from "../components/preview/index.js";
 import { NotificationController } from "../components/notification/index.js";
 import { TextareaController } from "../components/textarea/index.js";
@@ -9,6 +10,7 @@ import { TokenInputController } from "../components/token-input/index.js";
 
 window.Stimulus = Application.start();
 Stimulus.register("error-summary", ErrorSummaryController);
+Stimulus.register("geo-input", GeoInputController);
 Stimulus.register("notification", NotificationController);
 Stimulus.register("preview", PreviewController);
 Stimulus.register("textarea", TextareaController);


### PR DESCRIPTION
This PR adds a new field within a post’s advanced options to include location coordinates (that’s `h-geo` as opposed to `h-card` for location name and address which will be needed for an event/checkin posts). 

<img width="580" alt="Screenshot of new location field" src="https://user-images.githubusercontent.com/813383/209444040-ae830bf1-c284-41fa-9203-2698d88ce97e.png">

This produces the following JF2 properties:

```json
{
  "type": "geo",
  "latitude": "50.8211",
  "longitude": "-2.1452",
  "name": "50° 49′ 15.96″ N 2° 8′ 42.72″ W"
}
```

with `name` being an alternative DMS representation of the DD coordinates. 

Also adds:
* `geoInput` component
* `disabled` button styles (if permission to get location is not given)
* `input-button-group` to show an input and button combined within a single field