### PR TITLE
Consolidate URL utility functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2129,6 +2129,10 @@
       "resolved": "packages/syndicator-twitter",
       "link": true
     },
+    "node_modules/@indiekit/util": {
+      "resolved": "packages/util",
+      "link": true
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -22130,6 +22134,7 @@
         "@indiekit/store-gitlab": "^1.0.0-beta.4",
         "@indiekit/syndicator-mastodon": "^1.0.0-beta.4",
         "@indiekit/syndicator-twitter": "^1.0.0-beta.4",
+        "@indiekit/util": "^1.0.0-beta.4",
         "base-create": "^3.0.7",
         "chalk": "^5.0.0",
         "prompts": "^2.4.2"
@@ -22158,6 +22163,7 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.3",
+        "@indiekit/util": "^1.0.0-beta.4",
         "bcrypt": "^5.1.0",
         "express": "^4.17.1",
         "express-validator": "^7.0.0",
@@ -22341,6 +22347,7 @@
         "@indiekit/endpoint-syndicate": "^1.0.0-beta.4",
         "@indiekit/frontend": "^1.0.0-beta.4",
         "@indiekit/preset-jekyll": "^1.0.0-beta.4",
+        "@indiekit/util": "^1.0.0-beta.4",
         "clean-stack": "^5.0.0",
         "commander": "^11.0.0",
         "cookie-session": "^2.0.0",
@@ -22555,6 +22562,14 @@
         "twitter-lite": "^1.1.0",
         "undici": "^5.2.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/util": {
+      "name": "@indiekit/util",
+      "version": "1.0.0-beta.4",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }

--- a/packages/create-indiekit/lib/setup-prompts.js
+++ b/packages/create-indiekit/lib/setup-prompts.js
@@ -1,4 +1,4 @@
-import { isUrl } from "./utils.js";
+import { isUrl } from "@indiekit/util";
 
 export const setupPrompts = [
   {

--- a/packages/create-indiekit/lib/utils.js
+++ b/packages/create-indiekit/lib/utils.js
@@ -44,24 +44,6 @@ export const checkNodeVersion = (currentVersion, minimumMajorVersion) => {
 };
 
 /**
- * Check if given string is a valid URL
- * @param {object} string - URL
- * @returns {boolean} String is a URL
- */
-export const isUrl = (string) => {
-  if (typeof string !== "string") {
-    throw new TypeError("Expected a string");
-  }
-
-  try {
-    new URL(decodeURIComponent(string)); // eslint-disable-line no-new
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-/**
  * Get question prompts specified by plugin
  * @param {string} pluginName - Plug-in name
  * @returns {Promise<object>} Plug-in

--- a/packages/create-indiekit/package.json
+++ b/packages/create-indiekit/package.json
@@ -44,6 +44,7 @@
     "@indiekit/store-gitlab": "^1.0.0-beta.4",
     "@indiekit/syndicator-mastodon": "^1.0.0-beta.4",
     "@indiekit/syndicator-twitter": "^1.0.0-beta.4",
+    "@indiekit/util": "^1.0.0-beta.4",
     "base-create": "^3.0.7",
     "chalk": "^5.0.0",
     "prompts": "^2.4.2"

--- a/packages/create-indiekit/tests/unit/utils.js
+++ b/packages/create-indiekit/tests/unit/utils.js
@@ -5,7 +5,6 @@ import {
   addPluginConfig,
   checkNodeVersion,
   getPlugin,
-  isUrl,
 } from "../../lib/utils.js";
 
 test("Adds plug-in to Indiekit configuration", async (t) => {
@@ -35,22 +34,4 @@ test("Gets question prompts specified by plug-in", async (t) => {
   t.is(name, "Hugo preset");
   t.is(prompts[0].message, "Which front matter format are you using?");
   t.is(prompts[0].type, "select");
-});
-
-test("Checks if given string is a valid URL", (t) => {
-  t.true(isUrl("https%3A%2F%2Ffoo.bar"));
-  t.true(isUrl("https://foo.bar"));
-  t.false(isUrl("foo.bar"));
-});
-
-test("Throws error given URL is not a string", (t) => {
-  t.throws(
-    () => {
-      isUrl({});
-    },
-    {
-      instanceOf: TypeError,
-      message: "Expected a string",
-    }
-  );
 });

--- a/packages/endpoint-auth/lib/controllers/authorization.js
+++ b/packages/endpoint-auth/lib/controllers/authorization.js
@@ -1,8 +1,9 @@
 import { IndiekitError } from "@indiekit/error";
+import { isUrl } from "@indiekit/util";
 import { getClientInformation } from "../client.js";
 import { createRequestUri } from "../pushed-authorization-request.js";
 import { validateRedirect } from "../redirect.js";
-import { getCanonicalUrl, isUrl } from "../utils.js";
+import { getCanonicalUrl } from "../utils.js";
 
 export const authorizationController = {
   /**

--- a/packages/endpoint-auth/lib/controllers/authorization.js
+++ b/packages/endpoint-auth/lib/controllers/authorization.js
@@ -1,9 +1,8 @@
 import { IndiekitError } from "@indiekit/error";
-import { isUrl } from "@indiekit/util";
+import { getCanonicalUrl, isUrl } from "@indiekit/util";
 import { getClientInformation } from "../client.js";
 import { createRequestUri } from "../pushed-authorization-request.js";
 import { validateRedirect } from "../redirect.js";
-import { getCanonicalUrl } from "../utils.js";
 
 export const authorizationController = {
   /**

--- a/packages/endpoint-auth/lib/middleware/code.js
+++ b/packages/endpoint-auth/lib/middleware/code.js
@@ -1,8 +1,9 @@
 import { IndiekitError } from "@indiekit/error";
+import { getCanonicalUrl } from "@indiekit/util";
 import { verifyCode } from "../pkce.js";
 import { validateRedirect } from "../redirect.js";
 import { verifyToken } from "../token.js";
-import { getCanonicalUrl, getRequestParameters } from "../utils.js";
+import { getRequestParameters } from "../utils.js";
 
 /**
  * Validate authorization code before redeeming

--- a/packages/endpoint-auth/lib/utils.js
+++ b/packages/endpoint-auth/lib/utils.js
@@ -28,21 +28,3 @@ export const getRequestParameters = (request) => {
 
   return request.query;
 };
-
-/**
- * Check if given string is a valid URL
- * @param {object} string - URL
- * @returns {boolean} String is a URL
- */
-export const isUrl = (string) => {
-  if (typeof string !== "string") {
-    throw new TypeError("Expected a string");
-  }
-
-  try {
-    new URL(decodeURIComponent(string)); // eslint-disable-line no-new
-    return true;
-  } catch {
-    return false;
-  }
-};

--- a/packages/endpoint-auth/lib/utils.js
+++ b/packages/endpoint-auth/lib/utils.js
@@ -1,14 +1,6 @@
 import { randomBytes } from "node:crypto";
 
 /**
- * Canonicalise URL according to IndieAuth spec
- * @param {string} url - The URL to canonicalise
- * @returns {string} The canonicalised URL
- * @see {@link https://indieauth.spec.indieweb.org/#url-canonicalization}
- */
-export const getCanonicalUrl = (url) => new URL(url).href;
-
-/**
  * Generate cryptographically random string
  * @param {number} [length] - Length of string
  * @returns {string} Random string

--- a/packages/endpoint-auth/package.json
+++ b/packages/endpoint-auth/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.3",
+    "@indiekit/util": "^1.0.0-beta.4",
     "bcrypt": "^5.1.0",
     "express": "^4.17.1",
     "express-validator": "^7.0.0",

--- a/packages/endpoint-auth/tests/unit/utils.js
+++ b/packages/endpoint-auth/tests/unit/utils.js
@@ -1,9 +1,5 @@
 import test from "ava";
-import { getCanonicalUrl, getRequestParameters } from "../../lib/utils.js";
-
-test("Canonicalises URL", (t) => {
-  t.is(getCanonicalUrl("https://foo.bar"), "https://foo.bar/");
-});
+import { getRequestParameters } from "../../lib/utils.js";
 
 test("Gets request parameters from either query string or JSON body", (t) => {
   const resultBody = {

--- a/packages/endpoint-auth/tests/unit/utils.js
+++ b/packages/endpoint-auth/tests/unit/utils.js
@@ -1,9 +1,5 @@
 import test from "ava";
-import {
-  getCanonicalUrl,
-  getRequestParameters,
-  isUrl,
-} from "../../lib/utils.js";
+import { getCanonicalUrl, getRequestParameters } from "../../lib/utils.js";
 
 test("Canonicalises URL", (t) => {
   t.is(getCanonicalUrl("https://foo.bar"), "https://foo.bar/");
@@ -21,22 +17,4 @@ test("Gets request parameters from either query string or JSON body", (t) => {
 
   t.deepEqual(getRequestParameters(resultBody), { foo: "bar" });
   t.deepEqual(getRequestParameters(resultQuery), { foo: "bar" });
-});
-
-test("Checks if given string is a valid URL", (t) => {
-  t.true(isUrl("https%3A%2F%2Ffoo.bar"));
-  t.true(isUrl("https://foo.bar"));
-  t.false(isUrl("foo.bar"));
-});
-
-test("Throws error given URL is not a string", (t) => {
-  t.throws(
-    () => {
-      isUrl({});
-    },
-    {
-      instanceOf: TypeError,
-      message: "Expected a string",
-    }
-  );
 });

--- a/packages/endpoint-posts/views/post.njk
+++ b/packages/endpoint-posts/views/post.njk
@@ -4,15 +4,15 @@
 {% set postMedia -%}
 {%- if post.audio -%}
   {%- for item in post.audio -%}
-    <audio src="{{ item.url | absoluteUrl(publication.me) }}" controls>
+    <audio src="{{ item.url | url(publication.me) }}" controls>
   {%- endfor -%}
 {%- elif post.photo -%}
   {%- for item in post.photo -%}
-    <img src="{{ item.url | absoluteUrl(publication.me) }}" alt="{{ item.alt }}">
+    <img src="{{ item.url | url(publication.me) }}" alt="{{ item.alt }}">
   {%- endfor -%}
 {%- elif post.video -%}
   {% for item in post.video -%}
-    <video src="{{ item.url | absoluteUrl(publication.me) }}" controls>
+    <video src="{{ item.url | url(publication.me) }}" controls>
   {%- endfor -%}
 {%- endif -%}
 {%- endset %}

--- a/packages/frontend/lib/filters/index.js
+++ b/packages/frontend/lib/filters/index.js
@@ -1,5 +1,6 @@
+export { getCanonicalUrl as url } from "@indiekit/util";
 export { default as slugify } from "@sindresorhus/slugify";
 export { default as widont } from "widont";
 export { date, languageName, languageNativeName } from "./locale.js";
 export { excerpt, includes, linkTo, markdown } from "./string.js";
-export { absoluteUrl, friendlyUrl, imageUrl } from "./url.js";
+export { friendlyUrl, imageUrl } from "./url.js";

--- a/packages/frontend/lib/filters/url.js
+++ b/packages/frontend/lib/filters/url.js
@@ -1,22 +1,6 @@
 import path from "node:path";
 
 /**
- * Get absolute URL or path
- * @param {string} string - URL or path
- * @param {string} baseUrl - Base URL
- * @returns {string} Absolute URL
- */
-export const absoluteUrl = (string, baseUrl) => {
-  string = String(string);
-
-  try {
-    return new URL(string, baseUrl).href;
-  } catch {
-    return path.posix.join(baseUrl, string);
-  }
-};
-
-/**
  * Get friendly URL
  * @param {string} string - URL or path
  * @returns {string} Friendly URL

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",
+    "@indiekit/util": "^1.0.0-beta.4",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@sindresorhus/slugify": "^2.1.1",
     "color": "^4.0.1",

--- a/packages/frontend/tests/unit/filters/url.js
+++ b/packages/frontend/tests/unit/filters/url.js
@@ -1,29 +1,5 @@
 import test from "ava";
-import {
-  absoluteUrl,
-  friendlyUrl,
-  imageUrl,
-} from "../../../lib/filters/index.js";
-
-test("Gets absolute URL from path", (t) => {
-  t.is(
-    absoluteUrl("path1", "https://website.example"),
-    "https://website.example/path1"
-  );
-  t.is(
-    absoluteUrl("/path2", "https://website.example"),
-    "https://website.example/path2"
-  );
-  t.is(
-    absoluteUrl("https://website.example/path3", "https://website.example"),
-    "https://website.example/path3"
-  );
-});
-
-test("Gets absolute path from path", (t) => {
-  t.is(absoluteUrl("path1", "path"), "path/path1");
-  t.is(absoluteUrl("/path2", "path/path1"), "path/path1/path2");
-});
+import { friendlyUrl, imageUrl } from "../../../lib/filters/index.js";
 
 test("Gets friendly URL", (t) => {
   t.is(friendlyUrl("https://website.example/path"), "website.example/path");

--- a/packages/indiekit/lib/categories.js
+++ b/packages/indiekit/lib/categories.js
@@ -1,5 +1,5 @@
+import { isUrl } from "@indiekit/util";
 import { getCachedResponse } from "./cache.js";
-import { isUrl } from "./utils.js";
 
 /**
  * Return array of available categories. If not a simple array, fetch array

--- a/packages/indiekit/lib/endpoints.js
+++ b/packages/indiekit/lib/endpoints.js
@@ -1,4 +1,5 @@
-import { isUrl, getUrl } from "./utils.js";
+import { isUrl } from "@indiekit/util";
+import { getUrl } from "./utils.js";
 
 /**
  * Get endpoint URLs from application configuration or default plug-ins

--- a/packages/indiekit/lib/indieauth.js
+++ b/packages/indiekit/lib/indieauth.js
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import process from "node:process";
 import { IndiekitError } from "@indiekit/error";
+import { getCanonicalUrl } from "@indiekit/util";
 import { fetch } from "undici";
 import {
   findBearerToken,
@@ -8,7 +9,7 @@ import {
   verifyTokenValues,
 } from "./token.js";
 import { generateState, validateState } from "./state.js";
-import { getCanonicalUrl, randomString } from "./utils.js";
+import { randomString } from "./utils.js";
 
 export const IndieAuth = class {
   constructor(options = {}) {

--- a/packages/indiekit/lib/token.js
+++ b/packages/indiekit/lib/token.js
@@ -1,6 +1,6 @@
 import { IndiekitError } from "@indiekit/error";
+import { getCanonicalUrl } from "@indiekit/util";
 import { fetch } from "undici";
-import { getCanonicalUrl } from "./utils.js";
 
 export const findBearerToken = (request) => {
   if (request.session?.access_token) {

--- a/packages/indiekit/lib/utils.js
+++ b/packages/indiekit/lib/utils.js
@@ -42,14 +42,6 @@ export const decrypt = (hash, iv) => {
 };
 
 /**
- * Canonicalise URL according to IndieAuth spec
- * @param {string} url - The URL to canonicalise
- * @returns {string} The canonicalised URL
- * @see {@link https://indieauth.spec.indieweb.org/#url-canonicalization}
- */
-export const getCanonicalUrl = (url) => new URL(url).href;
-
-/**
  * Get fully resolved server URL
  * @param {import("express").Request} request - Request
  * @returns {string} Fully resolved URL

--- a/packages/indiekit/lib/utils.js
+++ b/packages/indiekit/lib/utils.js
@@ -59,24 +59,6 @@ export const getUrl = (request) => {
 };
 
 /**
- * Check if given string is a valid URL
- * @param {object} string - URL
- * @returns {boolean} String is a URL
- */
-export const isUrl = (string) => {
-  if (typeof string !== "string") {
-    throw new TypeError("Expected a string");
-  }
-
-  try {
-    new URL(decodeURIComponent(string)); // eslint-disable-line no-new
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-/**
  * Get package JSON object
  * @param {string} fileUrl - File URL
  * @returns {object} package.json

--- a/packages/indiekit/package.json
+++ b/packages/indiekit/package.json
@@ -48,6 +48,7 @@
     "@indiekit/endpoint-syndicate": "^1.0.0-beta.4",
     "@indiekit/frontend": "^1.0.0-beta.4",
     "@indiekit/preset-jekyll": "^1.0.0-beta.4",
+    "@indiekit/util": "^1.0.0-beta.4",
     "clean-stack": "^5.0.0",
     "commander": "^11.0.0",
     "cookie-session": "^2.0.0",

--- a/packages/indiekit/tests/unit/utils.js
+++ b/packages/indiekit/tests/unit/utils.js
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import test from "ava";
-import { decrypt, encrypt, isUrl, getPackageData } from "../../lib/utils.js";
+import { decrypt, encrypt, getPackageData } from "../../lib/utils.js";
 
 test.beforeEach((t) => {
   t.context = {
@@ -15,24 +15,6 @@ test("Encrypts and decrypts a string", (t) => {
   const encryptedResult = encrypt("foo", t.context.iv);
   t.regex(encryptedResult, /[\da-fA-F]+/);
   t.is(decrypt(encryptedResult, t.context.iv), "foo");
-});
-
-test("Checks if given string is a valid URL", (t) => {
-  t.true(isUrl("https%3A%2F%2Ffoo.bar"));
-  t.true(isUrl("https://foo.bar"));
-  t.false(isUrl("foo.bar"));
-});
-
-test("Throws error given URL is not a string", (t) => {
-  t.throws(
-    () => {
-      isUrl({ url: "https://foo.bar" });
-    },
-    {
-      instanceOf: TypeError,
-      message: "Expected a string",
-    }
-  );
 });
 
 test("Gets package JSON object", (t) => {

--- a/packages/syndicator-mastodon/lib/mastodon.js
+++ b/packages/syndicator-mastodon/lib/mastodon.js
@@ -1,8 +1,8 @@
 /* eslint-disable camelcase */
-import { isSameOrigin } from "@indiekit/util";
+import { getCanonicalUrl, isSameOrigin } from "@indiekit/util";
 import axios from "axios";
 import megalodon from "megalodon";
-import { createStatus, getAbsoluteUrl, getStatusIdFromUrl } from "./utils.js";
+import { createStatus, getStatusIdFromUrl } from "./utils.js";
 
 export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
   client() {
@@ -59,7 +59,7 @@ export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
     }
 
     try {
-      const mediaUrl = getAbsoluteUrl(url, me);
+      const mediaUrl = getCanonicalUrl(url, me);
       const response = await axios(mediaUrl, {
         responseType: "stream",
       });

--- a/packages/syndicator-mastodon/lib/mastodon.js
+++ b/packages/syndicator-mastodon/lib/mastodon.js
@@ -1,12 +1,8 @@
 /* eslint-disable camelcase */
+import { isSameOrigin } from "@indiekit/util";
 import axios from "axios";
 import megalodon from "megalodon";
-import {
-  createStatus,
-  getAbsoluteUrl,
-  getStatusIdFromUrl,
-  isTootUrl,
-} from "./utils.js";
+import { createStatus, getAbsoluteUrl, getStatusIdFromUrl } from "./utils.js";
 
 export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
   client() {
@@ -101,7 +97,10 @@ export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
 
     if (properties["repost-of"]) {
       // Syndicate repost of Mastodon URL with content as a reblog
-      if (isTootUrl(properties["repost-of"], serverUrl) && properties.content) {
+      if (
+        isSameOrigin(properties["repost-of"], serverUrl) &&
+        properties.content
+      ) {
         const status = createStatus(properties, {
           characterLimit,
           mediaIds,
@@ -111,7 +110,7 @@ export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
       }
 
       // Syndicate repost of Mastodon URL as a reblog
-      if (isTootUrl(properties["repost-of"], serverUrl)) {
+      if (isSameOrigin(properties["repost-of"], serverUrl)) {
         return this.postReblog(properties["repost-of"]);
       }
 
@@ -121,7 +120,7 @@ export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
 
     if (properties["like-of"]) {
       // Syndicate like of Mastodon URL as a like
-      if (isTootUrl(properties["like-of"], serverUrl)) {
+      if (isSameOrigin(properties["like-of"], serverUrl)) {
         return this.postFavourite(properties["like-of"]);
       }
 

--- a/packages/syndicator-mastodon/lib/utils.js
+++ b/packages/syndicator-mastodon/lib/utils.js
@@ -138,15 +138,3 @@ export const htmlToStatusText = (html, serverUrl) => {
 
   return statusText;
 };
-
-/**
- * Test if string is a Mastodon status URL
- * @param {string} string - Text that may be a URL
- * @param {string} serverUrl - Server URL, i.e. https://mastodon.social
- * @returns {boolean} Mastodon status URL?
- */
-export const isTootUrl = (string, serverUrl) => {
-  const parsedHostname = new URL(string).hostname;
-  const serverHostname = new URL(serverUrl).hostname;
-  return parsedHostname === serverHostname;
-};

--- a/packages/syndicator-mastodon/lib/utils.js
+++ b/packages/syndicator-mastodon/lib/utils.js
@@ -70,21 +70,6 @@ export const createStatus = (properties, options = {}) => {
 };
 
 /**
- * Get absolute URL
- * @param {string} string - URL or path
- * @param {string} me - Publication URL
- * @returns {string} Absolute URL
- */
-export const getAbsoluteUrl = (string, me) => {
-  try {
-    return new URL(string).href;
-  } catch {
-    const absoluteUrl = path.posix.join(me, string);
-    return new URL(absoluteUrl).href;
-  }
-};
-
-/**
  * Get status ID from Mastodon status URL
  * @param {string} url Mastodon status URL
  * @returns {string} Status ID

--- a/packages/syndicator-mastodon/package.json
+++ b/packages/syndicator-mastodon/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.3",
+    "@indiekit/util": "^1.0.0-beta.4",
     "axios": "^1.1.3",
     "brevity": "^0.2.9",
     "html-to-text": "^9.0.0",

--- a/packages/syndicator-mastodon/tests/unit/mastodon.js
+++ b/packages/syndicator-mastodon/tests/unit/mastodon.js
@@ -110,7 +110,7 @@ test.serial("Throws error fetching media to upload", async (t) => {
   await t.throwsAsync(
     mastodon(t.context.options).uploadMedia(
       t.context.media,
-      t.context.publication
+      t.context.publication.me
     ),
     {
       message: /Not found/,
@@ -130,7 +130,7 @@ test.failing("Uploads media and returns a media id", async (t) => {
 
   const result = await mastodon(t.context.options).uploadMedia(
     t.context.media,
-    t.context.publication
+    t.context.publication.me
   );
 
   t.is(result, "1234567890987654321");
@@ -148,7 +148,7 @@ test.failing("Throws error uploading media", async (t) => {
   await t.throwsAsync(
     mastodon(t.context.options).uploadMedia(
       t.context.media,
-      t.context.publication
+      t.context.publication.me
     ),
     {
       message: "Request failed with status code 404",
@@ -159,7 +159,7 @@ test.failing("Throws error uploading media", async (t) => {
 test("Returns false passing an object to media upload function", async (t) => {
   const result = await mastodon(t.context.options).uploadMedia(
     { foo: "bar" },
-    t.context.publication
+    t.context.publication.me
   );
 
   t.falsy(result);

--- a/packages/syndicator-mastodon/tests/unit/utils.js
+++ b/packages/syndicator-mastodon/tests/unit/utils.js
@@ -3,7 +3,6 @@ import { IndiekitError } from "@indiekit/error";
 import { getFixture } from "@indiekit-test/fixtures";
 import {
   createStatus,
-  getAbsoluteUrl,
   getStatusIdFromUrl,
   htmlToStatusText,
 } from "../../lib/utils.js";
@@ -119,21 +118,6 @@ test("Creates a status with a photo", (t) => {
 
   t.is(result.status, "Here’s the cheese sandwich I ate.");
   t.deepEqual(result.media_ids, ["1", "2", "3", "4"]);
-});
-
-test("Gets absolute URL", (t) => {
-  const result = getAbsoluteUrl(
-    `${t.context.me}/media/photo.jpg`,
-    t.context.me
-  );
-
-  t.is(result, `${t.context.me}/media/photo.jpg`);
-});
-
-test("Gets absolute URL by prepending publication URL", (t) => {
-  const result = getAbsoluteUrl("/media/photo.jpg", t.context.me);
-
-  t.is(result, `${t.context.me}/media/photo.jpg`);
 });
 
 test("Gets status ID from Mastodon permalink", (t) => {

--- a/packages/syndicator-mastodon/tests/unit/utils.js
+++ b/packages/syndicator-mastodon/tests/unit/utils.js
@@ -6,7 +6,6 @@ import {
   getAbsoluteUrl,
   getStatusIdFromUrl,
   htmlToStatusText,
-  isTootUrl,
 } from "../../lib/utils.js";
 
 test.beforeEach((t) => {
@@ -120,16 +119,6 @@ test("Creates a status with a photo", (t) => {
 
   t.is(result.status, "Here’s the cheese sandwich I ate.");
   t.deepEqual(result.media_ids, ["1", "2", "3", "4"]);
-});
-
-test("Tests if string is a toot permalink", (t) => {
-  t.true(
-    isTootUrl(
-      "https://mastodon.example/@username/1234567890987654321",
-      "https://mastodon.example"
-    )
-  );
-  t.false(isTootUrl("https://getindiekit.com", "https://mastodon.example"));
 });
 
 test("Gets absolute URL", (t) => {

--- a/packages/syndicator-twitter/lib/twitter.js
+++ b/packages/syndicator-twitter/lib/twitter.js
@@ -1,13 +1,9 @@
 /* eslint-disable camelcase */
 import { Buffer } from "node:buffer";
+import { isSameOrigin } from "@indiekit/util";
 import { fetch } from "undici";
 import Twitter from "twitter-lite";
-import {
-  createStatus,
-  getAbsoluteUrl,
-  getStatusIdFromUrl,
-  isTweetUrl,
-} from "./utils.js";
+import { createStatus, getAbsoluteUrl, getStatusIdFromUrl } from "./utils.js";
 
 export const twitter = (options) => ({
   client: (subdomain = "api") =>
@@ -142,13 +138,16 @@ export const twitter = (options) => ({
 
     if (properties["repost-of"]) {
       // Syndicate repost of Twitter URL with content as a quote tweet
-      if (isTweetUrl(properties["repost-of"]) && properties.content) {
+      if (
+        isSameOrigin(properties["repost-of"], "https://twitter.com") &&
+        properties.content
+      ) {
         const status = createStatus(properties, mediaIds);
         return this.postStatus(status);
       }
 
       // Syndicate repost of Twitter URL as a retweet
-      if (isTweetUrl(properties["repost-of"])) {
+      if (isSameOrigin(properties["repost-of"], "https://twitter.com")) {
         return this.postRetweet(properties["repost-of"]);
       }
 
@@ -158,7 +157,7 @@ export const twitter = (options) => ({
 
     if (properties["like-of"]) {
       // Syndicate like of Twitter URL as a like
-      if (isTweetUrl(properties["like-of"])) {
+      if (isSameOrigin(properties["like-of"], "https://twitter.com")) {
         return this.postLike(properties["like-of"]);
       }
 

--- a/packages/syndicator-twitter/lib/twitter.js
+++ b/packages/syndicator-twitter/lib/twitter.js
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import { Buffer } from "node:buffer";
-import { isSameOrigin } from "@indiekit/util";
+import { getCanonicalUrl, isSameOrigin } from "@indiekit/util";
 import { fetch } from "undici";
 import Twitter from "twitter-lite";
-import { createStatus, getAbsoluteUrl, getStatusIdFromUrl } from "./utils.js";
+import { createStatus, getStatusIdFromUrl } from "./utils.js";
 
 export const twitter = (options) => ({
   client: (subdomain = "api") =>
@@ -86,7 +86,7 @@ export const twitter = (options) => ({
     }
 
     try {
-      const mediaUrl = getAbsoluteUrl(url, me);
+      const mediaUrl = getCanonicalUrl(url, me);
       const response = await fetch(mediaUrl);
 
       if (!response.ok) {

--- a/packages/syndicator-twitter/lib/utils.js
+++ b/packages/syndicator-twitter/lib/utils.js
@@ -71,21 +71,6 @@ export const createStatus = (properties, mediaIds = null) => {
 };
 
 /**
- * Get absolute URL
- * @param {string} string - URL or path
- * @param {string} me - Publication URL
- * @returns {string} Absolute URL
- */
-export const getAbsoluteUrl = (string, me) => {
-  try {
-    return new URL(string).href;
-  } catch {
-    const absoluteUrl = path.posix.join(me, string);
-    return new URL(absoluteUrl).href;
-  }
-};
-
-/**
  * Get status ID from Twitter status URL
  * @param {string} url - Twitter status URL
  * @returns {string} Status ID

--- a/packages/syndicator-twitter/lib/utils.js
+++ b/packages/syndicator-twitter/lib/utils.js
@@ -137,13 +137,3 @@ export const htmlToStatusText = (html) => {
 
   return statusText;
 };
-
-/**
- * Test if string is a Twitter status URL
- * @param {string} string - URL
- * @returns {boolean} Twitter status URL?
- */
-export const isTweetUrl = (string) => {
-  const parsedUrl = new URL(string);
-  return parsedUrl.hostname === "twitter.com";
-};

--- a/packages/syndicator-twitter/package.json
+++ b/packages/syndicator-twitter/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.3",
+    "@indiekit/util": "^1.0.0-beta.4",
     "brevity": "^0.2.9",
     "html-to-text": "^9.0.0",
     "twitter-lite": "^1.1.0",

--- a/packages/syndicator-twitter/tests/unit/twitter.js
+++ b/packages/syndicator-twitter/tests/unit/twitter.js
@@ -139,7 +139,7 @@ test("Throws error fetching media to upload", async (t) => {
   await t.throwsAsync(
     twitter(t.context.options).uploadMedia(
       t.context.media("image.jpg"),
-      t.context.publication
+      t.context.publication.me
     ),
     {
       message: "Not Found",
@@ -157,7 +157,7 @@ test("Uploads media and returns a media id", async (t) => {
 
   const result = await twitter(t.context.options).uploadMedia(
     t.context.media("photo1.jpg"),
-    t.context.publication
+    t.context.publication.me
   );
 
   t.is(result, "1234567890987654321");
@@ -173,7 +173,7 @@ test("Throws error uploading media", async (t) => {
   await t.throwsAsync(
     twitter(t.context.options).uploadMedia(
       t.context.media("photo2.jpg"),
-      t.context.publication
+      t.context.publication.me
     ),
     {
       message: /Not found/,
@@ -184,7 +184,7 @@ test("Throws error uploading media", async (t) => {
 test("Returns false passing an object to media upload function", async (t) => {
   const result = await twitter(t.context.options).uploadMedia(
     { foo: "bar" },
-    t.context.publication
+    t.context.publication.me
   );
 
   t.falsy(result);

--- a/packages/syndicator-twitter/tests/unit/utils.js
+++ b/packages/syndicator-twitter/tests/unit/utils.js
@@ -6,7 +6,6 @@ import {
   getAbsoluteUrl,
   getStatusIdFromUrl,
   htmlToStatusText,
-  isTweetUrl,
 } from "../../lib/utils.js";
 
 test.beforeEach((t) => {
@@ -103,13 +102,6 @@ test("Creates a status with a photo", (t) => {
 
   t.is(result.status, "Here’s the cheese sandwich I ate.");
   t.is(result.media_ids, "1,2,3,4");
-});
-
-test("Tests if string is a tweet permalink", (t) => {
-  t.true(
-    isTweetUrl("https://twitter.com/paulrobertlloyd/status/1341502435760680961")
-  );
-  t.false(isTweetUrl("https://getindiekit.com"));
 });
 
 test("Gets absolute URL", (t) => {

--- a/packages/syndicator-twitter/tests/unit/utils.js
+++ b/packages/syndicator-twitter/tests/unit/utils.js
@@ -3,7 +3,6 @@ import { IndiekitError } from "@indiekit/error";
 import { getFixture } from "@indiekit-test/fixtures";
 import {
   createStatus,
-  getAbsoluteUrl,
   getStatusIdFromUrl,
   htmlToStatusText,
 } from "../../lib/utils.js";
@@ -102,21 +101,6 @@ test("Creates a status with a photo", (t) => {
 
   t.is(result.status, "Here’s the cheese sandwich I ate.");
   t.is(result.media_ids, "1,2,3,4");
-});
-
-test("Gets absolute URL", (t) => {
-  const result = getAbsoluteUrl(
-    `${t.context.me}/media/photo.jpg`,
-    t.context.me
-  );
-
-  t.is(result, `${t.context.me}/media/photo.jpg`);
-});
-
-test("Gets absolute URL by prepending publication URL", (t) => {
-  const result = getAbsoluteUrl("/media/photo.jpg", t.context.me);
-
-  t.is(result, `${t.context.me}/media/photo.jpg`);
 });
 
 test("Gets status ID from Twitter permalink", (t) => {

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -1,0 +1,7 @@
+# @indiekit/util
+
+Common utilities for Indiekit.
+
+## Installation
+
+`npm i @indiekit/util`

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -1,1 +1,1 @@
-export { isSameOrigin, isUrl } from "./lib/url.js";
+export { getCanonicalUrl, isSameOrigin, isUrl } from "./lib/url.js";

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -1,0 +1,1 @@
+export { isUrl } from "./lib/url.js";

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -1,1 +1,1 @@
-export { isUrl } from "./lib/url.js";
+export { isSameOrigin, isUrl } from "./lib/url.js";

--- a/packages/util/lib/url.js
+++ b/packages/util/lib/url.js
@@ -1,3 +1,22 @@
+import posix from "node:path/posix";
+
+/**
+ * Get canonical URL
+ * @param {string} string - URL or path
+ * @param {string} [baseUrl] - Base URL
+ * @returns {string} Canonical URL
+ * @see {@link https://indieauth.spec.indieweb.org/#url-canonicalization}
+ */
+export const getCanonicalUrl = (string, baseUrl = undefined) => {
+  string = String(string);
+
+  try {
+    return new URL(string, baseUrl).href;
+  } catch {
+    return posix.join(baseUrl, string);
+  }
+};
+
 /**
  * Check if parsed URL string has given origin
  * @param {string} string - URL, i.e. https://website.example:80/path

--- a/packages/util/lib/url.js
+++ b/packages/util/lib/url.js
@@ -1,0 +1,19 @@
+/**
+ * Check if given string is a valid URL
+ * @param {object} string - URL
+ * @returns {boolean} String is a URL
+ * @todo Replace with URL.canParse() when Indiekit supports Node v20+
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static}
+ */
+export const isUrl = (string) => {
+  if (typeof string !== "string") {
+    throw new TypeError("Expected a string");
+  }
+
+  try {
+    new URL(decodeURIComponent(string)); // eslint-disable-line no-new
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/packages/util/lib/url.js
+++ b/packages/util/lib/url.js
@@ -1,4 +1,17 @@
 /**
+ * Check if parsed URL string has given origin
+ * @param {string} string - URL, i.e. https://website.example:80/path
+ * @param {string} origin - Origin, i.e. https://website.example:80
+ * @returns {boolean} String is a URL with same origin
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy}
+ */
+export const isSameOrigin = (string, origin) => {
+  const url = new URL(string);
+  const originUrl = new URL(origin);
+  return url.origin === originUrl.origin;
+};
+
+/**
  * Check if given string is a valid URL
  * @param {object} string - URL
  * @returns {boolean} String is a URL

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@indiekit/util",
+  "version": "1.0.0-beta.4",
+  "description": "Common utilities for Indiekit",
+  "author": {
+    "name": "Paul Robert Lloyd",
+    "url": "https://paulrobertlloyd.com"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "type": "module",
+  "main": "index.js",
+  "files": [
+    "lib",
+    "index.js"
+  ],
+  "bugs": {
+    "url": "https://github.com/getindiekit/indiekit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getindiekit/indiekit.git",
+    "directory": "packages/util"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/util/tests/unit/url.js
+++ b/packages/util/tests/unit/url.js
@@ -1,5 +1,15 @@
 import test from "ava";
-import { isUrl } from "../../lib/url.js";
+import { isSameOrigin, isUrl } from "../../lib/url.js";
+
+test("Checks if parsed URL string has given origin", (t) => {
+  t.true(
+    isSameOrigin(
+      "https://mastodon.example/@username/1234567890987654321",
+      "https://mastodon.example"
+    )
+  );
+  t.false(isSameOrigin("https://getindiekit.com", "https://mastodon.example"));
+});
 
 test("Checks if given string is a valid URL", (t) => {
   t.true(isUrl("https%3A%2F%2Ffoo.bar"));

--- a/packages/util/tests/unit/url.js
+++ b/packages/util/tests/unit/url.js
@@ -1,0 +1,20 @@
+import test from "ava";
+import { isUrl } from "../../lib/url.js";
+
+test("Checks if given string is a valid URL", (t) => {
+  t.true(isUrl("https%3A%2F%2Ffoo.bar"));
+  t.true(isUrl("https://foo.bar"));
+  t.false(isUrl("foo.bar"));
+});
+
+test("Throws error if URL is not a string", (t) => {
+  t.throws(
+    () => {
+      isUrl({});
+    },
+    {
+      instanceOf: TypeError,
+      message: "Expected a string",
+    }
+  );
+});

--- a/packages/util/tests/unit/url.js
+++ b/packages/util/tests/unit/url.js
@@ -1,5 +1,21 @@
 import test from "ava";
-import { isSameOrigin, isUrl } from "../../lib/url.js";
+import { getCanonicalUrl, isSameOrigin, isUrl } from "../../lib/url.js";
+
+test("Gets canonical URL", (t) => {
+  t.is(getCanonicalUrl("https://website.example"), "https://website.example/");
+  t.is(
+    getCanonicalUrl("path1", "https://website.example"),
+    "https://website.example/path1"
+  );
+  t.is(
+    getCanonicalUrl("/path2", "https://website.example"),
+    "https://website.example/path2"
+  );
+  t.is(
+    getCanonicalUrl("https://website.example/path3", "https://website.example"),
+    "https://website.example/path3"
+  );
+});
 
 test("Checks if parsed URL string has given origin", (t) => {
   t.true(


### PR DESCRIPTION
Consolidates a number of URL utility functions duplicated across different packages:

* `isUrl`, used by:
  * `create-indiekit`
  * `endpoint-auth`
  * `indiekit`
* `getCanonicalUrl`, used by:
  * `endpoint-auth`
  * `frontend` (~~`absoluteUrl`~~)
  * `indiekit`
  * `syndicator-mastodon` (~~`getAbsoluteUrl`~~)
  * `syndicator-twitter` (~~`getAbsoluteUrl`~~)
* `isSameOrigin`, used by:
  * `syndicator-mastodon` (~~`isTootUrl`~~)
  * `syndicator-twitter` (~~`isTweetUrl`~~)

This reduced the number of tests, down from 632 to 621.

These have been added to a new `@indiekit/util` package, to which further shared utility functions can be added.

Partly addresses #544. 