### PR TITLE
Better error reporting on frontend

### DIFF
--- a/helpers/frontend/views/frontend-components.njk
+++ b/helpers/frontend/views/frontend-components.njk
@@ -319,19 +319,22 @@
 <h2><code>notification</code></h2>
 
 {{ notification({
-  text: "Standard notification"
+  text: "Standard notification",
+  details: "Details"
 }) }}
 
 {{ notification({
   type: "error",
-  text: "Error notification"
+  text: "Error notification",
+  details: "Details"
 }) }}
 
 {{ notification({
   disableAutoFocus: true,
   href: "#",
   type: "success",
-  text: "Success notification"
+  text: "Success notification",
+  details: "Details"
 }) }}
 
 <h2><code>pagination</code></h2>

--- a/packages/endpoint-auth/lib/controllers/documentation.js
+++ b/packages/endpoint-auth/lib/controllers/documentation.js
@@ -7,6 +7,7 @@ export const documentationController = (error, request, response, next) => {
     response.render("auth", {
       title: response.locals.__("auth.guidance.title"),
       error: error.message,
+      error_details: error.stack,
     });
   } else if (request.accepts("json")) {
     return next(error);

--- a/packages/endpoint-files/lib/controllers/delete.js
+++ b/packages/endpoint-files/lib/controllers/delete.js
@@ -42,6 +42,7 @@ export const deleteController = {
         title: response.locals.__("files.delete.title"),
         parent: { text: fileName },
         error: error.message,
+        error_details: error.stack,
       });
     }
   },

--- a/packages/endpoint-files/lib/controllers/form.js
+++ b/packages/endpoint-files/lib/controllers/form.js
@@ -54,6 +54,7 @@ export const formController = {
       response.render("file-form", {
         title: response.locals.__("files.upload.title"),
         error: error.message,
+        error_details: error.stack,
       });
     }
   },

--- a/packages/endpoint-posts/lib/controllers/delete.js
+++ b/packages/endpoint-posts/lib/controllers/delete.js
@@ -45,6 +45,7 @@ export const deleteController = {
         title: response.locals.__(`posts.${action}.title`),
         parent: { text: postName },
         error: error.message,
+        error_details: error.stack,
       });
     }
   },

--- a/packages/endpoint-posts/lib/controllers/form.js
+++ b/packages/endpoint-posts/lib/controllers/form.js
@@ -92,6 +92,7 @@ export const formController = {
           postTypeName.toLowerCase()
         ),
         error: error.message,
+        error_details: error.stack,
       });
     }
   },

--- a/packages/endpoint-posts/tests/integration/500-post-create.js
+++ b/packages/endpoint-posts/tests/integration/500-post-create.js
@@ -23,7 +23,7 @@ test("Returns 500 error creating post", async (t) => {
   ).textContent;
 
   t.is(response.status, 500);
-  t.is(result, "Test store: Unauthorized");
+  t.regex(result, /\bTest store: Unauthorized\b/g);
 
   server.close(t);
 });

--- a/packages/endpoint-share/lib/controllers/share.js
+++ b/packages/endpoint-share/lib/controllers/share.js
@@ -69,6 +69,7 @@ export const shareController = {
         name,
         bookmarkOf,
         error: error.message,
+        error_details: error.stack,
         minimalui: request.params.path === "bookmarklet",
       });
     }

--- a/packages/endpoint-share/tests/integration/400-post-share.js
+++ b/packages/endpoint-share/tests/integration/400-post-share.js
@@ -17,9 +17,9 @@ test("Returns 400 error publishing post", async (t) => {
   const result = dom.window.document;
 
   t.is(response.status, 400);
-  t.is(
+  t.regex(
     result.querySelector(".notification--error p").textContent,
-    "No bearer token provided by request"
+    /\bNo bearer token provided by request\b/g
   );
 
   server.close(t);

--- a/packages/frontend/components/authorize/template.njk
+++ b/packages/frontend/components/authorize/template.njk
@@ -1,6 +1,6 @@
 {% set clientLink = opts.client.name | friendlyUrl | linkTo(opts.client.url) %}
 {% set meLink = opts.me | friendlyUrl | replace("/", "/<wbr>") | linkTo(opts.me) %}
-<p class="{{ classes("authorize", opts.classes) }} s-flow"
+<p class="{{ classes("authorize", opts) }} s-flow"
   {{- attributes(opts.attributes) }}>
   {% if opts.client.logo %}
   <a class="authorize__client" href="{{ opts.client.url }}">

--- a/packages/frontend/components/details/styles.css
+++ b/packages/frontend/components/details/styles.css
@@ -33,7 +33,8 @@
 .details__main:not(#fieldset) {
   border-inline-start: var(--border-width-thickest) solid var(--color-outline);
   margin-block-start: var(--space-s);
-  padding-inline-start: var(--space-m);
+  padding-block: var(--space-xs);
+  padding-inline: var(--space-m);
 
   & pre {
     border-inline-start: none;

--- a/packages/frontend/components/details/template.njk
+++ b/packages/frontend/components/details/template.njk
@@ -1,5 +1,5 @@
 {% from "../prose/macro.njk" import prose with context %}
-<details class="{{ classes("details", action) }}"
+<details class="{{ classes("details", opts) }}"
   {%- if opts.id %} id="{{ opts.id }}"{% endif %}
   {{- " open" if opts.open }}
   {{- attributes(opts.attributes) }}>
@@ -7,6 +7,6 @@
     <span class="details__summary-text">{{ opts.summary | safe }}</span>
   </summary>
   <div class="details__main">
-    {{ caller() if caller else prose(opts) }}
+    {{ caller() if caller else prose({ text: opts.text }) }}
   </div>
 </details>

--- a/packages/frontend/components/notification/styles.css
+++ b/packages/frontend/components/notification/styles.css
@@ -1,5 +1,6 @@
 .notification {
   --anchor-color: currentcolor;
+  --anchor-color-hover: currentcolor;
   background-color: var(--color-notification);
   color: var(--color-on-notification);
 }
@@ -22,9 +23,6 @@
 }
 
 .notification__container {
-  align-items: baseline;
-  display: flex;
-  gap: var(--space-s);
   padding-block: var(--space-m);
 }
 
@@ -34,4 +32,20 @@
 
 .notification__text {
   --prose-font: var(--font-caption);
+}
+
+.notification__details {
+  --color-outline: currentcolor;
+  --font-label: var(--font-caption);
+  --prose-font: var(--font-code);
+
+  & .details__summary {
+    padding-block: 0;
+  }
+
+  & .details__main {
+    background-color: var(--color-shadow);
+    overflow: scroll;
+    white-space: nowrap;
+  }
 }

--- a/packages/frontend/components/notification/template.njk
+++ b/packages/frontend/components/notification/template.njk
@@ -1,19 +1,22 @@
 {% from "../prose/macro.njk" import prose with context %}
+{% from "../details/macro.njk" import details with context %}
 <div class="{{ classes("notification", opts) }}
   {{- " notification--" + opts.type if opts.type }}" data-controller="notification" aria-labelledby="notification-title" role="{{ "alert" if opts.type === "success" else "region" }}"
   {%- if opts.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ opts.disableAutoFocus }}"{% endif %}
   {{- attributes(opts.attributes) }}>
   <div class="notification__container -!-container">
-    <h2 class="notification__title" id="notification-title">
-      {{
-        (__("error") if opts.type === "error") or
-        (__("success") if opts.type === "success") or
-        __("important")
-      }}
-    </h2>
-    {{ prose({
+    <h2 class="notification__title" id="notification-title">{{
+      (__("error") if opts.type === "error") or
+      (__("success") if opts.type === "success") or
+      __("important")
+    }}</h2>
+    {{ details({
+      classes: "notification__details",
+      summary: opts.text,
+      text: opts.details
+    }) if opts.details else prose({
       classes: "notification__text",
       text: opts.text | linkTo(opts.href)
-    }) | indent(4) if opts.text }}
+    }) | indent(4) }}
   </div>
 </div>

--- a/packages/frontend/layouts/default.njk
+++ b/packages/frontend/layouts/default.njk
@@ -66,7 +66,8 @@
 <main class="{{ mainClasses }}" id="main"{% if mainControllers %} data-controller="{{ mainControllers }}"{% endif %}>
 {{- notification({
   type: ("error" if error) or ("success" if success),
-  text: (error if error) or (success if success) or notice
+  text: (error if error) or (success if success) or notice,
+  details: (error_details if error_details) or (success_details if success_details)
 }) if error or success or notice }}
 {{- backLink({
   href: back

--- a/packages/indiekit/lib/indieauth.js
+++ b/packages/indiekit/lib/indieauth.js
@@ -100,6 +100,7 @@ export const IndieAuth = class {
         return response.status(401).render("session/login", {
           title: response.locals.__("session.login.title"),
           error: error.message,
+          error_details: error.stack,
         });
       }
     };
@@ -172,6 +173,7 @@ export const IndieAuth = class {
         return response.render("session/login", {
           title: response.locals.__("session.login.title"),
           error: error.message,
+          error_details: error.stack,
         });
       }
     };


### PR DESCRIPTION
Error messages in the user interface now include the stack trace, hidden under a `details` element. Clicking on the error name reveals the trace:

<img src="https://github.com/getindiekit/indiekit/assets/813383/76405b65-0828-4230-a473-028eff30ffb8" alt="Screenshot of stack trace shown for an error on the sign in page" width="640">

Prompted by #598.