### PR TITLE
Replace `publication.timeZone` with `application.timeZone`

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -148,6 +148,22 @@ _Optional_, defaults to `"automatic"`. For example:
 }
 ```
 
+### application.timeZone `string`
+
+The time zone for the application. By default this is set to `"UTC"`, however if you want to offset dates according to your time zone you can provide [a time zone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This option also accepts a number of other values.
+
+_Optional_, defaults to `"UTC"`. For example:
+
+```json
+{
+  "application": {
+    "timeZone": "Europe/Berlin"
+  }
+}
+```
+
+See [customising the time zone →](time-zone.md)
+
 ### application.tokenEndpoint `URL`
 
 Indiekit uses its own token endpoint, but you can use a third-party service by setting a value for this option.
@@ -398,19 +414,3 @@ export default {
 <!--@include: .option-requires-js.md-->
 
 See [customising commit messages →](commit-messages.md)
-
-### publication.timeZone `string`
-
-The time zone for your publication. By default this is set to `"UTC"`, however if you want to offset dates according to your time zone you can provide [a time zone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This option also accepts a number of other values.
-
-_Optional_, defaults to `"UTC"`. For example:
-
-```json
-{
-  "publication": {
-    "timeZone": "Europe/Berlin"
-  }
-}
-```
-
-See [customising the time zone →](time-zone.md)

--- a/docs/configuration/time-zone.md
+++ b/docs/configuration/time-zone.md
@@ -1,6 +1,6 @@
 # Time zone
 
-You can provide one of the following values for `publication.timeZone`:
+You can provide one of the following values for `application.timeZone`:
 
 - `client`:
 
@@ -17,7 +17,7 @@ You can provide one of the following values for `publication.timeZone`:
   - If the client sends a date, Indiekit will update the date to use the given time zone
   - If the client does not send a date, Indiekit will use the current date with the given time zone
 
-> The default value for `publication.timeZone` is `UTC`.
+> The default value for `application.timeZone` is `UTC`.
 
 So for example, assuming the current local time is `2020-09-23T19:00:00+01:00 Europe/London`, given the following values sent by the client for `published`, the date Indiekit saves would be as follows:
 

--- a/helpers/config/index.js
+++ b/helpers/config/index.js
@@ -38,6 +38,7 @@ export const testConfig = async (options) => {
         name: "test",
         secret: process.env.SECRET,
       }),
+      timeZone: "UTC",
       tokenEndpoint: options?.application?.tokenEndpoint,
     },
     plugins: [
@@ -48,7 +49,6 @@ export const testConfig = async (options) => {
     publication: {
       me: options?.publication?.me || "https://website.example",
       ...(options.usePostTypes && { postTypes }),
-      timeZone: "UTC",
     },
     "@indiekit-test/store": {
       user: "user",

--- a/indiekit.config.js
+++ b/indiekit.config.js
@@ -10,6 +10,7 @@ const config = {
     ...(process.env.RAILWAY_ENVIRONMENT && {
       url: `https://${process.env.RAILWAY_STATIC_URL}`,
     }),
+    timeZone: process.env.TZ,
   },
   plugins: [
     "@indiekit-test/frontend",
@@ -22,7 +23,6 @@ const config = {
   publication: {
     me: process.env.PUBLICATION_URL,
     categories: ["internet", "indieweb", "indiekit", "test", "testing"],
-    timeZone: process.env.TZ,
   },
   "@indiekit/store-github": {
     user: process.env.GITHUB_USER,

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,39 +66,30 @@
       }
     },
     "helpers/access-token": {
-      "name": "@indiekit-test/token",
       "license": "MIT"
     },
     "helpers/config": {
-      "name": "@indiekit-test/config",
       "license": "MIT"
     },
     "helpers/fixtures": {
-      "name": "@indiekit-test/fixtures",
       "license": "MIT"
     },
     "helpers/frontend": {
-      "name": "@indiekit-test/frontend",
       "license": "MIT"
     },
     "helpers/media-data": {
-      "name": "@indiekit-test/media-data",
       "license": "MIT"
     },
     "helpers/mock-agent": {
-      "name": "@indiekit-test/mock-agent",
       "license": "MIT"
     },
     "helpers/post-data": {
-      "name": "@indiekit-test/post-data",
       "license": "MIT"
     },
     "helpers/publication": {
-      "name": "@indiekit-test/publication",
       "license": "MIT"
     },
     "helpers/server": {
-      "name": "@indiekit-test/server",
       "license": "MIT",
       "dependencies": {
         "get-port": "^7.0.0"
@@ -116,12 +107,19 @@
       }
     },
     "helpers/session": {
-      "name": "@indiekit-test/session",
       "license": "MIT"
     },
     "helpers/store": {
-      "name": "@indiekit-test/store",
       "license": "MIT"
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.9.3",
@@ -400,60 +398,47 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "optional": true
     },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
-      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.359.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.359.0.tgz",
-      "integrity": "sha512-zb5hSVuyHOXFTjGiqzPhQ/F6Zg4oLffO/NmC3MyvufUzr8yZYmcQzxNU6Jv6WbVmP01OiU4KAozBLMS7URfgzg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.363.0.tgz",
+      "integrity": "sha512-tsJzgBSCpna85IVsuS7FBIK9wkSl7fs8TJ/QzapIgu8rKss0ySHVO6TeMVAdw2BvaQl7CxU9c3PosjhLWHu6KQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.359.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.358.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/client-sts": "3.363.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
         "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-        "@aws-sdk/util-defaults-mode-node": "3.358.0",
         "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
         "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
         "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -461,43 +446,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.358.0.tgz",
-      "integrity": "sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
+      "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
         "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-        "@aws-sdk/util-defaults-mode-node": "3.358.0",
         "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
         "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
         "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -505,43 +490,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.358.0.tgz",
-      "integrity": "sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
+      "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
         "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-        "@aws-sdk/util-defaults-mode-node": "3.358.0",
         "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
         "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
         "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -549,46 +534,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.359.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.359.0.tgz",
-      "integrity": "sha512-zpyui8hXvEUvq8MwzZsm51ni0intvPjtV8dgx10nVJnm605nqrLlAMGqQ1S/UxO7CVmhqWbh5dnGHEc//UJlsw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
+      "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.358.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-sdk-sts": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-sdk-sts": "3.363.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
         "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-        "@aws-sdk/util-defaults-mode-node": "3.358.0",
         "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.1",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.2",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -596,30 +581,16 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
-      "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.359.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.359.0.tgz",
-      "integrity": "sha512-dSuHTucXcjIFsjdOq0HeSk0niWJ7V2hWnwyYh7MCwv43dP9u4V+11boLC6zIrw2Epx++JnIqhggKJAi6l/occw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.363.0.tgz",
+      "integrity": "sha512-5x42JvqEsBUrm6/qdf0WWe4mlmJjPItxamQhRjuOzeQD/BxsA2W5VS/7n0Ws0e27DNhlnUErcIJd+bBy6j1fqA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.359.0",
-        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/client-cognito-identity": "3.363.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -627,29 +598,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
-      "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
+      "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
         "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
-      "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -657,19 +613,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
-      "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
+      "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.358.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -677,20 +634,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
-      "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
+      "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-ini": "3.358.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.358.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-ini": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -698,14 +656,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
-      "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
+      "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -713,16 +672,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
-      "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
+      "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.358.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/token-providers": "3.358.0",
+        "@aws-sdk/client-sso": "3.363.0",
+        "@aws-sdk/token-providers": "3.363.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -730,13 +690,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
-      "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
+      "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -744,116 +705,25 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.359.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.359.0.tgz",
-      "integrity": "sha512-fwfdqoJihRUbk3KEYv8IfWRFI+cNQfXfVHLtDEcW3tCU8lqsL920YSEjqMuWGrWLp8dWESDX5C3wZugur0lnTQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.363.0.tgz",
+      "integrity": "sha512-hVa1DdYasnLud2EKjDAlDHiV/+H/Zq52chHU00c/R8XwPu1s0kZX3NMmlt0D2HhYqC1mUwtdmE58Jra2POviQQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.359.0",
-        "@aws-sdk/client-sso": "3.358.0",
-        "@aws-sdk/client-sts": "3.359.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.359.0",
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-ini": "3.358.0",
-        "@aws-sdk/credential-provider-node": "3.358.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.358.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/client-cognito-identity": "3.363.0",
+        "@aws-sdk/client-sso": "3.363.0",
+        "@aws-sdk/client-sts": "3.363.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.363.0",
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-ini": "3.363.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
         "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
-      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
-      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
-      "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
-      "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
-      "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
-      "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -861,13 +731,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
-      "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
+      "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -875,12 +746,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
-      "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
+      "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -888,67 +760,29 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
-      "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
+      "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
-      "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
-      "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
+      "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.357.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
         "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
-      "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -956,28 +790,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
-      "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
+      "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/signature-v4": "3.357.0",
         "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
-      "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
-      "optional": true,
-      "dependencies": {
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -985,155 +808,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
-      "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
+      "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
         "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-endpoints": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
-      "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
-      "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
-      "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
-      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
-      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
-      "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
-      "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg==",
-      "optional": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
-      "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
-      "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.357.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.358.0.tgz",
-      "integrity": "sha512-oqctxWb9yAqCh4ENwUkt9MC01l5uKoy+QCiSUUhQ76k7R3lyGOge9ycyRyoKl+oZWvEpnjZevXQFqEfGzkL7bA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-stream": "3.358.0",
-        "@smithy/types": "^1.0.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1141,15 +824,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
-      "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
+      "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.358.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/client-sso-oidc": "3.363.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1168,108 +852,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
-      "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.358.0.tgz",
-      "integrity": "sha512-KGfw64wRL/gROLD4Gatda8cUsaNKNhSnx+yDDcG2WkFlFfLr6FHvTijpRxvIM2Jau2ZhcdGzbegLjsFxviTJAA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.358.0.tgz",
-      "integrity": "sha512-2C5on0yppDS0xGpFkHRqfrG9TeTq6ive1hPX1V8UCkiI/TBQYl88XCKCKct8zTcejyK9klZUDGI8QQTan2UWkw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.357.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
@@ -1277,18 +859,6 @@
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "optional": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1307,81 +877,27 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
-      "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
-      "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream": {
-      "version": "3.358.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.358.0.tgz",
-      "integrity": "sha512-zUhpjxAXV2+0eALlTU6uXRYMs10XYpcYzl3NtLRe4wWgnrOOOZnF/t5LQDoKXOfaMdzwZ+i90+PYr+6JQ58+7g==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
-      "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
+      "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
-      "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
+      "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.357.0",
         "@aws-sdk/types": "3.357.0",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1394,19 +910,6 @@
         "aws-crt": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
@@ -2645,21 +2148,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
@@ -2669,26 +2157,12 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.4.tgz",
+      "integrity": "sha512-KE/SxsDqNs3rrWwFHcRh15ZLVFrI0YoZtgAdIyIq9k5hUNmiWRXXThPomIxHuL20sLdgzbDFyvkUMna14bvtrw==",
       "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
+      "peer": true
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
@@ -2706,9 +2180,9 @@
       }
     },
     "node_modules/@lerna/child-process": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.0.2.tgz",
-      "integrity": "sha512-15lMrNBL/pvREMJPSfIPieaBtyyapDco/TNjALLEL53JGzO9g8rj5PipfE9h5ILx8aq/GaP17XCh209aVCun/w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.1.1.tgz",
+      "integrity": "sha512-mR8PaTkckYPLmEBG2VsVsJq2UuzEvjXevOB1rKLKUZ/dPCGcottVhbiEzTxickc+s7Y/1dTTLn/1BKj3B1a5BA==",
       "dependencies": {
         "chalk": "^4.1.0",
         "execa": "^5.0.0",
@@ -2719,11 +2193,11 @@
       }
     },
     "node_modules/@lerna/create": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-7.0.2.tgz",
-      "integrity": "sha512-1arGpEpWbWmci1MyaGKvP2SqCAPFWpLqZp0swckianX1kx1mso9B16BWFvcHhU57zCD0Co/z+jX+02UEzZGP7Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-7.1.1.tgz",
+      "integrity": "sha512-1PY2OgwGxp7b91JzLKEhONVl69mCt1IyYEc6pzKy3Sv+UOdeK2QFq1SX/85hNOR3iitiyZ75bNWUTcBly1ZlZg==",
       "dependencies": {
-        "@lerna/child-process": "7.0.2",
+        "@lerna/child-process": "7.1.1",
         "dedent": "0.7.0",
         "fs-extra": "^11.1.1",
         "init-package-json": "5.0.0",
@@ -3096,30 +2570,30 @@
       }
     },
     "node_modules/@nrwl/devkit": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.4.0.tgz",
-      "integrity": "sha512-KUu9oNrMB8DP78BAO8XWJC5HOSS6dO6ocMWj2DtuNVgMgABviy+ih/TmrGKxQQBH0Ib4cxTeMIQVRdAak5c1UA==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.4.1.tgz",
+      "integrity": "sha512-kio+x1NonteK9Vxrgeai56+cDFkiWUl42YzLamNXORvICgVgGtcR7afdi9l7j9q2YPUuvtBos6T9YddS6YCb2g==",
       "dependencies": {
-        "@nx/devkit": "16.4.0"
+        "@nx/devkit": "16.4.1"
       }
     },
     "node_modules/@nrwl/tao": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.4.0.tgz",
-      "integrity": "sha512-6n4chOOv6jqact07NvIDRQfsnaiYYhi+mrqSuJKs6fL+c5kx/VCryndTP0MDTBbazfL6H7vwiQUkTja2sQDuwA==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.4.1.tgz",
+      "integrity": "sha512-aJqYxgz+PzyeuFrKj7jei8Xwq05JYLmq5o+4/Und+lkMZboqvVWz1ezwiMj9pzGoXz4td8b3sN1B+nwmORm3ZQ==",
       "dependencies": {
-        "nx": "16.4.0"
+        "nx": "16.4.1"
       },
       "bin": {
         "tao": "index.js"
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-16.4.0.tgz",
-      "integrity": "sha512-/Y+tC2IBxVEf3EKB80G9mF27ZBAFEBBmDMn1MPzfGX9AB2GGNCqgvSkSHT5DlkyxJOMqbE7DpMyHxubALyenEA==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-16.4.1.tgz",
+      "integrity": "sha512-N2oDaQQV9r6mnoPsAqKs8H+tsLdNptQms5AxgnhdEMYWH4ppmy6Zutg4h1qZWsbdqSyiLVuOqlPrPlzRM4EA4g==",
       "dependencies": {
-        "@nrwl/devkit": "16.4.0",
+        "@nrwl/devkit": "16.4.1",
         "ejs": "^3.1.7",
         "ignore": "^5.0.4",
         "semver": "7.5.3",
@@ -3145,9 +2619,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.4.0.tgz",
-      "integrity": "sha512-/ZXuF8M3u8DSNmjYstQKorzo7uIETNhnFinwWlO8mzz+SyR+Xs5G6penJ4+cB1ju3Hf3lZkXd5U6pEiW4OAAkA==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.4.1.tgz",
+      "integrity": "sha512-DkY51qgBlqgHwAVrK4k58tNZ1Uuqi4czA+aLs+J2OvC8W/4uRSajGPL4LWgdPWYe1zKxJvhFIFswchn8uQuaBw==",
       "cpu": [
         "arm64"
       ],
@@ -3160,9 +2634,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.4.0.tgz",
-      "integrity": "sha512-0Fo58qZzHgRs4SRVaAOBipdJQNew57YQbpFaLHKhCTyKc0Pe6THEYaaT/x9QVkcFO0x4AzNr9T7iJTrneNwcKg==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.4.1.tgz",
+      "integrity": "sha512-jMJz6wsCOl7n3x4lmiS7BbQZdGmKKsN1IUaLcJfxZjFN3YS8euO2bwO74trFkfNOdYG8KjFuw/+A62USYj4e+g==",
       "cpu": [
         "x64"
       ],
@@ -3175,9 +2649,9 @@
       }
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.4.0.tgz",
-      "integrity": "sha512-Qoes/NifE4zb5Gb6ZdC32HvxZBzO0xo74j7EozUV5rZEm3bCtKbKqThPV9Uuu+8S4j718r5vlob/IMXqRcWK4g==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.4.1.tgz",
+      "integrity": "sha512-8Ql2/g+WZOKnPC7x4IeW/vzIRi9K9BE6LvFGGMsTvqKJHurboGlPjBAAqo/wmgM+JPNivtzX+IsQQkcGQrFfLw==",
       "cpu": [
         "x64"
       ],
@@ -3190,9 +2664,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.4.0.tgz",
-      "integrity": "sha512-m8uklbettj8RnLtasjQPiYxqJotDSfO3LO1II8Bds53C7OT8TDnTkW68MEx+CxuSCQFy2Aa0Oih3jSvDzfnZzA==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.4.1.tgz",
+      "integrity": "sha512-EyK/q86FXO78oGcubBXlqdzCsrMBx+CgEyndS2IlvpGFXN3v2s3jE8v/RXWbPskJ6zJZytRvyMjTjxAnzjxb+A==",
       "cpu": [
         "arm"
       ],
@@ -3205,9 +2679,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.4.0.tgz",
-      "integrity": "sha512-bAs2T/zZQDTCzzhciE8kCrkwgXbeX3K83cGRacB7PDZZl/O4jr5TRO4zYHi6doytyLONjqhvWNLbIo4cEEcfZA==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.4.1.tgz",
+      "integrity": "sha512-2YpmfnHahuFXD7DN4j/O+8hvV1P1oa+QxO+hxBfPdqU45YmOPSwbVEcTsjYmc++iG9xURpGaSu3hGmk5JR4OoQ==",
       "cpu": [
         "arm64"
       ],
@@ -3220,9 +2694,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.4.0.tgz",
-      "integrity": "sha512-K1D8j4lRZDBVuW8iomeJjCznFz7rfP3qaB3RHjKZU5qrZBq1uYohhdfT7dzwWFNWEvt6WytfhGCl2S9PsQ37Wg==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.4.1.tgz",
+      "integrity": "sha512-+xDP3/veLSPaLFrp1lItZTK2rqpMEftOC+2TsRPQ1BwivGxBegerQYWgZxe6nfuBGrRD2xj8+aY4on5UfmYBJw==",
       "cpu": [
         "arm64"
       ],
@@ -3235,9 +2709,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.4.0.tgz",
-      "integrity": "sha512-v1NJ3ESaw5bdSeuh5Xslq1dXGWztf0mSLwZP510Rt9+ulr5LQ/X1Rri8zefU0gZNLcmJL0G2Qq7UTnppYGRTEg==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.4.1.tgz",
+      "integrity": "sha512-psbB+hTXffeeATO692To4zxz08XNUHNiHefZYVwT6hUWw+EsUAadnd3VimP9xoSzHyzvUk6raYPT783MySTzGg==",
       "cpu": [
         "x64"
       ],
@@ -3250,9 +2724,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.4.0.tgz",
-      "integrity": "sha512-+8YLVWZFq+k6YJ2ZDwR5sGaRnZhUVYtR8aPbGyonMnJ8VEQJNEqsm1KT6nt0gd3JJdxyphm3VsMQWBMo42jM+w==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.4.1.tgz",
+      "integrity": "sha512-pztJGR64NRygp675p/tkQIF2clIc9mxRVpVAaeIc1DoQTEpyeagqi6bTPwTTUdhDhTleqV6r3wOTL/3ImUrpng==",
       "cpu": [
         "x64"
       ],
@@ -3265,9 +2739,9 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.4.0.tgz",
-      "integrity": "sha512-HwE6AxlrfWvODT49vVX6NGMYc3zdMVXETCdZb0jZ/oz28XXTAPvVb/8DJgKSyCs0DPirEeCHiPwbdcJA1Bqw8A==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.4.1.tgz",
+      "integrity": "sha512-tmfVFZ5lKahYg16mUs7gwEJtlBkL9cEoc1Pf7cuFXHT+T7z5WhXoZ0q7VTyArf3gisK4fTmTAEEuUEK2MbQ2xA==",
       "cpu": [
         "arm64"
       ],
@@ -3280,9 +2754,9 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.4.0.tgz",
-      "integrity": "sha512-ISL3c6i/v+JOsUHEbngDHaobmbgu6oSY0htKas1RjLWGkWXDLgEXMRjQ/xDbNVYH00Mto7mmq+nrjkNNbqOrfQ==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.4.1.tgz",
+      "integrity": "sha512-MAy719VC8hCPkYJ6j5Gl+s4pevWL0dxbzcXtQDstC0Y7XWPFmHS+CDgK8zHWfaN8mK6Sebv+nTQ+e/ptEu1+TA==",
       "cpu": [
         "x64"
       ],
@@ -3592,13 +3066,12 @@
       }
     },
     "node_modules/@sigstore/tuf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-1.0.0.tgz",
-      "integrity": "sha512-bLzi9GeZgMCvjJeLUIfs8LJYCxrPRA8IXQkzUtaFKKVPTz0mucRyqFcV2U20yg9K+kYAD0YSitzGfRZCFLjdHQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-1.0.2.tgz",
+      "integrity": "sha512-vjwcYePJzM01Ha6oWWZ9gNcdIgnzyFxfqfWzph483DPJTH8Tb7f7bQRRll3CYVkyH56j0AgcPAcl6Vg95DPF+Q==",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.1.0",
-        "make-fetch-happen": "^11.0.1",
-        "tuf-js": "^1.1.3"
+        "tuf-js": "^1.1.7"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -3715,6 +3188,238 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
+      "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
+      "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-config-provider": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
+      "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
+      "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
+      "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/querystring-builder": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-base64": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
+      "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-buffer-from": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
+      "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
+      "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.2.tgz",
+      "integrity": "sha512-F3CyXgjtDI4quGFkDmVNytt6KMwlzzeMxtopk6Edue4uKdKcMC1vUmoRS5xTbFzKDDp4XwpnEV7FshPaL3eCPw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.3.tgz",
+      "integrity": "sha512-ZRsjG8adtxQ456FULPqPFmWtrW44Fq8IgdQvQB+rC2RSho3OUzS+TiEIwb5Zs6rf2IoewITKtfdtsUZcxXO0ng==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/service-error-classification": "^1.0.2",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
+      "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
+      "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
+      "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
+      "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/querystring-builder": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
+      "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/protocol-http": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
@@ -3728,12 +3433,278 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
+      "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-uri-escape": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
+      "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.2.tgz",
+      "integrity": "sha512-Q5CCuzYL5FGo6Rr/O+lZxXHm2hrRgbmMn8MgyjqZUWZg20COg20DuNtIbho2iht6CoB7jOpmpBqhWizLlzUZgg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
+      "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
+      "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^1.0.1",
+        "@smithy/is-array-buffer": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "@smithy/util-uri-escape": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
+      "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-stream": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/types": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
       "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
       "optional": true,
       "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
+      "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
+      "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
+      "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
+      "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
+      "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
+      "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
+      "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
+      "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
+      "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
+      "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.3.tgz",
+      "integrity": "sha512-gYQnZDD8I2XJFspVwUISyukjPWVikTzKR0IdG8hCWYPTpeULFl1o6yzXlT5SL63TBkuEYl0R1/93cdNtMiNnoA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
+      "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-buffer-from": "^1.0.1",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
+      "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
+      "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4030,9 +4001,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+      "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -4253,14 +4224,14 @@
       "dev": true
     },
     "node_modules/@vueuse/core": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.2.0.tgz",
-      "integrity": "sha512-aHBnoCteIS3hFu7ZZkVB93SanVDY6t4TIb7XDLxJT/HQdAZz+2RdIEJ8rj5LUoEJr7Damb5+sJmtpCwGez5ozQ==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.2.1.tgz",
+      "integrity": "sha512-c441bfMbkAwTNwVRHQ0zdYZNETK//P84rC01aP2Uy/aRFCiie9NE/k9KdIXbno0eDYP5NPUuWv0aA/I4Unr/7w==",
       "dev": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.17",
-        "@vueuse/metadata": "10.2.0",
-        "@vueuse/shared": "10.2.0",
+        "@vueuse/metadata": "10.2.1",
+        "@vueuse/shared": "10.2.1",
         "vue-demi": ">=0.14.5"
       },
       "funding": {
@@ -4294,13 +4265,13 @@
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.2.0.tgz",
-      "integrity": "sha512-e+MIRMi2Zo8DZKXszut8iVoZGlf07XXoaDt27W0DRJVYPdods50MV8Bnla5Tnuil0gHY/W5mMcqiQre9Xb246Q==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.2.1.tgz",
+      "integrity": "sha512-FDP5lni+z9FjHE9H3xuvwSjoRV9U8jmDvJpmHPCBjUgPGYRynwb60eHWXCFJXLUtb4gSIHy0e+iaEbrKdalCkQ==",
       "dev": true,
       "dependencies": {
-        "@vueuse/core": "10.2.0",
-        "@vueuse/shared": "10.2.0",
+        "@vueuse/core": "10.2.1",
+        "@vueuse/shared": "10.2.1",
         "vue-demi": ">=0.14.5"
       },
       "funding": {
@@ -4386,18 +4357,18 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.2.0.tgz",
-      "integrity": "sha512-IR7Mkq6QSgZ38q/2ZzOt+Zz1OpcEsnwE64WBumDQ+RGKrosFCtUA2zgRrOqDEzPBXrVB+4HhFkwDjQMu0fDBKw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.2.1.tgz",
+      "integrity": "sha512-3Gt68mY/i6bQvFqx7cuGBzrCCQu17OBaGWS5JdwISpMsHnMKKjC2FeB5OAfMcCQ0oINfADP3i9A4PPRo0peHdQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.2.0.tgz",
-      "integrity": "sha512-dIeA8+g9Av3H5iF4NXR/sft4V6vys76CpZ6hxwj8eMXybXk2WRl3scSsOVi+kQ9SX38COR7AH7WwY83UcuxbSg==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.2.1.tgz",
+      "integrity": "sha512-QWHq2bSuGptkcxx4f4M/fBYC3Y8d3M2UYyLsyzoPgEoVzJURQ0oJeWXu79OiLlBb8gTKkqe4mO85T/sf39mmiw==",
       "dev": true,
       "dependencies": {
         "vue-demi": ">=0.14.5"
@@ -4761,6 +4732,33 @@
         "clean-stack": "^4.0.0",
         "indent-string": "^5.0.0"
       },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/aggregate-error/node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/aggregate-error/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -5154,9 +5152,9 @@
       }
     },
     "node_modules/ava/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -5667,15 +5665,15 @@
       }
     },
     "node_modules/cacache/node_modules/glob": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.0.tgz",
-      "integrity": "sha512-AQ1/SB9HH0yCx1jXAT4vmCbTOPe5RQ+kCurjbel5xSCGhebumUv+GJZfa1rEqor3XIViqwSEmlkZCQD43RWrBg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.1.tgz",
+      "integrity": "sha512-9BKYcEeIs7QwlCYs+Y3GBvqAMISufUS0i2ELd11zpZjxI5V9iyRj0HgzB5/cLf2NY4vcYBTYzJ7GIui7j/4DOw==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
         "minipass": "^5.0.0 || ^6.0.2",
-        "path-scurry": "^1.7.0"
+        "path-scurry": "^1.10.0"
       },
       "bin": {
         "glob": "dist/cjs/src/bin.js"
@@ -5849,9 +5847,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001507",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
-      "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
+      "version": "1.0.30001509",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
+      "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6031,15 +6029,14 @@
       }
     },
     "node_modules/clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+      "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6049,7 +6046,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -6794,9 +6790,9 @@
       }
     },
     "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -7390,9 +7386,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.440",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.440.tgz",
-      "integrity": "sha512-r6dCgNpRhPwiWlxbHzZQ/d9swfPaEJGi8ekqRBwQYaR3WmA5VkqQfBWSDDjuJU1ntO+W9tHx8OHV/96Q8e0dVw=="
+      "version": "1.4.447",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.447.tgz",
+      "integrity": "sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw=="
     },
     "node_modules/emittery": {
       "version": "1.0.1",
@@ -8171,9 +8167,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "46.2.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.2.6.tgz",
-      "integrity": "sha512-zIaK3zbSrKuH12bP+SPybPgcHSM6MFzh3HFeaODzmsF1N8C1l8dzJ22cW1aq4g0+nayU1VMjmNf7hg0dpShLrA==",
+      "version": "46.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.3.tgz",
+      "integrity": "sha512-Prc7ol+vCIghPeECpwZq5+P+VZfoi87suywvbYCiCnkI1kTmVSdcOC2M8mioglWxBbd28wbb1OVjg/8OzGzatA==",
       "dev": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.39.4",
@@ -8886,9 +8882,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -9613,9 +9609,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.0.tgz",
-      "integrity": "sha512-lgbo68hHTQnFddybKbbs/RDRJnJT5YyGy2kQzVwbq+g67X73i+5MVTval34QxGkOe9X5Ujf1UYpCaphLyltjEg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.2.tgz",
+      "integrity": "sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==",
       "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -11555,12 +11551,12 @@
       }
     },
     "node_modules/lerna": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-7.0.2.tgz",
-      "integrity": "sha512-omFpf1pTiaObC2YOC7K+euaDwhQA9CyKN1kXxmlSwaSkh8b8QTs4SC8jp3oNeXfcHpVS1ttuuz98AvQvJD46wA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-7.1.1.tgz",
+      "integrity": "sha512-rjivAl3bYu2+lWOi90vy0tYFgwBYPMiNkR/DuEWZC08wle5dsbOZ/SlXeLk9+kzbF89Bt5P6p+qF78A2tJsWPA==",
       "dependencies": {
-        "@lerna/child-process": "7.0.2",
-        "@lerna/create": "7.0.2",
+        "@lerna/child-process": "7.1.1",
+        "@lerna/create": "7.1.1",
         "@npmcli/run-script": "6.0.2",
         "@nx/devkit": ">=16.1.3 < 17",
         "@octokit/plugin-enterprise-rest": "6.0.1",
@@ -12100,9 +12096,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.10.36",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.36.tgz",
-      "integrity": "sha512-NCPWES1poiS4NSzIS49mxHM5hCkSWov8wFICRKfL9narzimqAXlnAgNloHCt0BukZHbWt8TIStCdzLy7LXBYpQ=="
+      "version": "1.10.37",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.37.tgz",
+      "integrity": "sha512-Z10PCaOCiAxbUxLyR31DNeeNugSVP6iv/m7UrSKS5JHziEMApJtgku4e9Q69pzzSC9LnQiM09sqsGf2ticZnMw=="
     },
     "node_modules/lightningcss": {
       "version": "1.21.1",
@@ -12345,9 +12341,9 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.2.2.tgz",
-      "integrity": "sha512-71gSwXKy649VrSU09s10uAT0rWCcY3aewhMaHyl2N84oBk4Xs9HgxvUp3AYu+bNsK4NrOYYxvSgg7FyGJ+jGcA==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.2.3.tgz",
+      "integrity": "sha512-zVVEXLuQIhr1Y7R7YAWx4TZLdvuzk7DnmrsTNL0fax6Z3jrpFcas+vKbzxhhvp6TA55m1SQuWkpzI1qbfDZbAg==",
       "dev": true,
       "dependencies": {
         "chalk": "5.2.0",
@@ -14676,15 +14672,15 @@
       "dev": true
     },
     "node_modules/nx": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-16.4.0.tgz",
-      "integrity": "sha512-HhJnOAm2wlaIVMmxK1HcdcKfX5DlnQc1RAHFf+QostvQQ/SmUg9f7LoStxpNm01JhQTehb01tH9zAsXKcKzO4A==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-16.4.1.tgz",
+      "integrity": "sha512-om1v2xu+e4/ibQ4PgnFfemwnfS4e9Biss3R0lx1d8GmaVRIJ/o4Ng0c6F5Uw9l/WMc0DyAnGBthKyrVAlHPs1A==",
       "hasInstallScript": true,
       "dependencies": {
-        "@nrwl/tao": "16.4.0",
+        "@nrwl/tao": "16.4.1",
         "@parcel/watcher": "2.0.4",
         "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "^3.0.0-rc.18",
+        "@yarnpkg/parsers": "3.0.0-rc.46",
         "@zkochan/js-yaml": "0.0.6",
         "axios": "^1.0.0",
         "chalk": "^4.1.0",
@@ -14720,16 +14716,16 @@
         "nx": "bin/nx.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "16.4.0",
-        "@nx/nx-darwin-x64": "16.4.0",
-        "@nx/nx-freebsd-x64": "16.4.0",
-        "@nx/nx-linux-arm-gnueabihf": "16.4.0",
-        "@nx/nx-linux-arm64-gnu": "16.4.0",
-        "@nx/nx-linux-arm64-musl": "16.4.0",
-        "@nx/nx-linux-x64-gnu": "16.4.0",
-        "@nx/nx-linux-x64-musl": "16.4.0",
-        "@nx/nx-win32-arm64-msvc": "16.4.0",
-        "@nx/nx-win32-x64-msvc": "16.4.0"
+        "@nx/nx-darwin-arm64": "16.4.1",
+        "@nx/nx-darwin-x64": "16.4.1",
+        "@nx/nx-freebsd-x64": "16.4.1",
+        "@nx/nx-linux-arm-gnueabihf": "16.4.1",
+        "@nx/nx-linux-arm64-gnu": "16.4.1",
+        "@nx/nx-linux-arm64-musl": "16.4.1",
+        "@nx/nx-linux-x64-gnu": "16.4.1",
+        "@nx/nx-linux-x64-musl": "16.4.1",
+        "@nx/nx-win32-arm64-msvc": "16.4.1",
+        "@nx/nx-win32-x64-msvc": "16.4.1"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.4.2",
@@ -15054,17 +15050,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -15572,11 +15568,11 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.0.tgz",
+      "integrity": "sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==",
       "dependencies": {
-        "lru-cache": "^9.1.1",
+        "lru-cache": "^9.1.1 || ^10.0.0",
         "minipass": "^5.0.0 || ^6.0.2"
       },
       "engines": {
@@ -15587,9 +15583,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -16534,15 +16530,15 @@
       }
     },
     "node_modules/read-package-json/node_modules/glob": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.0.tgz",
-      "integrity": "sha512-AQ1/SB9HH0yCx1jXAT4vmCbTOPe5RQ+kCurjbel5xSCGhebumUv+GJZfa1rEqor3XIViqwSEmlkZCQD43RWrBg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.1.tgz",
+      "integrity": "sha512-9BKYcEeIs7QwlCYs+Y3GBvqAMISufUS0i2ELd11zpZjxI5V9iyRj0HgzB5/cLf2NY4vcYBTYzJ7GIui7j/4DOw==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
         "minipass": "^5.0.0 || ^6.0.2",
-        "path-scurry": "^1.7.0"
+        "path-scurry": "^1.10.0"
       },
       "bin": {
         "glob": "dist/cjs/src/bin.js"
@@ -17081,9 +17077,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.25.2.tgz",
-      "integrity": "sha512-VLnkxZMDr3jpxgtmS8pQZ0UvhslmF4ADq/9w4erkctbgjCqLW9oa89fJuXEs4ZmgyoF7Dm8rMDKSS5b5u2hHUg==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.0.tgz",
+      "integrity": "sha512-YzJH0eunH2hr3knvF3i6IkLO/jTjAEwU4HoMUbQl4//Tnl3ou0e7P5SjxdDr8HQJdeUJShlbEHXrrnEHy1l7Yg==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17469,9 +17465,9 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
-      "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
+      "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
       "dev": true,
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
@@ -17505,14 +17501,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sigstore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-1.6.0.tgz",
-      "integrity": "sha512-QODKff/qW/TXOZI6V/Clqu74xnInAS6it05mufj4/fSewexLtfEntgLZZcBtUK44CDQyUE5TUXYy1ARYzlfG9g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-1.7.0.tgz",
+      "integrity": "sha512-KP7QULhWdlu3hlp+jw2EvgWKlOGOY9McLj/jrchLjHNlNPK0KWIwF919cbmOp6QiKXLmPijR2qH/5KYWlbtG9Q==",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.1.0",
-        "@sigstore/tuf": "^1.0.0",
-        "make-fetch-happen": "^11.0.1",
-        "tuf-js": "^1.1.3"
+        "@sigstore/tuf": "^1.0.1",
+        "make-fetch-happen": "^11.0.1"
       },
       "bin": {
         "sigstore": "bin/sigstore.js"
@@ -18563,9 +18558,9 @@
       "dev": true
     },
     "node_modules/tabbable": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
-      "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "dev": true
     },
     "node_modules/table": {
@@ -18772,9 +18767,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.1.tgz",
-      "integrity": "sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==",
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.2.tgz",
+      "integrity": "sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -19120,9 +19115,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -19254,9 +19249,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19684,9 +19679,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.88.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.0.tgz",
-      "integrity": "sha512-O3jDhG5e44qIBSi/P6KpcCcH7HD+nYIHVBhdWFxcLOcIGN8zGo5nqF3BjyNCxIh4p1vFdNnreZv2h2KkoAw3lw==",
+      "version": "5.88.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
+      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -19951,15 +19946,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/widont/-/widont-0.3.4.tgz",
       "integrity": "sha512-X4/KhsPmilZbHaqsApmOM7i+Sr/lKDwvRjX0wSAh8gUfv1Au2IFIXQQ/LMbP4X+cQR01lxvEF6FXS0Je0i4FyA=="
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
@@ -21677,9 +21663,9 @@
       }
     },
     "packages/create-indiekit/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -21688,7 +21674,6 @@
       }
     },
     "packages/endpoint-auth": {
-      "name": "@indiekit/endpoint-auth",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21705,7 +21690,6 @@
       }
     },
     "packages/endpoint-files": {
-      "name": "@indiekit/endpoint-files",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21719,7 +21703,6 @@
       }
     },
     "packages/endpoint-image": {
-      "name": "@indiekit/endpoint-image",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21732,7 +21715,6 @@
       }
     },
     "packages/endpoint-json-feed": {
-      "name": "@indiekit/endpoint-json-feed",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21744,7 +21726,6 @@
       }
     },
     "packages/endpoint-media": {
-      "name": "@indiekit/endpoint-media",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21761,7 +21742,6 @@
       }
     },
     "packages/endpoint-micropub": {
-      "name": "@indiekit/endpoint-micropub",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21782,7 +21762,6 @@
       }
     },
     "packages/endpoint-posts": {
-      "name": "@indiekit/endpoint-posts",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21799,7 +21778,6 @@
       }
     },
     "packages/endpoint-share": {
-      "name": "@indiekit/endpoint-share",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21813,7 +21791,6 @@
       }
     },
     "packages/endpoint-syndicate": {
-      "name": "@indiekit/endpoint-syndicate",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21827,7 +21804,6 @@
       }
     },
     "packages/error": {
-      "name": "@indiekit/error",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "engines": {
@@ -21835,7 +21811,6 @@
       }
     },
     "packages/frontend": {
-      "name": "@indiekit/frontend",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21862,7 +21837,6 @@
       }
     },
     "packages/indiekit": {
-      "name": "@indiekit/indiekit",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21899,20 +21873,6 @@
         "node": ">=18"
       }
     },
-    "packages/indiekit/node_modules/clean-stack": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
-      "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/indiekit/node_modules/commander": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
@@ -21921,19 +21881,7 @@
         "node": ">=16"
       }
     },
-    "packages/indiekit/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/preset-hugo": {
-      "name": "@indiekit/preset-hugo",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -21996,7 +21944,6 @@
       }
     },
     "packages/preset-jekyll": {
-      "name": "@indiekit/preset-jekyll",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22007,7 +21954,6 @@
       }
     },
     "packages/store-bitbucket": {
-      "name": "@indiekit/store-bitbucket",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22019,7 +21965,6 @@
       }
     },
     "packages/store-file-system": {
-      "name": "@indiekit/store-file-system",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22030,7 +21975,6 @@
       }
     },
     "packages/store-ftp": {
-      "name": "@indiekit/store-ftp",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22042,7 +21986,6 @@
       }
     },
     "packages/store-gitea": {
-      "name": "@indiekit/store-gitea",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22054,7 +21997,6 @@
       }
     },
     "packages/store-github": {
-      "name": "@indiekit/store-github",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22066,7 +22008,6 @@
       }
     },
     "packages/store-gitlab": {
-      "name": "@indiekit/store-gitlab",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22078,7 +22019,6 @@
       }
     },
     "packages/syndicator-internet-archive": {
-      "name": "@indiekit/syndicator-internet-archive",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22090,7 +22030,6 @@
       }
     },
     "packages/syndicator-mastodon": {
-      "name": "@indiekit/syndicator-mastodon",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -22105,7 +22044,6 @@
       }
     },
     "packages/syndicator-twitter": {
-      "name": "@indiekit/syndicator-twitter",
       "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {

--- a/packages/endpoint-media/lib/file.js
+++ b/packages/endpoint-media/lib/file.js
@@ -4,7 +4,7 @@ import { randomString } from "./utils.js";
 
 /**
  * Derive properties from file data
- * @param {object} publication - Publication configuration
+ * @param {object} timeZone - Application time zone
  * @param {object} file - Original file object
  * @returns {Promise<object>} File properties
  * @example fileData('brighton-pier.jpg') => {
@@ -16,9 +16,7 @@ import { randomString } from "./utils.js";
  *   published: '2020-07-19T22:59:23.497Z',
  * }
  */
-export const getFileProperties = async (publication, file) => {
-  const { timeZone } = publication;
-
+export const getFileProperties = async (timeZone, file) => {
   const basename = randomString();
   const { ext } = await fileTypeFromBuffer(file.data);
   const published = getPublishedProperty(timeZone);

--- a/packages/endpoint-media/lib/media-data.js
+++ b/packages/endpoint-media/lib/media-data.js
@@ -11,11 +11,11 @@ export const mediaData = {
    * @returns {Promise<object>} Media data
    */
   async create(application, publication, file) {
-    const { media } = application;
+    const { media, timeZone } = application;
     const { me, postTypes } = publication;
 
     // Media properties
-    const properties = await getFileProperties(publication, file);
+    const properties = await getFileProperties(timeZone, file);
 
     // Get post type configuration
     const type = await getMediaType(file);
@@ -34,11 +34,11 @@ export const mediaData = {
     }
 
     // Media paths
-    const path = renderPath(typeConfig.media.path, properties, publication);
+    const path = renderPath(typeConfig.media.path, properties, application);
     const url = renderPath(
       typeConfig.media.url || typeConfig.media.path,
       properties,
-      publication
+      application
     );
     properties.url = getPermalink(me, url);
 

--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -15,10 +15,10 @@ export const randomString = () => Math.random().toString(36).slice(-5);
  * Render path from URI template and properties
  * @param {string} path - URI template path
  * @param {object} properties - Properties to use
- * @param {object} publication - Publication configuration
+ * @param {object} application - Application configuration
  * @returns {string} Path
  */
-export const renderPath = (path, properties, publication) => {
+export const renderPath = (path, properties, application) => {
   let tokens = {};
   const dateObject = new Date(properties.published);
   const serverTimeZone = getServerTimeZone();
@@ -51,9 +51,9 @@ export const renderPath = (path, properties, publication) => {
   for (const dateToken of dateTokens) {
     tokens[dateToken] = format(dateObject, dateToken, {
       timeZone:
-        publication.timeZone === "server"
+        application.timeZone === "server"
           ? serverTimeZone
-          : publication.timeZone,
+          : application.timeZone,
       // @ts-ignore (https://github.com/marnusw/date-fns-tz/issues/239)
       useAdditionalDayOfYearTokens: true,
     });

--- a/packages/endpoint-media/tests/unit/file.js
+++ b/packages/endpoint-media/tests/unit/file.js
@@ -18,12 +18,11 @@ test("Derives media type and returns equivalent post type", async (t) => {
 });
 
 test("Derives properties from file data", async (t) => {
-  const publication = { timeZone: "UTC" };
   const file = {
     data: getFixture("file-types/photo.jpg", null),
     name: "photo.jpg",
   };
-  const result = await getFileProperties(publication, file);
+  const result = await getFileProperties("UTC", file);
 
   t.is(result.originalname, "photo.jpg");
   t.is(result.ext, "jpg");

--- a/packages/endpoint-media/tests/unit/utils.js
+++ b/packages/endpoint-media/tests/unit/utils.js
@@ -38,8 +38,8 @@ test("Renders path from URI template and properties", (t) => {
     published: "2020-01-01",
     "mp-slug": "foo",
   };
-  const publication = {};
-  const result = renderPath(template, properties, publication);
+  const application = {};
+  const result = renderPath(template, properties, application);
 
   t.regex(
     result,

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -15,7 +15,7 @@ export const postData = {
    * @returns {Promise<object>} Post data
    */
   async create(application, publication, properties, draftMode = false) {
-    const { posts } = application;
+    const { posts, timeZone } = application;
     const { me, postTypes, syndicationTargets } = publication;
 
     // Add syndication targets
@@ -28,7 +28,7 @@ export const postData = {
     properties = normaliseProperties(publication, properties);
 
     // Add published date (or use that provided by client)
-    properties.published = getDate(publication.timeZone, properties.published);
+    properties.published = getDate(timeZone, properties.published);
 
     // Post type
     const type = getPostType(properties);
@@ -44,9 +44,9 @@ export const postData = {
     const path = await renderPath(
       typeConfig.post.path,
       properties,
-      publication
+      application
     );
-    const url = await renderPath(typeConfig.post.url, properties, publication);
+    const url = await renderPath(typeConfig.post.url, properties, application);
     properties.url = getPermalink(me, url);
 
     // Post status
@@ -91,7 +91,7 @@ export const postData = {
    * @returns {Promise<object>} Post data
    */
   async update(application, publication, url, operation) {
-    const { posts } = application;
+    const { posts, timeZone } = application;
     const { me, postTypes } = publication;
 
     // Read properties
@@ -118,7 +118,7 @@ export const postData = {
     properties = normaliseProperties(publication, properties);
 
     // Add updated date
-    properties.updated = getDate(publication.timeZone);
+    properties.updated = getDate(timeZone);
 
     // Post type
     const type = getPostType(properties);
@@ -129,12 +129,12 @@ export const postData = {
     const path = await renderPath(
       typeConfig.post.path,
       properties,
-      publication
+      application
     );
     const updatedUrl = await renderPath(
       typeConfig.post.url,
       properties,
-      publication
+      application
     );
     properties.url = getPermalink(me, updatedUrl);
 
@@ -156,7 +156,7 @@ export const postData = {
    * @returns {Promise<object>} Post data
    */
   async delete(application, publication, url) {
-    const { posts } = application;
+    const { posts, timeZone } = application;
     const { postTypes } = publication;
 
     // Read properties
@@ -173,7 +173,7 @@ export const postData = {
     }
 
     // Add deleted date
-    properties.deleted = getDate(publication.timeZone);
+    properties.deleted = getDate(timeZone);
 
     // Post type
     const typeConfig = getPostTypeConfig(properties["post-type"], postTypes);
@@ -182,7 +182,7 @@ export const postData = {
     const path = await renderPath(
       typeConfig.post.path,
       properties,
-      publication
+      application
     );
 
     // Update data in posts collection
@@ -220,7 +220,7 @@ export const postData = {
     const path = await renderPath(
       typeConfig.post.path,
       properties,
-      publication
+      application
     );
 
     // Post status

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -97,10 +97,10 @@ export const relativeMediaPath = (url, me) =>
  * Render path from URI template and properties
  * @param {string} path - URI template path
  * @param {object} properties - Properties to use
- * @param {object} publication - Publication configuration
+ * @param {object} application - Application configuration
  * @returns {Promise<string>} Path
  */
-export const renderPath = async (path, properties, publication) => {
+export const renderPath = async (path, properties, application) => {
   const dateObject = new Date(properties.published);
   const serverTimeZone = getServerTimeZone();
   const dateTokens = [
@@ -134,9 +134,9 @@ export const renderPath = async (path, properties, publication) => {
   for (const dateToken of dateTokens) {
     tokens[dateToken] = format(dateObject, dateToken, {
       timeZone:
-        publication.timeZone === "server"
+        application.timeZone === "server"
           ? serverTimeZone
-          : publication.timeZone,
+          : application.timeZone,
       // @ts-ignore (https://github.com/marnusw/date-fns-tz/issues/239)
       useAdditionalDayOfYearTokens: true,
     });
@@ -146,7 +146,7 @@ export const renderPath = async (path, properties, publication) => {
   tokens.D60 = newbase60.DateToSxg(dateObject); // eslint-disable-line new-cap
 
   // Add count of post-type for the day
-  const count = await postTypeCount.get(publication, properties);
+  const count = await postTypeCount.get(application, properties);
   tokens.n = count + 1;
 
   // Add slug token if 'mp-slug' property

--- a/packages/endpoint-micropub/tests/unit/jf2.js
+++ b/packages/endpoint-micropub/tests/unit/jf2.js
@@ -26,7 +26,6 @@ test.beforeEach((t) => {
           info: { uid: "https://social.example/" },
         },
       ],
-      timeZone: "UTC",
     },
   };
 });

--- a/packages/endpoint-micropub/tests/unit/utils.js
+++ b/packages/endpoint-micropub/tests/unit/utils.js
@@ -72,7 +72,7 @@ test("Renders path from URI template and properties", async (t) => {
     published: "2020-01-01",
     "mp-slug": "foo",
   };
-  const publication = {
+  const application = {
     posts: {
       aggregate: () => ({
         toArray: async () => [],
@@ -88,7 +88,7 @@ test("Renders path from URI template and properties", async (t) => {
       },
     },
   };
-  const result = await renderPath(template, properties, publication);
+  const result = await renderPath(template, properties, application);
 
   t.regex(
     result,

--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -29,6 +29,7 @@ export const defaultConfig = {
     repository: package_.repository,
     themeColor: "#04f",
     themeColorScheme: "automatic",
+    timeZone: "UTC",
     ttl: 604_800, // 7 days
     version: package_.version,
   },
@@ -53,7 +54,6 @@ export const defaultConfig = {
     storeMessageTemplate: (metaData) =>
       `${metaData.action} ${metaData.postType} ${metaData.fileType}`,
     syndicationTargets: [],
-    timeZone: "UTC",
   },
 };
 

--- a/packages/indiekit/locales/de.json
+++ b/packages/indiekit/locales/de.json
@@ -55,6 +55,7 @@
         "dark": "Dunkel",
         "light": "Licht"
       },
+      "timeZone": "Zeitzone",
       "tokenEndpoint": "Token-Endpunkt",
       "version": "Version"
     },
@@ -65,8 +66,7 @@
       "preset": "Voreinstellung",
       "store": "Inhaltsspeicher",
       "summaryTitle": "Veröffentlichungseinstellungen",
-      "syndicationTargets": "Syndikationsziele",
-      "timeZone": "Zeitzone"
+      "syndicationTargets": "Syndikationsziele"
     },
     "title": "Server Status"
   }

--- a/packages/indiekit/locales/en.json
+++ b/packages/indiekit/locales/en.json
@@ -53,13 +53,13 @@
         "light": "Light",
         "dark": "Dark"
       },
+      "timeZone": "Time zone",
       "version": "Version"
     },
     "publication": {
       "summaryTitle": "Publication settings",
       "me": "Web address",
       "locale": "Language",
-      "timeZone": "Time zone",
       "store": "Content store",
       "preset": "Preset",
       "postTypes": "Post types",

--- a/packages/indiekit/locales/es.json
+++ b/packages/indiekit/locales/es.json
@@ -55,6 +55,7 @@
         "dark": "Oscuro",
         "light": "Claro"
       },
+      "timeZone": "Zona horaria",
       "tokenEndpoint": "Punto final de token",
       "version": "Versión"
     },
@@ -65,8 +66,7 @@
       "preset": "Preestablecido",
       "store": "Almacén de contenido",
       "summaryTitle": "Configuración de publicación",
-      "syndicationTargets": "Objetivos de sindicación",
-      "timeZone": "Zona horaria"
+      "syndicationTargets": "Objetivos de sindicación"
     },
     "title": "Estado del servidor"
   }

--- a/packages/indiekit/locales/fr.json
+++ b/packages/indiekit/locales/fr.json
@@ -55,6 +55,7 @@
         "dark": "Sombre",
         "light": "Lumière"
       },
+      "timeZone": "Fuseau horaire",
       "tokenEndpoint": "Endpoint de jeton",
       "version": "Version"
     },
@@ -65,8 +66,7 @@
       "preset": "Préréglage",
       "store": "Magasin de contenu",
       "summaryTitle": "Paramètres de publication",
-      "syndicationTargets": "Cibles de syndication",
-      "timeZone": "Fuseau horaire"
+      "syndicationTargets": "Cibles de syndication"
     },
     "title": "Statut du serveur"
   }

--- a/packages/indiekit/locales/id.json
+++ b/packages/indiekit/locales/id.json
@@ -55,6 +55,7 @@
         "dark": "Gelap",
         "light": "Terang"
       },
+      "timeZone": "Zona Waktu",
       "tokenEndpoint": "Titik akhir Token",
       "version": "Versi"
     },
@@ -65,8 +66,7 @@
       "preset": "Prasetel",
       "store": "Penyimpanan Konten",
       "summaryTitle": "Pengaturan publikasi",
-      "syndicationTargets": "Sasaran sindikasi",
-      "timeZone": "Zona Waktu"
+      "syndicationTargets": "Sasaran sindikasi"
     },
     "title": "Status server"
   }

--- a/packages/indiekit/locales/nl.json
+++ b/packages/indiekit/locales/nl.json
@@ -55,6 +55,7 @@
         "dark": "Donker",
         "light": "Licht"
       },
+      "timeZone": "Tijdzone",
       "tokenEndpoint": "Token-eindpunt",
       "version": "Versie"
     },
@@ -65,8 +66,7 @@
       "preset": "Vooringestelde",
       "store": "Content store",
       "summaryTitle": "Publicatie-instellingen",
-      "syndicationTargets": "Syndicatiedoelen",
-      "timeZone": "Tijdzone"
+      "syndicationTargets": "Syndicatiedoelen"
     },
     "title": "Status server"
   }

--- a/packages/indiekit/locales/pl.json
+++ b/packages/indiekit/locales/pl.json
@@ -55,6 +55,7 @@
         "dark": "Ciemny",
         "light": "Jasny"
       },
+      "timeZone": "Strefa czasowa",
       "tokenEndpoint": "Punkt końcowy tokena",
       "version": "Wersja"
     },
@@ -65,8 +66,7 @@
       "preset": "Szablon",
       "store": "Sklep z treściami",
       "summaryTitle": "Ustawienia publikacji",
-      "syndicationTargets": "Cele syndykacji",
-      "timeZone": "Strefa czasowa"
+      "syndicationTargets": "Cele syndykacji"
     },
     "title": "Status serwera"
   }

--- a/packages/indiekit/locales/pt.json
+++ b/packages/indiekit/locales/pt.json
@@ -55,6 +55,7 @@
         "dark": "Escuro",
         "light": "Luz"
       },
+      "timeZone": "Fuso horário",
       "tokenEndpoint": "Endpoint de token",
       "version": "Versão"
     },
@@ -65,8 +66,7 @@
       "preset": "Pré-ajuste",
       "store": "Loja de conteúdo",
       "summaryTitle": "Configurações de publicação",
-      "syndicationTargets": "Locais de distribuição",
-      "timeZone": "Fuso horário"
+      "syndicationTargets": "Locais de distribuição"
     },
     "title": "Status do servidor"
   }

--- a/packages/indiekit/locales/sr.json
+++ b/packages/indiekit/locales/sr.json
@@ -55,6 +55,7 @@
         "dark": "Mrak",
         "light": "Svetlo"
       },
+      "timeZone": "Vremenska zona",
       "tokenEndpoint": "Krajnja tačka tokena",
       "version": "Verzija"
     },
@@ -65,8 +66,7 @@
       "preset": "Postavljeno unapred",
       "store": "Prodavnica sadržaja",
       "summaryTitle": "Podešavanja publikacije",
-      "syndicationTargets": "Ciljevi sindikacije",
-      "timeZone": "Vremenska zona"
+      "syndicationTargets": "Ciljevi sindikacije"
     },
     "title": "Status servera"
   }

--- a/packages/indiekit/locales/zh-Hans-CN.json
+++ b/packages/indiekit/locales/zh-Hans-CN.json
@@ -55,6 +55,7 @@
         "dark": "深色",
         "light": "浅色"
       },
+      "timeZone": "时区",
       "tokenEndpoint": "令牌终端节点",
       "version": "版本"
     },
@@ -65,8 +66,7 @@
       "preset": "预设",
       "store": "内容存储",
       "summaryTitle": "发布设置",
-      "syndicationTargets": "内容联合目标",
-      "timeZone": "时区"
+      "syndicationTargets": "内容联合目标"
     },
     "title": "服务器状态"
   }

--- a/packages/indiekit/views/status.njk
+++ b/packages/indiekit/views/status.njk
@@ -73,13 +73,6 @@
         }
       }, {
         key: {
-          text: __("status.publication.timeZone")
-        },
-        value: {
-          text: publication.timeZone
-        }
-      }, {
-        key: {
           text: __("status.publication.preset")
         },
         value: {
@@ -134,6 +127,13 @@
         },
         value: {
           text: localeHtml
+        }
+      }, {
+        key: {
+          text: __("status.application.timeZone")
+        },
+        value: {
+          text: application.timeZone
         }
       }, {
         key: {


### PR DESCRIPTION
In 1d69a37fac4ad5b3036981af111261f2ae82cbae I moved the `posts` and `media` content databases to the `application` settings object, away from `publication`.

In doing this, I missed updating `renderPath()` with should have been updated to take the `application` object. However, to correct this, I’d then need to provide both the `application` and `publication` objects to `renderPath()` as this needs `publication.timeZone`. Which got me thinking; maybe the `timeZone` setting belongs on the application object, too. This PR does that.

**This is a breaking change** but will ship in the next beta with a warning to update `publication.timeZone` to `application.timeZone`, if set.

(Having essentially 2 objects to store different settings may have been a bad idea… but something to think about at a later date).