### PR TITLE
`content.text` improvements

### DIFF
--- a/helpers/fixtures/jf2/article-content-provided-as-html.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-as-html.jf2
@@ -1,0 +1,5 @@
+{
+  "type": "entry",
+  "name": "What I had for lunch",
+  "content": "<blockquote><p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>"
+}

--- a/helpers/fixtures/jf2/article-content-provided-as-text.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-as-text.jf2
@@ -1,0 +1,5 @@
+{
+  "type": "entry",
+  "name": "What I had for lunch",
+  "content": "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
+}

--- a/helpers/fixtures/jf2/article-content-provided-html-text-mixed.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-html-text-mixed.jf2
@@ -3,7 +3,6 @@
   "name": "What I had for lunch",
   "content": {
     "html": "<blockquote><p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>",
-    "text": "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
-  },
-  "url": "https://foo.bar/lunchtime"
+    "text": "<blockquote><p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>"
+  }
 }

--- a/helpers/fixtures/jf2/article-content-provided-text.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-text.jf2
@@ -2,6 +2,6 @@
   "type": "entry",
   "name": "What I had for lunch",
   "content": {
-    "text": "> I ate a *cheese* sandwich, which was > 10."
+    "text": "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
   }
 }

--- a/helpers/fixtures/jf2/article-content-provided.jf2
+++ b/helpers/fixtures/jf2/article-content-provided.jf2
@@ -1,5 +1,0 @@
-{
-  "type": "entry",
-  "name": "What I had for lunch",
-  "content": "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was > 10."
-}

--- a/helpers/fixtures/jf2/note-content-provided-html-text-mixed.jf2
+++ b/helpers/fixtures/jf2/note-content-provided-html-text-mixed.jf2
@@ -1,8 +1,0 @@
-{
-  "type": "entry",
-  "content": {
-    "html": "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>",
-    "text": "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>"
-  },
-  "url": "https://foo.bar/lunchtime"
-}

--- a/helpers/fixtures/jf2/note-content-provided-html-text.jf2
+++ b/helpers/fixtures/jf2/note-content-provided-html-text.jf2
@@ -1,8 +1,0 @@
-{
-  "type": "entry",
-  "content": {
-    "html": "<blockquote><p>I ate a <i>cheese</i> sandwich, which &gt; 10.</p></blockquote>",
-    "text": "I ate a cheese sandwich, which was > 10."
-  },
-  "url": "https://foo.bar/lunchtime"
-}

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -1,5 +1,5 @@
 import { mf2tojf2, mf2tojf2referenced } from "@paulrobertlloyd/mf2tojf2";
-import { markdownToHtml, textToMarkdown } from "./markdown.js";
+import { markdownToHtml, htmlToMarkdown } from "./markdown.js";
 import { reservedProperties } from "./reserved-properties.js";
 import {
   decodeQueryParameter,
@@ -136,7 +136,7 @@ export const getContentProperty = (properties) => {
 
   // Ensure any existing text property is in fact Markdown
   if (text) {
-    text = textToMarkdown(text);
+    text = htmlToMarkdown(text);
   }
 
   // Return existing text and HTML representations, unamended
@@ -146,7 +146,7 @@ export const getContentProperty = (properties) => {
 
   // If HTML representation only, add text representation
   if (html && !text) {
-    return { html, text: textToMarkdown(html) };
+    return { html, text: htmlToMarkdown(html) };
   }
 
   // If text representation only, add HTML representation
@@ -155,7 +155,7 @@ export const getContentProperty = (properties) => {
   }
 
   // Return property with text and HTML representations
-  text = text || textToMarkdown(content);
+  text = text || htmlToMarkdown(content);
   html = markdownToHtml(content);
   return { html, text };
 };

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -7,6 +7,7 @@ import {
   relativeMediaPath,
   randomString,
   slugifyString,
+  stringIsHtml,
   toArray,
 } from "./utils.js";
 
@@ -136,7 +137,7 @@ export const getContentProperty = (properties) => {
 
   // Ensure any existing text property is in fact Markdown
   if (text) {
-    text = htmlToMarkdown(text);
+    text = stringIsHtml(text) ? htmlToMarkdown(text) : text;
   }
 
   // Return existing text and HTML representations, unamended
@@ -154,9 +155,12 @@ export const getContentProperty = (properties) => {
     return { html: markdownToHtml(text), text };
   }
 
-  // Return property with text and HTML representations
-  text = text || htmlToMarkdown(content);
-  html = markdownToHtml(content);
+  // If no `text` or `html` properties, derive from given `content` string
+  if (typeof content === "string") {
+    text = stringIsHtml(content) ? htmlToMarkdown(content) : content;
+    html = stringIsHtml(content) ? content : markdownToHtml(content);
+  }
+
   return { html, text };
 };
 

--- a/packages/endpoint-micropub/lib/markdown.js
+++ b/packages/endpoint-micropub/lib/markdown.js
@@ -23,12 +23,12 @@ export const markdownToHtml = (string) => {
 };
 
 /**
- * Convert text to Markdown
+ * Convert HTML to Markdown
  *
  * @param {string} string - String (may be HTML or Markdown)
  * @returns {string} Markdown
  */
-export const textToMarkdown = (string) => {
+export const htmlToMarkdown = (string) => {
   // Normalise text as HTML before converting to Markdown
   string = markdownToHtml(string);
 

--- a/packages/endpoint-micropub/lib/markdown.js
+++ b/packages/endpoint-micropub/lib/markdown.js
@@ -45,7 +45,7 @@ export const htmlToMarkdown = (string) => {
    *
    * @param {string} string - String
    * @returns {string} String
-   * @see {@link: https://github.com/mixmark-io/turndown#escaping-markdown-characters}
+   * @see {@link https://github.com/mixmark-io/turndown#escaping-markdown-characters}
    */
   turndownService.escape = (string) => string;
 

--- a/packages/endpoint-micropub/lib/markdown.js
+++ b/packages/endpoint-micropub/lib/markdown.js
@@ -11,7 +11,6 @@ export const markdownToHtml = (string) => {
   const options = {
     html: true,
     breaks: true,
-    linkify: true,
     typographer: true,
   };
 

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -174,6 +174,14 @@ export const renderPath = async (path, properties, publication) => {
 };
 
 /**
+ * Check if string is HTML
+ *
+ * @param {string} string - String
+ * @returns {boolean} String is HTML
+ */
+export const stringIsHtml = (string) => /<\/?[a-z][\s\S]*>/i.test(string);
+
+/**
  * Substitute variables enclosed in { } braces with data from object
  *
  * @param {string} string - String to parse

--- a/packages/endpoint-micropub/tests/unit/jf2.js
+++ b/packages/endpoint-micropub/tests/unit/jf2.js
@@ -132,37 +132,25 @@ test("Gets normalised audio property", (t) => {
 
 test("Gets text and HTML values from `content` property", (t) => {
   const properties = JSON.parse(
-    getFixture("jf2/note-content-provided-html-text.jf2")
+    getFixture("jf2/article-content-provided-html-text.jf2")
   );
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: "<blockquote><p>I ate a <i>cheese</i> sandwich, which &gt; 10.</p></blockquote>",
-    text: "I ate a cheese sandwich, which was > 10.",
+    html: '<blockquote><p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>',
+    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
 });
 
 test("Gets mixed text and HTML values from `content` property", (t) => {
   const properties = JSON.parse(
-    getFixture("jf2/note-content-provided-html-text-mixed.jf2")
+    getFixture("jf2/article-content-provided-html-text-mixed.jf2")
   );
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>",
-    text: "> I ate a *cheese* sandwich, which was > 10.",
-  });
-});
-
-test("Gets HTML from `content` property and adds text value", (t) => {
-  const properties = JSON.parse(
-    getFixture("jf2/note-content-provided-html.jf2")
-  );
-  const result = getContentProperty(properties);
-
-  t.deepEqual(result, {
-    html: "<blockquote><p>I ate a <i>cheese</i> sandwich, which was &gt; 10.</p></blockquote>",
-    text: "> I ate a *cheese* sandwich, which was > 10.",
+    html: '<blockquote><p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>',
+    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from [https://cafe.example](https://cafe.example), which was > 10.\n\n– Me, then.",
   });
 });
 
@@ -173,22 +161,32 @@ test("Gets content from `content.text` property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: `<blockquote>
-<p>I ate a <em>cheese</em> sandwich, which was &gt; 10.</p>
-</blockquote>`,
-    text: "> I ate a *cheese* sandwich, which was > 10.",
+    html: `<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>`,
+    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
 });
 
-test("Gets content from `content` property", (t) => {
-  const properties = JSON.parse(getFixture("jf2/article-content-provided.jf2"));
+test("Gets HTML from `content` property and adds text value", (t) => {
+  const properties = JSON.parse(
+    getFixture("jf2/article-content-provided-as-html.jf2")
+  );
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: `<blockquote>
-<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich, which was &gt; 10.</p>
-</blockquote>`,
-    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was > 10.",
+    html: '<blockquote><p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>',
+    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from [https://cafe.example](https://cafe.example), which was > 10.\n\n– Me, then.",
+  });
+});
+
+test("Gets text content from `content` and adds HTML property", (t) => {
+  const properties = JSON.parse(
+    getFixture("jf2/article-content-provided-as-text.jf2")
+  );
+  const result = getContentProperty(properties);
+
+  t.deepEqual(result, {
+    html: '<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>',
+    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
 });
 
@@ -314,7 +312,9 @@ test("Derives slug, ignoring empty `mp-slug` property", (t) => {
 });
 
 test("Derives slug from `name` property", (t) => {
-  const properties = JSON.parse(getFixture("jf2/article-content-provided.jf2"));
+  const properties = JSON.parse(
+    getFixture("jf2/article-content-provided-text.jf2")
+  );
   const result = getSlugProperty(properties, "-");
 
   t.is(result, "what-i-had-for-lunch");
@@ -443,17 +443,17 @@ test("Doesn’t add unavailable syndication target", (t) => {
 });
 
 test("Normalises JF2 (few properties)", (t) => {
-  const properties = JSON.parse(getFixture("jf2/article-content-provided.jf2"));
+  const properties = JSON.parse(
+    getFixture("jf2/article-content-provided-as-text.jf2")
+  );
   const result = normaliseProperties(t.context.publication, properties);
 
   t.is(result.type, "entry");
   t.is(result.name, "What I had for lunch");
   t.is(result["mp-slug"], "what-i-had-for-lunch");
   t.deepEqual(result.content, {
-    html: `<blockquote>
-<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich, which was &gt; 10.</p>
-</blockquote>`,
-    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was > 10.",
+    html: '<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>',
+    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
   t.falsy(result.audio);
   t.falsy(result.photo);

--- a/packages/endpoint-micropub/tests/unit/jf2.js
+++ b/packages/endpoint-micropub/tests/unit/jf2.js
@@ -161,7 +161,7 @@ test("Gets content from `content.text` property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: `<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>`,
+    html: `<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>`,
     text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
 });
@@ -185,7 +185,7 @@ test("Gets text content from `content` and adds HTML property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: '<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>',
+    html: '<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>',
     text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
 });
@@ -452,7 +452,7 @@ test("Normalises JF2 (few properties)", (t) => {
   t.is(result.name, "What I had for lunch");
   t.is(result["mp-slug"], "what-i-had-for-lunch");
   t.deepEqual(result.content, {
-    html: '<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>',
+    html: '<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>',
     text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
   t.falsy(result.audio);

--- a/packages/endpoint-micropub/tests/unit/markdown.js
+++ b/packages/endpoint-micropub/tests/unit/markdown.js
@@ -3,14 +3,44 @@ import { markdownToHtml, htmlToMarkdown } from "../../lib/markdown.js";
 
 test("Converts Markdown to HTML", (t) => {
   t.is(
-    markdownToHtml("This is a **[link](#)**"),
-    '<p>This is a <strong><a href="#">link</a></strong></p>'
+    markdownToHtml("This is **strong**"),
+    "<p>This is <strong>strong</strong></p>"
+  );
+  t.is(
+    markdownToHtml("[Linked text](https://website.example)"),
+    '<p><a href="https://website.example">Linked text</a></p>'
+  );
+  t.is(
+    markdownToHtml("[https://website.example](https://website.example)"),
+    '<p><a href="https://website.example">https://website.example</a></p>'
+  );
+  t.is(
+    markdownToHtml("<https://website.example>"),
+    '<p><a href="https://website.example">https://website.example</a></p>'
+  );
+  t.is(
+    markdownToHtml("https://website.example"),
+    "<p>https://website.example</p>"
   );
 });
 
 test("Converts HTML to Markdown", (t) => {
   t.is(
-    htmlToMarkdown('<p>This is a <strong><a href="#">link</a></strong></p>'),
-    "This is a **[link](#)**"
+    htmlToMarkdown("<p>This is a <strong>strong</strong></p>"),
+    "This is a **strong**"
+  );
+  t.is(
+    htmlToMarkdown('<p><a href="https://website.example">Linked text</a></p>'),
+    "[Linked text](https://website.example)"
+  );
+  t.is(
+    htmlToMarkdown(
+      '<p><a href="https://website.example">https://website.example</a></p>'
+    ),
+    "[https://website.example](https://website.example)"
+  );
+  t.is(
+    htmlToMarkdown("<p>https://website.example</p>"),
+    "https://website.example"
   );
 });

--- a/packages/endpoint-micropub/tests/unit/markdown.js
+++ b/packages/endpoint-micropub/tests/unit/markdown.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import { markdownToHtml, textToMarkdown } from "../../lib/markdown.js";
+import { markdownToHtml, htmlToMarkdown } from "../../lib/markdown.js";
 
 test("Converts Markdown to HTML", (t) => {
   t.is(
@@ -8,18 +8,9 @@ test("Converts Markdown to HTML", (t) => {
   );
 });
 
-test("Converts text to Markdown", (t) => {
-  // HTML to Markdown
+test("Converts HTML to Markdown", (t) => {
   t.is(
-    textToMarkdown('<p>This is a <strong><a href="#">link</a></strong></p>'),
+    htmlToMarkdown('<p>This is a <strong><a href="#">link</a></strong></p>'),
     "This is a **[link](#)**"
-  );
-
-  // Markdown to Markdown
-  t.is(
-    textToMarkdown("**First** paragraph\n\n**Second** paragraph"),
-    `**First** paragraph
-
-**Second** paragraph`
   );
 });

--- a/packages/endpoint-micropub/tests/unit/utils.js
+++ b/packages/endpoint-micropub/tests/unit/utils.js
@@ -9,6 +9,7 @@ import {
   relativeMediaPath,
   renderPath,
   slugifyString,
+  stringIsHtml,
   supplant,
   toArray,
 } from "../../lib/utils.js";
@@ -100,6 +101,11 @@ test("Slugifies a string", (t) => {
   t.is(slugifyString("Foo bar baz", "_"), "foo_bar_baz");
   t.is(slugifyString("McLaren's Lando Norris"), "mclarens-lando-norris");
   t.is(slugifyString("McLaren’s Lando Norris"), "mclarens-lando-norris");
+});
+
+test("Checks if string is HTML", (t) => {
+  t.true(stringIsHtml('<p>The <a href="#">cheese</a> was &gt; 10.</p>'));
+  t.false(stringIsHtml("> The [cheese](#) was > 10."));
 });
 
 test("Substitutes variables enclosed in { } braces with data from object", (t) => {


### PR DESCRIPTION
## Background

Content can arrive in many forms. Ideally it would arrived as an object with `content.html` and `content.text` representations. Sometimes, only one of these values will be provided, or a string is provided in `content`, which could be either text or HTML.

Indiekit aims attempts to normalise any incoming content request, and generate text and HTML representations:

* Text can be derived from HTML, using Turndown.
* HTML can be derived from text, using markdown-it.

## Previous approach

As part of this normalisation, any value for `context.text` (or a `content` string), was parsed as HTML and converted back to Markdown. This change was made in #564 (we needed to parse markdown as HTML and back into Markdown to prevent issues with line breaks). But boy oh boy, this was real funky. 🕺

However, as @sentience [pointed out](https://github.com/getindiekit/indiekit/issues/570#issuecomment-1371536135):

>  I don't expect [Indiekit] to modify the Markdown I give it

## New approach

1. Don’t change any incoming plain text. To catch the case of HTML being sent in `content.text` or, more likely, HTML being sent in `content`, run a little regex to see if the context contains any tags. If it does, only then run it though `htmlToMarkdown()`.
2. Don’t ‘linkify’ any bare URLs in entered/incoming `content.text`. This means linkifying remains the preserve of the publication’s own Markdown renderer, rather than be dictated by Indiekit, whose behaviour here can’t be controlled[^1]. It also prevents weird Markdown being generated like `[https://website.example](https://website.example)`.

(Fixes #570)

[^1]: URLs can be explicitly linked using Markdown’s angle bracket syntax, i.e.: `<https://website.example>`