### PR TITLE
Add option for character limit to Mastodon syndicator

### DIFF
--- a/packages/syndicator-mastodon/README.md
+++ b/packages/syndicator-mastodon/README.md
@@ -28,10 +28,11 @@ Add `@indiekit/syndicator-mastodon` to your list of plug-ins, specifying options
 
 ## Options
 
-| Option        | Type      | Description                                                                                                   |
-| :------------ | :-------- | :------------------------------------------------------------------------------------------------------------ |
-| `accessToken` | `string`  | Your Mastodon access token. _Required_, defaults to `process.env.MASTODON_ACCESS_TOKEN`.                      |
-| `url`         | `string`  | Your Mastodon server, i.e. `https://mastodon.social`. _Required_.                                             |
-| `user`        | `string`  | Your Mastodon username (without the `@`). _Required_.                                                         |
-| `checked`     | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`. |
-| `forced`      | `boolean` | Ignore the presence or value of `checked` and always syndicate. _Optional_.                                   |
+| Option           | Type      | Description                                                                                                   |
+| :--------------- | :-------- | :------------------------------------------------------------------------------------------------------------ |
+| `accessToken`    | `string`  | Your Mastodon access token. _Required_, defaults to `process.env.MASTODON_ACCESS_TOKEN`.                      |
+| `url`            | `string`  | Your Mastodon server, i.e. `https://mastodon.social`. _Required_.                                             |
+| `user`           | `string`  | Your Mastodon username (without the `@`). _Required_.                                                         |
+| `characterLimit` | `number`  | Maximum number of characters before a post is truncated. _Optional_, defaults to `500`.                       |
+| `checked`        | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`. |
+| `forced`         | `boolean` | Ignore the presence or value of `checked` and always syndicate. _Optional_.                                   |

--- a/packages/syndicator-mastodon/index.js
+++ b/packages/syndicator-mastodon/index.js
@@ -5,6 +5,7 @@ import { mastodon } from "./lib/mastodon.js";
 
 const defaults = {
   accessToken: process.env.MASTODON_ACCESS_TOKEN,
+  characterLimit: 500,
   checked: false,
 };
 
@@ -65,8 +66,9 @@ export default class MastodonSyndicator {
   async syndicate(properties, publication) {
     try {
       return await mastodon({
-        url: `${this.#url.protocol}//${this.#url.hostname}`,
         accessToken: this.options.accessToken,
+        characterLimit: this.options.characterLimit,
+        serverUrl: `${this.#url.protocol}//${this.#url.hostname}`,
       }).post(properties, publication);
     } catch (error) {
       throw new IndiekitError(error.message, {

--- a/packages/syndicator-mastodon/lib/mastodon.js
+++ b/packages/syndicator-mastodon/lib/mastodon.js
@@ -8,10 +8,10 @@ import {
   isTootUrl,
 } from "./utils.js";
 
-export const mastodon = (options) => ({
+export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
   client() {
     const generator = megalodon.default;
-    return generator("mastodon", options.url, options.accessToken);
+    return generator("mastodon", serverUrl, accessToken);
   },
 
   /**
@@ -106,16 +106,17 @@ export const mastodon = (options) => ({
 
     if (properties["repost-of"]) {
       // Syndicate repost of Mastodon URL with content as a reblog
-      if (
-        isTootUrl(properties["repost-of"], options.url) &&
-        properties.content
-      ) {
-        const status = createStatus(properties, mediaIds);
+      if (isTootUrl(properties["repost-of"], serverUrl) && properties.content) {
+        const status = createStatus(properties, {
+          characterLimit,
+          mediaIds,
+          serverUrl,
+        });
         return this.postStatus(status);
       }
 
       // Syndicate repost of Mastodon URL as a reblog
-      if (isTootUrl(properties["repost-of"], options.url)) {
+      if (isTootUrl(properties["repost-of"], serverUrl)) {
         return this.postReblog(properties["repost-of"]);
       }
 
@@ -125,7 +126,7 @@ export const mastodon = (options) => ({
 
     if (properties["like-of"]) {
       // Syndicate like of Mastodon URL as a like
-      if (isTootUrl(properties["like-of"], options.url)) {
+      if (isTootUrl(properties["like-of"], serverUrl)) {
         return this.postFavourite(properties["like-of"]);
       }
 
@@ -133,7 +134,11 @@ export const mastodon = (options) => ({
       return false;
     }
 
-    const status = createStatus(properties, options.url, mediaIds);
+    const status = createStatus(properties, {
+      characterLimit,
+      mediaIds,
+      serverUrl,
+    });
     if (status) {
       return this.postStatus(status);
     }

--- a/packages/syndicator-mastodon/lib/utils.js
+++ b/packages/syndicator-mastodon/lib/utils.js
@@ -8,11 +8,14 @@ import { htmlToText } from "html-to-text";
  * Get status parameters from given JF2 properties
  *
  * @param {object} properties - A JF2 properties object
- * @param {string} serverUrl - Server URL, i.e. https://mastodon.social
- * @param {Array} mediaIds - Mastodon media IDs
+ * @param {object} [options={}] - Options
+ * @param {number} options.characterLimit - Character limit
+ * @param {Array} options.mediaIds - Mastodon media IDs
+ * @param {string} options.serverUrl - Server URL, i.e. https://mastodon.social
  * @returns {object} Status parameters
  */
-export const createStatus = (properties, serverUrl, mediaIds) => {
+export const createStatus = (properties, options = {}) => {
+  const { characterLimit, mediaIds, serverUrl } = options;
   const parameters = {};
 
   let status;
@@ -40,7 +43,7 @@ export const createStatus = (properties, serverUrl, mediaIds) => {
       properties.url,
       false, // https://indieweb.org/permashortlink
       false, // https://indieweb.org/permashortcitation
-      500
+      characterLimit
     );
   }
 

--- a/packages/syndicator-mastodon/tests/unit/mastodon.js
+++ b/packages/syndicator-mastodon/tests/unit/mastodon.js
@@ -23,8 +23,7 @@ test.beforeEach((t) => {
     statusId: "1234567890987654321",
     options: {
       accessToken: "0123456789abcdefghijklmno",
-      url: "https://mastodon.example",
-      user: "username",
+      serverUrl: "https://mastodon.example",
     },
     publication: {
       me: "https://website.example",
@@ -33,7 +32,7 @@ test.beforeEach((t) => {
 });
 
 test("Posts a favourite", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post(`/api/v1/statuses/${t.context.statusId}/favourite`)
     .reply(200, t.context.apiResponse);
 
@@ -45,7 +44,7 @@ test("Posts a favourite", async (t) => {
 });
 
 test("Throws error posting a favourite", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post(`/api/v1/statuses/${t.context.statusId}/favourite`)
     .reply(404, { message: "Not found" });
 
@@ -58,7 +57,7 @@ test("Throws error posting a favourite", async (t) => {
 });
 
 test("Posts a reblog", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post(`/api/v1/statuses/${t.context.statusId}/reblog`)
     .reply(200, t.context.apiResponse);
 
@@ -70,7 +69,7 @@ test("Posts a reblog", async (t) => {
 });
 
 test("Throws error posting a reblog", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post(`/api/v1/statuses/${t.context.statusId}/reblog`)
     .reply(404, { message: "Not found" });
 
@@ -83,28 +82,22 @@ test("Throws error posting a reblog", async (t) => {
 });
 
 test("Posts a status", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post("/api/v1/statuses")
     .reply(200, t.context.apiResponse);
 
-  const result = await mastodon(t.context.options).postStatus(
-    t.context.status,
-    t.context.options.url
-  );
+  const result = await mastodon(t.context.options).postStatus(t.context.status);
 
   t.is(result, "https://mastodon.example/@username/1234567890987654321");
 });
 
 test("Throws error posting a status", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post("/api/v1/statuses")
     .reply(404, { message: "Not found" });
 
   await t.throwsAsync(
-    mastodon(t.context.options).postStatus(
-      t.context.status,
-      t.context.options.url
-    ),
+    mastodon(t.context.options).postStatus(t.context.status),
     {
       message: "Request failed with status code 404",
     }
@@ -130,10 +123,10 @@ test.failing("Uploads media and returns a media id", async (t) => {
   nock("https://website.example")
     .get("/image.jpg")
     .reply(200, { body: getFixture("file-types/photo.jpg", false) });
-  nock(t.context.options.url).post("/api/v1/media").reply(200, {
+  nock(t.context.options.serverUrl).post("/api/v1/media").reply(200, {
     id: "1234567890987654321",
   });
-  nock(t.context.options.url).post("/api/v1/media").reply(200, {});
+  nock(t.context.options.serverUrl).post("/api/v1/media").reply(200, {});
 
   const result = await mastodon(t.context.options).uploadMedia(
     t.context.media,
@@ -148,7 +141,7 @@ test.failing("Throws error uploading media", async (t) => {
   nock("https://website.example")
     .get("/image.jpg")
     .reply(200, { body: getFixture("file-types/photo.jpg", false) });
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post("/api/v1/media")
     .reply(404, { message: "Not found" });
 
@@ -173,7 +166,7 @@ test("Returns false passing an object to media upload function", async (t) => {
 });
 
 test("Posts a favourite of a toot to Mastodon", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post(`/api/v1/statuses/${t.context.statusId}/favourite`)
     .reply(200, t.context.apiResponse);
 
@@ -199,7 +192,7 @@ test("Doesn’t post a favourite of a URL to Mastodon", async (t) => {
 });
 
 test("Posts a repost of a toot to Mastodon", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post(`/api/v1/statuses/${t.context.statusId}/reblog`)
     .reply(200, t.context.apiResponse);
 
@@ -225,7 +218,7 @@ test("Doesn’t post a repost of a URL to Mastodon", async (t) => {
 });
 
 test("Posts a quote status to Mastodon", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post("/api/v1/statuses")
     .reply(200, t.context.apiResponse);
 
@@ -244,7 +237,7 @@ test("Posts a quote status to Mastodon", async (t) => {
 });
 
 test("Posts a status to Mastodon", async (t) => {
-  nock(t.context.options.url)
+  nock(t.context.options.serverUrl)
     .post("/api/v1/statuses")
     .reply(200, t.context.apiResponse);
 

--- a/packages/syndicator-mastodon/tests/unit/utils.js
+++ b/packages/syndicator-mastodon/tests/unit/utils.js
@@ -19,7 +19,9 @@ test.beforeEach((t) => {
 test("Creates a status with article post name and URL", (t) => {
   const result = createStatus(
     JSON.parse(getFixture("jf2/article-content-provided-html-text.jf2")),
-    "https://mastodon.example"
+    {
+      serverUrl: "https://mastodon.example",
+    }
   );
 
   t.is(result.status, "What I had for lunch https://foo.bar/lunchtime");
@@ -28,7 +30,9 @@ test("Creates a status with article post name and URL", (t) => {
 test("Creates a status with HTML content", (t) => {
   const result = createStatus(
     JSON.parse(getFixture("jf2/note-content-provided-html.jf2")),
-    "https://mastodon.example"
+    {
+      serverUrl: "https://mastodon.example",
+    }
   );
 
   t.is(result.status, "> I ate a cheese sandwich, which was > 10.");
@@ -37,7 +41,9 @@ test("Creates a status with HTML content", (t) => {
 test("Creates a status with HTML content and appends last link", (t) => {
   const result = createStatus(
     JSON.parse(getFixture("jf2/note-content-provided-html-with-link.jf2")),
-    "https://mastodon.example"
+    {
+      serverUrl: "https://mastodon.example",
+    }
   );
 
   t.is(
@@ -51,7 +57,9 @@ test("Creates a status with HTML content and doesn’t append Mastodon link", (t
     JSON.parse(
       getFixture("jf2/note-content-provided-html-with-mastodon-link.jf2")
     ),
-    "https://mastodon.example"
+    {
+      serverUrl: "https://mastodon.example",
+    }
   );
 
   t.is(result.status, "I ate @cheese’s sandwich, which was nice.");
@@ -60,7 +68,9 @@ test("Creates a status with HTML content and doesn’t append Mastodon link", (t
 test("Creates a reblog with status URL and post content", (t) => {
   const result = createStatus(
     JSON.parse(getFixture("jf2/repost-mastodon.jf2")),
-    "https://mastodon.example"
+    {
+      serverUrl: "https://mastodon.example",
+    }
   );
 
   t.is(
@@ -72,7 +82,9 @@ test("Creates a reblog with status URL and post content", (t) => {
 test("Adds link to status post is in reply to", (t) => {
   const result = createStatus(
     JSON.parse(getFixture("jf2/reply-mastodon.jf2")),
-    "https://mastodon.example"
+    {
+      serverUrl: "https://mastodon.example",
+    }
   );
 
   t.is(result.status, "I ate a cheese sandwich too!");
@@ -82,10 +94,9 @@ test("Adds link to status post is in reply to", (t) => {
 test("Throws creating a status if post is off-service reply", (t) => {
   t.throws(
     () => {
-      createStatus(
-        JSON.parse(getFixture("jf2/reply-twitter.jf2")),
-        "https://mastodon.example"
-      );
+      createStatus(JSON.parse(getFixture("jf2/reply-twitter.jf2")), {
+        serverUrl: "https://mastodon.example",
+      });
     },
     {
       instanceOf: IndiekitError,
@@ -101,8 +112,10 @@ test("Creates a status with a photo", (t) => {
         html: "<p>Here’s the cheese sandwich I ate.</p>",
       },
     },
-    "https://mastodon.example",
-    ["1", "2", "3", "4"]
+    {
+      mediaIds: ["1", "2", "3", "4"],
+      serverUrl: "https://mastodon.example",
+    }
   );
 
   t.is(result.status, "Here’s the cheese sandwich I ate.");


### PR DESCRIPTION
This PR adds a `characterLimit` option to the Mastodon syndicator, defaulting to `500`.

Also:

* Renames a `url` variable to be consistent with the use of `serverUrl` throughout other parts of the plug-in
* Refactors `createStatus()` to pass properties and an options object (looks like incorrect values were passed to this method for reposts)

Fixes #572.