### PR TITLE
docs: improve description of MONGO_URL format

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -107,7 +107,9 @@ Before you can use Indiekit, some extra configuration values that only you and y
 
   A database is optional but required for many features to work.
 
-  A MongoDB URL will have the following format: `mongodb+srv://<username>:<password>@<hostname>`
+  A MongoDB URL will have the following format: `mongodb://<username>:<password>@<hostname>/<database>`
+
+  (The URL may start with `mongodb+srv://` if you are connecting to a server cluster, not a single server.)
 
   ::: tip
   Some hosts include support for MongoDB. If not, you can create a database for free using [MongoDB’s own Atlas service](https://www.mongodb.com/atlas).


### PR DESCRIPTION
The string will always contain a database name, and it may use the `mongodb:` or `mongodb+srv:` protocol.