### PR TITLE
Correctly encode html/text content containing `<`/`>` characters

### DIFF
--- a/helpers/fixtures/jf2/article-content-provided-html-text.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-html-text.jf2
@@ -2,8 +2,8 @@
   "type": "entry",
   "name": "What I had for lunch",
   "content": {
-    "html": "<p>I ate a <i>cheese</i> sandwich, which was nice.</p>",
-    "text": "I ate a *cheese* sandwich, which was nice."
+    "html": "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>",
+    "text": "> I ate a *cheese* sandwich, which was > 10."
   },
   "url": "https://foo.bar/lunchtime",
   "post-type": "article"

--- a/helpers/fixtures/jf2/article-content-provided-text.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-text.jf2
@@ -2,6 +2,6 @@
   "type": "entry",
   "name": "What I had for lunch",
   "content": {
-    "text": "I ate a *cheese* sandwich, which was nice."
+    "text": "> I ate a *cheese* sandwich, which was > 10."
   }
 }

--- a/helpers/fixtures/jf2/article-content-provided.jf2
+++ b/helpers/fixtures/jf2/article-content-provided.jf2
@@ -1,5 +1,5 @@
 {
   "type": "entry",
   "name": "What I had for lunch",
-  "content": "I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice."
+  "content": "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was > 10."
 }

--- a/helpers/fixtures/jf2/note-content-provided-html-text-mixed.jf2
+++ b/helpers/fixtures/jf2/note-content-provided-html-text-mixed.jf2
@@ -1,8 +1,8 @@
 {
   "type": "entry",
   "content": {
-    "html": "<p>I ate a <i>cheese</i> sandwich, which was nice.</p>",
-    "text": "<p>I ate a <i>cheese</i> sandwich, which was nice.</p>"
+    "html": "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>",
+    "text": "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>"
   },
   "url": "https://foo.bar/lunchtime"
 }

--- a/helpers/fixtures/jf2/note-content-provided-html-text.jf2
+++ b/helpers/fixtures/jf2/note-content-provided-html-text.jf2
@@ -1,8 +1,8 @@
 {
   "type": "entry",
   "content": {
-    "html": "<p>I ate a <i>cheese</i> sandwich, which was nice.</p>",
-    "text": "I ate a cheese sandwich, which was nice."
+    "html": "<blockquote><p>I ate a <i>cheese</i> sandwich, which &gt; 10.</p></blockquote>",
+    "text": "I ate a cheese sandwich, which was > 10."
   },
   "url": "https://foo.bar/lunchtime"
 }

--- a/helpers/fixtures/jf2/note-content-provided-html-with-link.jf2
+++ b/helpers/fixtures/jf2/note-content-provided-html-with-link.jf2
@@ -1,6 +1,6 @@
 {
   "type": "entry",
   "content": {
-    "html": "<p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich, which was nice.</p>"
+    "html": "<blockquote><p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich, which was &gt; 10.</p></blockquote>"
   }
 }

--- a/helpers/fixtures/jf2/note-content-provided-html.jf2
+++ b/helpers/fixtures/jf2/note-content-provided-html.jf2
@@ -1,7 +1,7 @@
 {
   "type": "entry",
   "content": {
-    "html": "<p>I ate a <i>cheese</i> sandwich, which was nice.</p>"
+    "html": "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>"
   },
   "url": "https://foo.bar/lunchtime"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18304,11 +18304,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/striptags": {
-      "version": "4.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-4.0.0-alpha.4.tgz",
-      "integrity": "sha512-/0jWyVWhpg9ciRHfjKYBpMHXct/HrFRfsR2HU77nGPbc8SPcVSIHZlZR/0TG3MyPq2C+HiHuwx8BlbcdI/cNbw=="
-    },
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -21905,7 +21900,6 @@
         "lodash": "^4.17.21",
         "markdown-it": "^13.0.0",
         "newbase60": "^1.3.1",
-        "striptags": "^4.0.0-alpha.2",
         "turndown": "^7.1.1",
         "undici": "^5.2.0",
         "uuid": "^9.0.0"
@@ -23979,7 +23973,6 @@
         "lodash": "^4.17.21",
         "markdown-it": "^13.0.0",
         "newbase60": "^1.3.1",
-        "striptags": "^4.0.0-alpha.2",
         "turndown": "^7.1.1",
         "undici": "^5.2.0",
         "uuid": "^9.0.0"
@@ -36054,11 +36047,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
-    },
-    "striptags": {
-      "version": "4.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-4.0.0-alpha.4.tgz",
-      "integrity": "sha512-/0jWyVWhpg9ciRHfjKYBpMHXct/HrFRfsR2HU77nGPbc8SPcVSIHZlZR/0TG3MyPq2C+HiHuwx8BlbcdI/cNbw=="
     },
     "strnum": {
       "version": "1.0.5",

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -1,6 +1,5 @@
 import { mf2tojf2, mf2tojf2referenced } from "@paulrobertlloyd/mf2tojf2";
-import { striptags } from "striptags";
-import { markdownToHtml, htmlToMarkdown } from "./markdown.js";
+import { markdownToHtml, textToMarkdown } from "./markdown.js";
 import { reservedProperties } from "./reserved-properties.js";
 import {
   decodeQueryParameter,
@@ -135,25 +134,29 @@ export const getContentProperty = (properties) => {
   const { content } = properties;
   let { html, text } = content;
 
-  // Strip any HTML from text property
+  // Ensure any existing text property is in fact Markdown
   if (text) {
-    text = striptags(text);
+    text = textToMarkdown(text);
   }
 
-  // Return existing text and HTML representations
+  // Return existing text and HTML representations, unamended
   if (html && text) {
     return { html, text };
   }
 
   // If HTML representation only, add text representation
   if (html && !text) {
-    text = htmlToMarkdown(html);
-    return { html, text };
+    return { html, text: textToMarkdown(html) };
+  }
+
+  // If text representation only, add HTML representation
+  if (!html && text) {
+    return { html: markdownToHtml(text), text };
   }
 
   // Return property with text and HTML representations
-  text = text || striptags(content);
-  html = markdownToHtml(text);
+  text = text || textToMarkdown(content);
+  html = markdownToHtml(content);
   return { html, text };
 };
 

--- a/packages/endpoint-micropub/lib/markdown.js
+++ b/packages/endpoint-micropub/lib/markdown.js
@@ -23,12 +23,15 @@ export const markdownToHtml = (string) => {
 };
 
 /**
- * Convert HTML to Markdown
+ * Convert text to Markdown
  *
- * @param {string} string - HTML
+ * @param {string} string - String (may be HTML or Markdown)
  * @returns {string} Markdown
  */
-export const htmlToMarkdown = (string) => {
+export const textToMarkdown = (string) => {
+  // Normalise text as HTML before converting to Markdown
+  string = markdownToHtml(string);
+
   const options = {
     codeBlockStyle: "fenced",
     emDelimiter: "*",
@@ -36,6 +39,13 @@ export const htmlToMarkdown = (string) => {
   };
 
   const turndownService = new TurndownService(options);
+
+  /**
+   * Disable escaping of Markdown characters
+   *
+   * @see {@link: https://github.com/mixmark-io/turndown#escaping-markdown-characters}
+   */
+  turndownService.escape = (string) => string;
 
   const markdown = turndownService.turndown(string);
 

--- a/packages/endpoint-micropub/package.json
+++ b/packages/endpoint-micropub/package.json
@@ -44,7 +44,6 @@
     "lodash": "^4.17.21",
     "markdown-it": "^13.0.0",
     "newbase60": "^1.3.1",
-    "striptags": "^4.0.0-alpha.2",
     "turndown": "^7.1.1",
     "undici": "^5.2.0",
     "uuid": "^9.0.0"

--- a/packages/endpoint-micropub/tests/unit/jf2.js
+++ b/packages/endpoint-micropub/tests/unit/jf2.js
@@ -137,8 +137,8 @@ test("Gets text and HTML values from `content` property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: "<p>I ate a <i>cheese</i> sandwich, which was nice.</p>",
-    text: "I ate a cheese sandwich, which was nice.",
+    html: "<blockquote><p>I ate a <i>cheese</i> sandwich, which &gt; 10.</p></blockquote>",
+    text: "I ate a cheese sandwich, which was > 10.",
   });
 });
 
@@ -149,8 +149,8 @@ test("Gets mixed text and HTML values from `content` property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: "<p>I ate a <i>cheese</i> sandwich, which was nice.</p>",
-    text: "I ate a cheese sandwich, which was nice.",
+    html: "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>",
+    text: "> I ate a *cheese* sandwich, which was > 10.",
   });
 });
 
@@ -161,8 +161,8 @@ test("Gets HTML from `content` property and adds text value", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: "<p>I ate a <i>cheese</i> sandwich, which was nice.</p>",
-    text: "I ate a *cheese* sandwich, which was nice.",
+    html: "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>",
+    text: "> I ate a *cheese* sandwich, which was > 10.",
   });
 });
 
@@ -173,8 +173,10 @@ test("Gets content from `content.text` property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: "<p>I ate a <em>cheese</em> sandwich, which was nice.</p>",
-    text: "I ate a *cheese* sandwich, which was nice.",
+    html: `<blockquote>
+<p>I ate a <em>cheese</em> sandwich, which was &gt; 10.</p>
+</blockquote>`,
+    text: "> I ate a *cheese* sandwich, which was > 10.",
   });
 });
 
@@ -183,8 +185,10 @@ test("Gets content from `content` property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: '<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich, which was nice.</p>',
-    text: "I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.",
+    html: `<blockquote>
+<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich, which was &gt; 10.</p>
+</blockquote>`,
+    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was > 10.",
   });
 });
 
@@ -446,8 +450,10 @@ test("Normalises JF2 (few properties)", (t) => {
   t.is(result.name, "What I had for lunch");
   t.is(result["mp-slug"], "what-i-had-for-lunch");
   t.deepEqual(result.content, {
-    html: '<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich, which was nice.</p>',
-    text: "I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.",
+    html: `<blockquote>
+<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich, which was &gt; 10.</p>
+</blockquote>`,
+    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was > 10.",
   });
   t.falsy(result.audio);
   t.falsy(result.photo);

--- a/packages/endpoint-micropub/tests/unit/markdown.js
+++ b/packages/endpoint-micropub/tests/unit/markdown.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import { markdownToHtml, htmlToMarkdown } from "../../lib/markdown.js";
+import { markdownToHtml, textToMarkdown } from "../../lib/markdown.js";
 
 test("Converts Markdown to HTML", (t) => {
   t.is(
@@ -8,14 +8,18 @@ test("Converts Markdown to HTML", (t) => {
   );
 });
 
-test("Converts HTML to Markdown", (t) => {
+test("Converts text to Markdown", (t) => {
+  // HTML to Markdown
   t.is(
-    htmlToMarkdown('<p>This is a <strong><a href="#">link</a></strong></p>'),
+    textToMarkdown('<p>This is a <strong><a href="#">link</a></strong></p>'),
     "This is a **[link](#)**"
   );
 
+  // Markdown to Markdown
   t.is(
-    htmlToMarkdown("<h1><cite>Everything Everywhere All at Once</cite></h1>"),
-    "# Everything Everywhere All at Once"
+    textToMarkdown("**First** paragraph\n\n**Second** paragraph"),
+    `**First** paragraph
+
+**Second** paragraph`
   );
 });

--- a/packages/syndicator-mastodon/tests/unit/utils.js
+++ b/packages/syndicator-mastodon/tests/unit/utils.js
@@ -31,7 +31,7 @@ test("Creates a status with HTML content", (t) => {
     "https://mastodon.example"
   );
 
-  t.is(result.status, "I ate a cheese sandwich, which was nice.");
+  t.is(result.status, "> I ate a cheese sandwich, which was > 10.");
 });
 
 test("Creates a status with HTML content and appends last link", (t) => {
@@ -42,7 +42,7 @@ test("Creates a status with HTML content and appends last link", (t) => {
 
   t.is(
     result.status,
-    "I ate a cheese sandwich, which was nice. https://en.wikipedia.org/wiki/Cheese"
+    "> I ate a cheese sandwich, which was > 10. https://en.wikipedia.org/wiki/Cheese"
   );
 });
 

--- a/packages/syndicator-twitter/tests/unit/utils.js
+++ b/packages/syndicator-twitter/tests/unit/utils.js
@@ -29,7 +29,7 @@ test("Creates a status with HTML content", (t) => {
     JSON.parse(getFixture("jf2/note-content-provided-html.jf2"))
   );
 
-  t.is(result.status, "I ate a cheese sandwich, which was nice.");
+  t.is(result.status, "> I ate a cheese sandwich, which was > 10.");
 });
 
 test("Creates a status with HTML content and appends last link", (t) => {
@@ -39,7 +39,7 @@ test("Creates a status with HTML content and appends last link", (t) => {
 
   t.is(
     result.status,
-    "I ate a cheese sandwich, which was nice. https://en.wikipedia.org/wiki/Cheese"
+    "> I ate a cheese sandwich, which was > 10. https://en.wikipedia.org/wiki/Cheese"
   );
 });
 


### PR DESCRIPTION
Not sure why I was using `striptags` when I already had the `htmlToMarkdown` function (that uses Turndown) that achieves roughly similar. Maybe it’s because of the issues I encountered trying to use it this time round:

1. encoding Markdown as Markdown with Turndown leads to escaping of markdown characters:

   ```md
   This is a [link](/)
   ```

   becomes

   ```md
   This is a \\[link\\](/)
   ```

2. encoding Markdown as Markdown means any existing line breaks are ignored:

   ```md
   Paragraph

   > Blockquote
   ```

   becomes

   ```md
   Paragraph > Blockquote
   ```

However, we can avoid these issues by

1. [Disabling the escaping of Markdown characters in Turndown](https://github.com/mixmark-io/turndown#escaping-markdown-characters)
2. Converting Markdown to HTML before converting it back to Markdown

…and that means we can remove a dependency: we no longer need `striptags`. 

This PR resolves the issue reported in #563, meaning any Markdown is retained, and any HTML within pre-formatted text is also retained.

In addition to making this change, I have updated tests to include strings that include `>` for use either in Markdown or as a greater than symbol.