### PR TITLE
Micropub endpoint: Try to be less clever deriving `text` and `html` JF2 values

### DIFF
--- a/helpers/fixtures/jf2/article-content-provided-as-html.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-as-html.jf2
@@ -1,5 +1,0 @@
-{
-  "type": "entry",
-  "name": "What I had for lunch",
-  "content": "<blockquote><p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>"
-}

--- a/helpers/fixtures/jf2/article-content-provided-as-text.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-as-text.jf2
@@ -1,5 +1,0 @@
-{
-  "type": "entry",
-  "name": "What I had for lunch",
-  "content": "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
-}

--- a/helpers/fixtures/jf2/article-content-provided-html-text-mixed.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-html-text-mixed.jf2
@@ -1,8 +1,0 @@
-{
-  "type": "entry",
-  "name": "What I had for lunch",
-  "content": {
-    "html": "<blockquote><p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>",
-    "text": "<blockquote><p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>"
-  }
-}

--- a/helpers/fixtures/jf2/article-content-provided-html-text.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-html-text.jf2
@@ -2,8 +2,8 @@
   "type": "entry",
   "name": "What I had for lunch",
   "content": {
-    "html": "<blockquote><p>I ate a <a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>",
-    "text": "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
+    "html": "<blockquote><p>I <del>ate</del><ins>had</ins> a <cite><a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a></cite> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>",
+    "text": "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
   },
   "url": "https://foo.bar/lunchtime"
 }

--- a/helpers/fixtures/jf2/article-content-provided-html.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-html.jf2
@@ -1,0 +1,8 @@
+{
+  "type": "entry",
+  "name": "What I had for lunch",
+  "content": {
+    "html": "<blockquote><p>I <del>ate</del><ins>had</ins> a <cite><a href=\"https://en.wikipedia.org/wiki/Cheese\">cheese</a></cite> sandwich from <a href=\"https://cafe.example\">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>"
+  },
+  "url": "https://foo.bar/lunchtime"
+}

--- a/helpers/fixtures/jf2/article-content-provided-text.jf2
+++ b/helpers/fixtures/jf2/article-content-provided-text.jf2
@@ -2,6 +2,6 @@
   "type": "entry",
   "name": "What I had for lunch",
   "content": {
-    "text": "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
+    "text": "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
   }
 }

--- a/helpers/fixtures/jf2/article-content-provided.jf2
+++ b/helpers/fixtures/jf2/article-content-provided.jf2
@@ -1,0 +1,5 @@
+{
+  "type": "entry",
+  "name": "What I had for lunch",
+  "content": "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
+}

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -7,7 +7,6 @@ import {
   relativeMediaPath,
   randomString,
   slugifyString,
-  stringIsHtml,
   toArray,
 } from "./utils.js";
 
@@ -126,19 +125,18 @@ export const getAudioProperty = (properties, me) => {
 };
 
 /**
- * Get content property (HTML, else object value, else property value)
+ * Get content property.
+ *
+ * JF2 allows for the provision of both plaintext and HTML representations.
+ * Use existing values, or add HTML representation if only plaintext provided.
  *
  * @param {object} properties - JF2 properties
  * @returns {Array} `content` property
+ * @see {@link https://www.w3.org/TR/jf2/#html-content}
  */
 export const getContentProperty = (properties) => {
   const { content } = properties;
   let { html, text } = content;
-
-  // Ensure any existing text property is in fact Markdown
-  if (text) {
-    text = stringIsHtml(text) ? htmlToMarkdown(text) : text;
-  }
 
   // Return existing text and HTML representations, unamended
   if (html && text) {
@@ -155,10 +153,10 @@ export const getContentProperty = (properties) => {
     return { html: markdownToHtml(text), text };
   }
 
-  // If no `text` or `html` properties, derive from given `content` string
+  // If content is a string, add `html` and move plaintext to `text.
   if (typeof content === "string") {
-    text = stringIsHtml(content) ? htmlToMarkdown(content) : content;
-    html = stringIsHtml(content) ? content : markdownToHtml(content);
+    text = content;
+    html = markdownToHtml(content);
   }
 
   return { html, text };

--- a/packages/endpoint-micropub/lib/markdown.js
+++ b/packages/endpoint-micropub/lib/markdown.js
@@ -48,6 +48,11 @@ export const htmlToMarkdown = (string) => {
    */
   turndownService.escape = (string) => string;
 
+  /**
+   * List of inline elements to keep in Markdown
+   */
+  turndownService.keep(["cite", "del", "ins"]);
+
   const markdown = turndownService.turndown(string);
 
   return markdown;

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -174,14 +174,6 @@ export const renderPath = async (path, properties, publication) => {
 };
 
 /**
- * Check if string is HTML
- *
- * @param {string} string - String
- * @returns {boolean} String is HTML
- */
-export const stringIsHtml = (string) => /<\/?[a-z][\s\S]*>/i.test(string);
-
-/**
  * Substitute variables enclosed in { } braces with data from object
  *
  * @param {string} string - String to parse

--- a/packages/endpoint-micropub/tests/unit/jf2.js
+++ b/packages/endpoint-micropub/tests/unit/jf2.js
@@ -137,20 +137,20 @@ test("Gets text and HTML values from `content` property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: '<blockquote><p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>',
-    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
+    html: `<blockquote><p>I <del>ate</del><ins>had</ins> a <cite><a href="https://en.wikipedia.org/wiki/Cheese">cheese</a></cite> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>`,
+    text: "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
 });
 
-test("Gets mixed text and HTML values from `content` property", (t) => {
+test("Gets content from `content.html` property", (t) => {
   const properties = JSON.parse(
-    getFixture("jf2/article-content-provided-html-text-mixed.jf2")
+    getFixture("jf2/article-content-provided-html.jf2")
   );
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: '<blockquote><p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>',
-    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from [https://cafe.example](https://cafe.example), which was > 10.\n\n– Me, then.",
+    html: `<blockquote><p>I <del>ate</del><ins>had</ins> a <cite><a href="https://en.wikipedia.org/wiki/Cheese">cheese</a></cite> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>`,
+    text: `> I <del>ate</del><ins>had</ins> a <cite><a href="https://en.wikipedia.org/wiki/Cheese">cheese</a></cite> sandwich from [https://cafe.example](https://cafe.example), which was > 10.\n\n– Me, then.`,
   });
 });
 
@@ -161,32 +161,18 @@ test("Gets content from `content.text` property", (t) => {
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: `<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>`,
-    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
-  });
-});
-
-test("Gets HTML from `content` property and adds text value", (t) => {
-  const properties = JSON.parse(
-    getFixture("jf2/article-content-provided-as-html.jf2")
-  );
-  const result = getContentProperty(properties);
-
-  t.deepEqual(result, {
-    html: '<blockquote><p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from <a href="https://cafe.example">https://cafe.example</a>, which was &gt; 10.</p></blockquote><p>– Me, then.</p>',
-    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from [https://cafe.example](https://cafe.example), which was > 10.\n\n– Me, then.",
+    html: `<blockquote>\n<p>I <del>ate</del><ins>had</ins> a <cite><a href="https://en.wikipedia.org/wiki/Cheese">cheese</a></cite> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>`,
+    text: "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
 });
 
 test("Gets text content from `content` and adds HTML property", (t) => {
-  const properties = JSON.parse(
-    getFixture("jf2/article-content-provided-as-text.jf2")
-  );
+  const properties = JSON.parse(getFixture("jf2/article-content-provided.jf2"));
   const result = getContentProperty(properties);
 
   t.deepEqual(result, {
-    html: '<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>',
-    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
+    html: `<blockquote>\n<p>I <del>ate</del><ins>had</ins> a <cite><a href="https://en.wikipedia.org/wiki/Cheese">cheese</a></cite> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>`,
+    text: "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
 });
 
@@ -443,17 +429,15 @@ test("Doesn’t add unavailable syndication target", (t) => {
 });
 
 test("Normalises JF2 (few properties)", (t) => {
-  const properties = JSON.parse(
-    getFixture("jf2/article-content-provided-as-text.jf2")
-  );
+  const properties = JSON.parse(getFixture("jf2/article-content-provided.jf2"));
   const result = normaliseProperties(t.context.publication, properties);
 
   t.is(result.type, "entry");
   t.is(result.name, "What I had for lunch");
   t.is(result["mp-slug"], "what-i-had-for-lunch");
   t.deepEqual(result.content, {
-    html: '<blockquote>\n<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>',
-    text: "> I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
+    html: `<blockquote>\n<p>I <del>ate</del><ins>had</ins> a <cite><a href="https://en.wikipedia.org/wiki/Cheese">cheese</a></cite> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>`,
+    text: "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
   });
   t.falsy(result.audio);
   t.falsy(result.photo);
@@ -467,7 +451,7 @@ test("Normalises JF2 (all properties)", (t) => {
   t.is(result.type, "entry");
   t.is(result.name, "What I had for lunch");
   t.deepEqual(result.content, {
-    html: '<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich, which was nice.</p>',
+    html: `<p>I ate a <a href="https://en.wikipedia.org/wiki/Cheese">cheese</a> sandwich, which was nice.</p>`,
     text: "I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.",
   });
   t.deepEqual(result.audio, [{ url: "https://website.example/audio.mp3" }]);

--- a/packages/endpoint-micropub/tests/unit/utils.js
+++ b/packages/endpoint-micropub/tests/unit/utils.js
@@ -9,7 +9,6 @@ import {
   relativeMediaPath,
   renderPath,
   slugifyString,
-  stringIsHtml,
   supplant,
   toArray,
 } from "../../lib/utils.js";
@@ -101,11 +100,6 @@ test("Slugifies a string", (t) => {
   t.is(slugifyString("Foo bar baz", "_"), "foo_bar_baz");
   t.is(slugifyString("McLaren's Lando Norris"), "mclarens-lando-norris");
   t.is(slugifyString("McLaren’s Lando Norris"), "mclarens-lando-norris");
-});
-
-test("Checks if string is HTML", (t) => {
-  t.true(stringIsHtml('<p>The <a href="#">cheese</a> was &gt; 10.</p>'));
-  t.false(stringIsHtml("> The [cheese](#) was > 10."));
 });
 
 test("Substitutes variables enclosed in { } braces with data from object", (t) => {


### PR DESCRIPTION
Previously, this endpoint accounted for the following cases for an incoming JF2 `content` property: 

* HTML being provided for `content.text`
* HTML being provided for `content`

This may be a case of over engineering:

1. If plaintext contains HTML, this should be considered intentional. Markdown can include inline HTML elements which don’t have equivalents in Markdown (i.e. `<cite>`).

2. If plaintext is entirely HTML, that’s an issue with the Micropub client: it should send content using the correct Microformats representation (which is also `content.html`), and therefore an issue should be filled against that client.

This PR:
* removes any attempt to detect HTML in plaintext and convert it to Markdown
* adds missing test for deriving `content.text` from sole `content.html` value
* adds support for keeping `<cite>`, `<ins>` and `<del>` in any HTML converted to text
* adds inline `<cite>`, `<ins>` and `<del>` HTML elements to test fixtures

cc @sentience 