### PR TITLE
fix: use MONGO_URL env variable if specified

### DIFF
--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -12,7 +12,7 @@ export const defaultConfig = {
     endpoints: [],
     hasDatabase: false,
     localesAvailable: ["de", "en", "es", "fr", "id", "nl", "pl", "pt", "sr"],
-    mongodbUrl: false,
+    mongodbUrl: process.env.MONGO_URL || false,
     name: "Indiekit",
     repository: package_.repository,
     themeColor: "#04f",


### PR DESCRIPTION
Fixes getindiekit/indiekit#556

It doesn't appear that there are currently any tests for **config/defaults.js** or **lib/config.js**, so I've not written a regression test for this. Let me know if you need me to add one.

I was unable to test this fix locally due to #558, but it looks straightforward. 🤞🏻