### PR TITLE
Don’t include `mp-syndicate-to` in post file

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -68,8 +68,6 @@ Once an application knows your server’s Micropub endpoint and has permission t
     ```yaml
     ---
     date: 2021-02-15T21:38:25.343Z
-    mp-syndicate-to:
-    - https://mastodon.example/@username
     ---
     Hello world
     ```
@@ -80,7 +78,7 @@ Once an application knows your server’s Micropub endpoint and has permission t
 
 ## Sharing content with third-party websites (syndication)
 
-Note the `mp-syndicate-to` property in the above example. Indiekit can be configured to share posts on other social networks. This is called [syndication](concepts.md#syndication). Any syndication targets you have configured will appear under this property.
+Indiekit can be configured to share posts on other social networks, a process called [syndication](concepts.md#syndication).
 
 After publishing a post, pinging Indiekit’s syndication endpoint will check if any posts need syndicating.
 
@@ -107,7 +105,7 @@ After publishing a post, pinging Indiekit’s syndication endpoint will check if
     {
       "action": "update",
       "url": "https://website.example/notes/1",
-      "delete": "mp-syndicate"
+      "delete": "mp-syndicate-to"
       "replace": {
         "syndication": [
           "https://mastodon.example/@username/12345"
@@ -124,8 +122,6 @@ After publishing a post, pinging Indiekit’s syndication endpoint will check if
     + updated: 2021-02-15T21:40:15.131Z
     + syndication:
     + - https://mastodon.example/@username/12345
-    - mp-syndicate-to:
-    - - https://mastodon.example/@username
       ---
       Hello world
     ```

--- a/packages/preset-hugo/index.js
+++ b/packages/preset-hugo/index.js
@@ -249,9 +249,6 @@ export default class HugoPreset {
       ...(properties.postStatus === "draft" && { draft: true }),
       ...(properties.visibility && { visibility: properties.visibility }),
       ...(properties.syndication && { syndication: properties.syndication }),
-      ...(properties.mpSyndicateTo && {
-        mpSyndicateTo: properties.mpSyndicateTo,
-      }),
       ...(properties.references && { references: properties.references }),
     };
 

--- a/packages/preset-hugo/tests/index.js
+++ b/packages/preset-hugo/tests/index.js
@@ -144,8 +144,7 @@ test("Renders post template with JSON front matter", (t) => {
   "inReplyTo": "https://website.example",
   "draft": true,
   "visibility": "private",
-  "syndication": "https://website.example/post/12345",
-  "mpSyndicateTo": "https://social.example"
+  "syndication": "https://website.example/post/12345"
 }
 I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.
 `
@@ -174,7 +173,6 @@ inReplyTo = "https://website.example"
 draft = true
 visibility = "private"
 syndication = "https://website.example/post/12345"
-mpSyndicateTo = "https://social.example"
 
 [location]
 type = "geo"
@@ -242,7 +240,6 @@ inReplyTo: https://website.example
 draft: true
 visibility: private
 syndication: https://website.example/post/12345
-mpSyndicateTo: https://social.example
 ---
 I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.
 `

--- a/packages/preset-jekyll/index.js
+++ b/packages/preset-jekyll/index.js
@@ -175,9 +175,6 @@ export default class JekyllPreset {
       ...(properties["post-status"] === "draft" && { published: false }),
       ...(properties.visibility && { visibility: properties.visibility }),
       ...(properties.syndication && { syndication: properties.syndication }),
-      ...(properties["mp-syndicate-to"] && {
-        "mp-syndicate-to": properties["mp-syndicate-to"],
-      }),
       ...(properties.references && { references: properties.references }),
     };
     let frontMatter = YAML.stringify(properties, { lineWidth: 0 });

--- a/packages/preset-jekyll/tests/index.js
+++ b/packages/preset-jekyll/tests/index.js
@@ -125,7 +125,6 @@ in-reply-to: https://website.example
 published: false
 visibility: private
 syndication: https://website.example/post/12345
-mp-syndicate-to: https://social.example
 ---
 I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.
 `


### PR DESCRIPTION
Like `mp-slug` and `mp-photo-alt`, incoming properties prefixed with `mp-*` are directives for the server, and shouldn’t be published.

This PR prevents `mp-syndicate-to` being included in published post files, and updates the documentation that previously included an example of this value being shown in post files.