### PR TITLE
Add post (media) count token to media endpoint

### DIFF
--- a/docs/configuration/post-types.md
+++ b/docs/configuration/post-types.md
@@ -75,7 +75,7 @@ Values for `*.path` and `*.url` can be customised using the following tokens:
 | `T` | `post` `media` | UNIX epoch milliseconds, eg <samp>51296952000</samp> |
 | `uuid` | `post` `media` | A [random UUID][uuid] |
 | `slug` | `post` | Provided slug, slugified `name` or a 5 character string, eg <samp>ycf9o</samp> |
-| `n`[^1] | `post` | Incremental count of posts (for type) in the same day, eg <samp>1</samp> |
+| `n`[^1] | `post` `media` | Incremental count of posts (for type) in the same day, eg <samp>1</samp> |
 | `basename` | `media` | 5 character alpha-numeric string, eg <samp>w9gwi</samp> |
 | `ext` | `media` | File extension of uploaded file, eg <samp>jpg</samp> |
 | `filename` | `media` | `basename` plus `ext`, eg <samp>w9gwi.jpg</samp> |

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -62,7 +62,7 @@ The following [scopes](https://indieweb.org/scope) are supported:
 * [x] [Offset](https://github.com/indieweb/micropub-extensions/issues/36) query parameter
 * [x] [Delete media](https://github.com/indieweb/micropub-extensions/issues/30)
 
-[^1]: A media endpoint source query includes the following properties in its [response](https://github.com/indieweb/micropub-extensions/issues/13): `content-type`, `published`, `post-type` and `url`.
+[^1]: A media endpoint source query includes the following properties in its [response](https://github.com/indieweb/micropub-extensions/issues/13): `content-type`, `media-type`, `published` and `url`.
 
 ### Server commands
 

--- a/helpers/media-data/index.js
+++ b/helpers/media-data/index.js
@@ -2,7 +2,7 @@ export const mediaData = {
   path: "photo.jpg",
   properties: {
     "content-type": "image/jpeg",
-    "post-type": "photo",
+    "media-type": "photo",
     published: "2020-01-01T00:00:00+00:00",
     url: "https://website.example/photo.jpg",
   },

--- a/packages/endpoint-files/lib/controllers/files.js
+++ b/packages/endpoint-files/lib/controllers/files.js
@@ -31,7 +31,7 @@ export const filesController = async (request, response, next) => {
     if (mediaResponse?.items?.length > 0) {
       files = mediaResponse.items.map((item) => {
         item.id = getFileId(item.url);
-        item.icon = item["post-type"];
+        item.icon = item["media-type"];
         item.photo = {
           url: item.url,
         };

--- a/packages/endpoint-files/views/file.njk
+++ b/packages/endpoint-files/views/file.njk
@@ -1,7 +1,7 @@
 {% extends "document.njk" %}
 
 {% block content %}
-  {% set type = file["post-type"] %}
+  {% set type = file["media-type"] %}
   {% if type === "audio" %}
     <audio src="{{ file.url }}" controls></audio>
   {% elif type === "photo" %}

--- a/packages/endpoint-media/lib/controllers/query.js
+++ b/packages/endpoint-media/lib/controllers/query.js
@@ -33,7 +33,7 @@ export const queryController = async (request, response, next) => {
             {
               projection: {
                 "properties.content-type": 1,
-                "properties.post-type": 1,
+                "properties.media-type": 1,
                 "properties.published": 1,
                 "properties.url": 1,
               },
@@ -59,7 +59,7 @@ export const queryController = async (request, response, next) => {
           response.json({
             items: cursor.items.map((post) => ({
               "content-type": post.properties["content-type"],
-              "post-type": post.properties["post-type"],
+              "media-type": post.properties["media-type"],
               published: post.properties.published,
               url: post.properties.url,
             })),

--- a/packages/endpoint-media/lib/media-content.js
+++ b/packages/endpoint-media/lib/media-content.js
@@ -12,7 +12,7 @@ export const mediaContent = {
       action: "upload",
       result: "uploaded",
       fileType: "file",
-      postType: mediaData.properties["post-type"],
+      postType: mediaData.properties["media-type"],
     };
     const message = storeMessageTemplate(metaData);
 
@@ -40,7 +40,7 @@ export const mediaContent = {
       action: "delete",
       result: "deleted",
       fileType: "file",
-      postType: mediaData.properties["post-type"],
+      postType: mediaData.properties["media-type"],
     };
     const message = storeMessageTemplate(metaData);
 

--- a/packages/endpoint-media/lib/media-data.js
+++ b/packages/endpoint-media/lib/media-data.js
@@ -19,7 +19,7 @@ export const mediaData = {
 
     // Get post type configuration
     const type = await getMediaType(file);
-    properties["post-type"] = type;
+    properties["media-type"] = type;
 
     // Throw error if trying to create unsupported media
     const supportedMediaTypes = ["audio", "photo", "video"];

--- a/packages/endpoint-media/lib/media-data.js
+++ b/packages/endpoint-media/lib/media-data.js
@@ -34,8 +34,12 @@ export const mediaData = {
     }
 
     // Media paths
-    const path = renderPath(typeConfig.media.path, properties, application);
-    const url = renderPath(
+    const path = await renderPath(
+      typeConfig.media.path,
+      properties,
+      application
+    );
+    const url = await renderPath(
       typeConfig.media.url || typeConfig.media.path,
       properties,
       application

--- a/packages/endpoint-media/lib/media-type-count.js
+++ b/packages/endpoint-media/lib/media-type-count.js
@@ -16,7 +16,7 @@ export const mediaTypeCount = {
     }
 
     // Post type
-    const postType = properties["post-type"];
+    const postType = properties["media-type"];
     const startDate = new Date(new Date(properties.published).toDateString());
     const endDate = new Date(startDate);
     endDate.setDate(endDate.getDate() + 1);

--- a/packages/endpoint-media/lib/media-type-count.js
+++ b/packages/endpoint-media/lib/media-type-count.js
@@ -1,0 +1,45 @@
+export const mediaTypeCount = {
+  /**
+   * Count the number of media of a given type
+   * @param {object} application - Application configuration
+   * @param {object} properties - JF2 properties
+   * @returns {Promise<object>} Media count
+   */
+  async get(application, properties) {
+    if (!application.posts || !application.posts.count()) {
+      console.warn("No database configuration provided");
+      console.info(
+        "See https://getindiekit.com/configuration/#application-mongodburl-url"
+      );
+
+      return;
+    }
+
+    // Post type
+    const postType = properties["post-type"];
+    const startDate = new Date(new Date(properties.published).toDateString());
+    const endDate = new Date(startDate);
+    endDate.setDate(endDate.getDate() + 1);
+    const response = await application.posts
+      .aggregate([
+        {
+          $addFields: {
+            convertedDate: {
+              $toDate: "$properties.published",
+            },
+          },
+        },
+        {
+          $match: {
+            "properties.post-type": postType,
+            convertedDate: {
+              $gte: startDate,
+              $lt: endDate,
+            },
+          },
+        },
+      ])
+      .toArray();
+    return response.length;
+  },
+};

--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -63,7 +63,7 @@ export const renderPath = async (path, properties, application) => {
   // Add day of the year (NewBase60) token
   tokens.D60 = newbase60.DateToSxg(dateObject); // eslint-disable-line new-cap
 
-  // Add count of post-type for the day
+  // Add count of media type for the day
   const count = await mediaTypeCount.get(application, properties);
   tokens.n = count + 1;
 

--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { format } from "date-fns-tz";
 import newbase60 from "newbase60";
 import { getServerTimeZone } from "./date.js";
+import { mediaTypeCount } from "./media-type-count.js";
 
 /**
  * Generate random alpha-numeric string, 5 characters long
@@ -16,9 +17,9 @@ export const randomString = () => Math.random().toString(36).slice(-5);
  * @param {string} path - URI template path
  * @param {object} properties - Properties to use
  * @param {object} application - Application configuration
- * @returns {string} Path
+ * @returns {Promise<string>} Path
  */
-export const renderPath = (path, properties, application) => {
+export const renderPath = async (path, properties, application) => {
   let tokens = {};
   const dateObject = new Date(properties.published);
   const serverTimeZone = getServerTimeZone();
@@ -61,6 +62,10 @@ export const renderPath = (path, properties, application) => {
 
   // Add day of the year (NewBase60) token
   tokens.D60 = newbase60.DateToSxg(dateObject); // eslint-disable-line new-cap
+
+  // Add count of post-type for the day
+  const count = await mediaTypeCount.get(application, properties);
+  tokens.n = count + 1;
 
   // Add slug token if 'mp-slug' property
   if (properties["mp-slug"]) {

--- a/packages/endpoint-media/tests/unit/media-data.js
+++ b/packages/endpoint-media/tests/unit/media-data.js
@@ -23,7 +23,7 @@ test.beforeEach((t) => {
             return {
               path: "photo.jpg",
               properties: {
-                "post-type": "photo",
+                "media-type": "photo",
                 url: url["properties.url"],
               },
             };
@@ -48,7 +48,7 @@ test("Creates media data", async (t) => {
   );
 
   t.regex(result.path, /\b[\d\w]{5}\b/g);
-  t.is(result.properties["post-type"], "photo");
+  t.is(result.properties["media-type"], "photo");
 });
 
 test("Throws error creating media data for unsupported media type", async (t) => {
@@ -83,7 +83,7 @@ test("Throws error creating media data for non-configured media type", async (t)
 test("Reads media data", async (t) => {
   const result = await mediaData.read(t.context.application, t.context.url);
 
-  t.is(result.properties["post-type"], "photo");
+  t.is(result.properties["media-type"], "photo");
   t.is(result.properties.url, "https://website.example/photo.jpg");
 });
 

--- a/packages/endpoint-media/tests/unit/media-type-count.js
+++ b/packages/endpoint-media/tests/unit/media-type-count.js
@@ -1,0 +1,45 @@
+import test from "ava";
+import JekyllPreset from "@indiekit/preset-jekyll";
+import { mediaTypeCount } from "../../lib/media-type-count.js";
+
+test.beforeEach((t) => {
+  t.context = {
+    properties: {
+      type: "entry",
+      published: new Date(),
+      name: "Bar",
+      "mp-slug": "bar",
+      "post-type": "note",
+    },
+    application: {
+      me: "https://website.example",
+      postTypes: new JekyllPreset().postTypes,
+      posts: {
+        aggregate: () => ({
+          toArray: async () => [
+            {
+              type: "entry",
+              published: new Date(),
+              name: "Foo",
+              "mp-slug": "foo",
+              "post-type": "note",
+            },
+          ],
+        }),
+        count() {
+          return 1;
+        },
+      },
+    },
+    url: "https://website.example/foo",
+  };
+});
+
+test("Counts the number of media of a given type", async (t) => {
+  const result = await mediaTypeCount.get(
+    t.context.application,
+    t.context.properties
+  );
+
+  t.is(result, 1);
+});

--- a/packages/endpoint-media/tests/unit/utils.js
+++ b/packages/endpoint-media/tests/unit/utils.js
@@ -32,14 +32,14 @@ test("Generates random alpha-numeric string, 5 characters long", (t) => {
   t.regex(randomString(), /[\d\w]{5}/g);
 });
 
-test("Renders path from URI template and properties", (t) => {
+test("Renders path from URI template and properties", async (t) => {
   const template = "{yyyy}/{MM}/{uuid}/{slug}";
   const properties = {
     published: "2020-01-01",
     "mp-slug": "foo",
   };
   const application = {};
-  const result = renderPath(template, properties, application);
+  const result = await renderPath(template, properties, application);
 
   t.regex(
     result,


### PR DESCRIPTION
Fixes #606.

Gets the post count by looking up the `post-type` property based on a media item’s `media-type` property.

Not sure if this’ll work though as it depends on a post being published _before_ the corresponding media item(s) is uploaded; the micropub media endpoint is asynchronous, and will publish media before a post has been sent to the server.