### PR TITLE
Consolidate string utility functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22575,6 +22575,9 @@
       "name": "@indiekit/util",
       "version": "1.0.0-beta.4",
       "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/slugify": "^2.1.0"
+      },
       "engines": {
         "node": ">=18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22240,7 +22240,6 @@
         "@indiekit/error": "^1.0.0-beta.3",
         "@indiekit/util": "^1.0.0-beta.4",
         "@paulrobertlloyd/mf2tojf2": "^1.0.0",
-        "@sindresorhus/slugify": "^2.1.0",
         "date-fns": "^2.23.0",
         "date-fns-tz": "^2.0.0",
         "express": "^4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22315,7 +22315,6 @@
         "@hotwired/stimulus": "^3.0.1",
         "@indiekit/util": "^1.0.0-beta.4",
         "@rollup/plugin-node-resolve": "^15.0.0",
-        "@sindresorhus/slugify": "^2.1.1",
         "color": "^4.0.1",
         "date-fns": "^2.23.0",
         "iso-639-1": "^2.1.9",

--- a/packages/endpoint-auth/lib/pushed-authorization-request.js
+++ b/packages/endpoint-auth/lib/pushed-authorization-request.js
@@ -1,4 +1,4 @@
-import { randomString } from "./utils.js";
+import { randomString } from "@indiekit/util";
 
 /**
  * Mimic a Pushed Authorization Request (PAR)

--- a/packages/endpoint-auth/lib/utils.js
+++ b/packages/endpoint-auth/lib/utils.js
@@ -1,13 +1,3 @@
-import { randomBytes } from "node:crypto";
-
-/**
- * Generate cryptographically random string
- * @param {number} [length] - Length of string
- * @returns {string} Random string
- */
-export const randomString = (length = 16) =>
-  randomBytes(length).toString("base64url").slice(0, length);
-
 /**
  * Get request parameters from either query string or JSON body
  * @param {import("express").Request} request - Request

--- a/packages/endpoint-media/lib/file.js
+++ b/packages/endpoint-media/lib/file.js
@@ -1,6 +1,6 @@
+import { randomString } from "@indiekit/util";
 import { fileTypeFromBuffer } from "file-type";
 import { getDate } from "./date.js";
-import { randomString } from "./utils.js";
 
 /**
  * Derive properties from file data
@@ -17,7 +17,7 @@ import { randomString } from "./utils.js";
  * }
  */
 export const getFileProperties = async (timeZone, file) => {
-  const basename = randomString();
+  const basename = randomString(5).toLowerCase();
   const { ext } = await fileTypeFromBuffer(file.data);
   const published = getPublishedProperty(timeZone);
 

--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -6,13 +6,6 @@ import { getServerTimeZone } from "./date.js";
 import { mediaTypeCount } from "./media-type-count.js";
 
 /**
- * Generate random alpha-numeric string, 5 characters long
- * @returns {string} Alpha-numeric string
- * @example random() => 'f0pjf'
- */
-export const randomString = () => Math.random().toString(36).slice(-5);
-
-/**
  * Render path from URI template and properties
  * @param {string} path - URI template path
  * @param {object} properties - Properties to use

--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { supplant } from "@indiekit/util";
 import { format } from "date-fns-tz";
 import newbase60 from "newbase60";
 import { getServerTimeZone } from "./date.js";
@@ -79,26 +80,6 @@ export const renderPath = async (path, properties, application) => {
   path = supplant(path, tokens);
 
   return path;
-};
-
-/**
- * Substitute variables enclosed in { } braces with data from object
- * @param {string} string - String to parse
- * @param {object} object - Properties to use
- * @returns {string} String with substituted
- */
-export const supplant = (string, object) => {
-  const replacer = function (match, p1) {
-    const r = object[p1];
-
-    if (typeof r === "string" || typeof r === "number") {
-      return r;
-    }
-
-    return match;
-  };
-
-  return string.replace(/{([^{}]*)}/g, replacer);
 };
 
 /**

--- a/packages/endpoint-media/tests/unit/file.js
+++ b/packages/endpoint-media/tests/unit/file.js
@@ -26,6 +26,6 @@ test("Derives properties from file data", async (t) => {
 
   t.is(result.originalname, "photo.jpg");
   t.is(result.ext, "jpg");
-  t.regex(result.filename, /[\d\w]{5}.jpg/g);
+  t.regex(result.filename, /[\d\w-]{5}.jpg/g);
   t.true(isValid(parseISO(result.published)));
 });

--- a/packages/endpoint-media/tests/unit/utils.js
+++ b/packages/endpoint-media/tests/unit/utils.js
@@ -4,7 +4,6 @@ import {
   getPostTypeConfig,
   randomString,
   renderPath,
-  supplant,
 } from "../../lib/utils.js";
 
 test("Get post type configuration for a given type", (t) => {
@@ -31,16 +30,4 @@ test("Renders path from URI template and properties", async (t) => {
     result,
     /\d{4}\/\d{2}\/[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}\/foo/
   );
-});
-
-test("Substitutes variables enclosed in { } braces with data from object", (t) => {
-  const string = "{array} {string} {number}";
-  const object = {
-    array: ["Array"],
-    string: "string",
-    number: 1,
-  };
-  const result = supplant(string, object);
-
-  t.is(result, "{array} string 1");
 });

--- a/packages/endpoint-media/tests/unit/utils.js
+++ b/packages/endpoint-media/tests/unit/utils.js
@@ -1,20 +1,12 @@
 import test from "ava";
 import JekyllPreset from "@indiekit/preset-jekyll";
-import {
-  getPostTypeConfig,
-  randomString,
-  renderPath,
-} from "../../lib/utils.js";
+import { getPostTypeConfig, renderPath } from "../../lib/utils.js";
 
 test("Get post type configuration for a given type", (t) => {
   const { postTypes } = new JekyllPreset();
   const result = getPostTypeConfig("note", postTypes);
 
   t.is(result.name, "Note");
-});
-
-test("Generates random alpha-numeric string, 5 characters long", (t) => {
-  t.regex(randomString(), /[\d\w]{5}/g);
 });
 
 test("Renders path from URI template and properties", async (t) => {

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -1,3 +1,4 @@
+import { slugify } from "@indiekit/util";
 import { mf2tojf2, mf2tojf2referenced } from "@paulrobertlloyd/mf2tojf2";
 import { markdownToHtml, htmlToMarkdown } from "./markdown.js";
 import { reservedProperties } from "./reserved-properties.js";
@@ -6,7 +7,6 @@ import {
   excerptString,
   relativeMediaPath,
   randomString,
-  slugifyString,
   toArray,
 } from "./utils.js";
 
@@ -240,7 +240,7 @@ export const getSlugProperty = (properties, separator) => {
     string = randomString();
   }
 
-  return slugifyString(string, separator);
+  return slugify(string, separator);
 };
 
 /**

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -1,4 +1,4 @@
-import { slugify } from "@indiekit/util";
+import { randomString, slugify } from "@indiekit/util";
 import { mf2tojf2, mf2tojf2referenced } from "@paulrobertlloyd/mf2tojf2";
 import { markdownToHtml, htmlToMarkdown } from "./markdown.js";
 import { reservedProperties } from "./reserved-properties.js";
@@ -6,7 +6,6 @@ import {
   decodeQueryParameter,
   excerptString,
   relativeMediaPath,
-  randomString,
   toArray,
 } from "./utils.js";
 
@@ -237,7 +236,7 @@ export const getSlugProperty = (properties, separator) => {
   } else if (name) {
     string = excerptString(name, 5);
   } else {
-    string = randomString();
+    string = randomString(5);
   }
 
   return slugify(string, separator);

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { supplant } from "@indiekit/util";
 import { format } from "date-fns-tz";
 import newbase60 from "newbase60";
 import slugify from "@sindresorhus/slugify";
@@ -144,26 +145,6 @@ export const renderPath = async (path, properties, application) => {
   path = supplant(path, tokens);
 
   return path;
-};
-
-/**
- * Substitute variables enclosed in { } braces with data from object
- * @param {string} string - String to parse
- * @param {object} object - Properties to use
- * @returns {string} String with substituted
- */
-export const supplant = (string, object) => {
-  const replacer = function (match, p1) {
-    const r = object[p1];
-
-    if (typeof r === "string" || typeof r === "number") {
-      return r;
-    }
-
-    return match;
-  };
-
-  return string.replace(/{([^{}]*)}/g, replacer);
 };
 
 /**

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -2,7 +2,6 @@ import crypto from "node:crypto";
 import { supplant } from "@indiekit/util";
 import { format } from "date-fns-tz";
 import newbase60 from "newbase60";
-import slugify from "@sindresorhus/slugify";
 import { getServerTimeZone } from "./date.js";
 import { postTypeCount } from "./post-type-count.js";
 
@@ -27,27 +26,6 @@ export const excerptString = (string, n) => {
   if (typeof string === "string") {
     const excerpt = string.split(/\s+/).slice(0, n).join(" ");
     return excerpt;
-  }
-};
-
-/**
- * Slugify a string
- * @param {string} string - String to excerpt
- * @param {string} [separator] - Character used to separate words
- * @returns {string} Slugified string
- * @example slugifyString('Foo bar baz', '_') => 'foo_bar_baz'
- */
-export const slugifyString = (string, separator = "-") => {
-  if (typeof string === "string") {
-    const slug = slugify(string, {
-      customReplacements: [
-        ["'", ""],
-        ["’", ""],
-      ],
-      decamelize: false,
-      separator,
-    });
-    return slug;
   }
 };
 

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -39,13 +39,6 @@ export const getPostTypeConfig = (type, postTypes) =>
   postTypes.find((item) => item.type === type);
 
 /**
- * Generate random alpha-numeric string, 5 characters long
- * @returns {string} Alpha-numeric string
- * @example random() => 'jb6zm'
- */
-export const randomString = () => Math.random().toString(36).slice(-5);
-
-/**
  * Render relative path if URL is on publication
  * @param {string} url - External URL
  * @param {string} me - Publication URL

--- a/packages/endpoint-micropub/package.json
+++ b/packages/endpoint-micropub/package.json
@@ -38,7 +38,6 @@
     "@indiekit/error": "^1.0.0-beta.3",
     "@indiekit/util": "^1.0.0-beta.4",
     "@paulrobertlloyd/mf2tojf2": "^1.0.0",
-    "@sindresorhus/slugify": "^2.1.0",
     "date-fns": "^2.23.0",
     "date-fns-tz": "^2.0.0",
     "express": "^4.17.1",

--- a/packages/endpoint-micropub/tests/unit/jf2.js
+++ b/packages/endpoint-micropub/tests/unit/jf2.js
@@ -311,7 +311,7 @@ test("Derives slug by generating random number", (t) => {
   );
   const result = getSlugProperty(properties, "-");
 
-  t.regex(result, /[\d\w]{5}/g);
+  t.regex(result, /[\d\w-]{5}/g);
 });
 
 test("Does not add syndication target if no syndicators", (t) => {

--- a/packages/endpoint-micropub/tests/unit/utils.js
+++ b/packages/endpoint-micropub/tests/unit/utils.js
@@ -8,7 +8,6 @@ import {
   relativeMediaPath,
   renderPath,
   slugifyString,
-  supplant,
   toArray,
 } from "../../lib/utils.js";
 
@@ -86,18 +85,6 @@ test("Slugifies a string", (t) => {
   t.is(slugifyString("Foo bar baz", "_"), "foo_bar_baz");
   t.is(slugifyString("McLaren's Lando Norris"), "mclarens-lando-norris");
   t.is(slugifyString("McLaren’s Lando Norris"), "mclarens-lando-norris");
-});
-
-test("Substitutes variables enclosed in { } braces with data from object", (t) => {
-  const string = "{array} {string} {number}";
-  const object = {
-    array: ["Array"],
-    string: "string",
-    number: 1,
-  };
-  const result = supplant(string, object);
-
-  t.is(result, "{array} string 1");
 });
 
 test("Convert string to array if not already an array", (t) => {

--- a/packages/endpoint-micropub/tests/unit/utils.js
+++ b/packages/endpoint-micropub/tests/unit/utils.js
@@ -7,7 +7,6 @@ import {
   randomString,
   relativeMediaPath,
   renderPath,
-  slugifyString,
   toArray,
 } from "../../lib/utils.js";
 
@@ -79,12 +78,6 @@ test("Renders path from URI template and properties", async (t) => {
     result,
     /\d{4}\/\d{2}\/[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}\/foo/
   );
-});
-
-test("Slugifies a string", (t) => {
-  t.is(slugifyString("Foo bar baz", "_"), "foo_bar_baz");
-  t.is(slugifyString("McLaren's Lando Norris"), "mclarens-lando-norris");
-  t.is(slugifyString("McLaren’s Lando Norris"), "mclarens-lando-norris");
 });
 
 test("Convert string to array if not already an array", (t) => {

--- a/packages/endpoint-micropub/tests/unit/utils.js
+++ b/packages/endpoint-micropub/tests/unit/utils.js
@@ -4,7 +4,6 @@ import {
   decodeQueryParameter,
   excerptString,
   getPostTypeConfig,
-  randomString,
   relativeMediaPath,
   renderPath,
   toArray,
@@ -27,12 +26,6 @@ test("Get post type configuration for a given type", (t) => {
   const result = getPostTypeConfig("note", postTypes);
 
   t.is(result.name, "Note");
-});
-
-test("Generates random alpha-numeric string, 5 characters long", (t) => {
-  const result = randomString();
-
-  t.regex(result, /[\d\w]{5}/g);
 });
 
 test("Renders relative path if at publication URL", (t) => {

--- a/packages/frontend/lib/filters/index.js
+++ b/packages/frontend/lib/filters/index.js
@@ -1,5 +1,4 @@
-export { getCanonicalUrl as url } from "@indiekit/util";
-export { default as slugify } from "@sindresorhus/slugify";
+export { slugify, getCanonicalUrl as url } from "@indiekit/util";
 export { default as widont } from "widont";
 export { date, languageName, languageNativeName } from "./locale.js";
 export { excerpt, includes, linkTo, markdown } from "./string.js";

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -39,7 +39,6 @@
     "@hotwired/stimulus": "^3.0.1",
     "@indiekit/util": "^1.0.0-beta.4",
     "@rollup/plugin-node-resolve": "^15.0.0",
-    "@sindresorhus/slugify": "^2.1.1",
     "color": "^4.0.1",
     "date-fns": "^2.23.0",
     "iso-639-1": "^2.1.9",

--- a/packages/indiekit/lib/indieauth.js
+++ b/packages/indiekit/lib/indieauth.js
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import process from "node:process";
 import { IndiekitError } from "@indiekit/error";
-import { getCanonicalUrl } from "@indiekit/util";
+import { getCanonicalUrl, randomString } from "@indiekit/util";
 import { fetch } from "undici";
 import {
   findBearerToken,
@@ -9,7 +9,6 @@ import {
   verifyTokenValues,
 } from "./token.js";
 import { generateState, validateState } from "./state.js";
-import { randomString } from "./utils.js";
 
 export const IndieAuth = class {
   constructor(options = {}) {

--- a/packages/indiekit/lib/utils.js
+++ b/packages/indiekit/lib/utils.js
@@ -64,11 +64,3 @@ export const getPackageData = (fileUrl) => {
     return {};
   }
 };
-
-/**
- * Generate cryptographically random string
- * @param {number} [length] - Length of string
- * @returns {string} Random string
- */
-export const randomString = (length = 21) =>
-  randomBytes(length).toString("hex").slice(0, length);

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -1,1 +1,2 @@
+export { supplant } from "./lib/string.js";
 export { getCanonicalUrl, isSameOrigin, isUrl } from "./lib/url.js";

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -1,2 +1,2 @@
-export { slugify, supplant } from "./lib/string.js";
+export { randomString, slugify, supplant } from "./lib/string.js";
 export { getCanonicalUrl, isSameOrigin, isUrl } from "./lib/url.js";

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -1,2 +1,2 @@
-export { supplant } from "./lib/string.js";
+export { slugify, supplant } from "./lib/string.js";
 export { getCanonicalUrl, isSameOrigin, isUrl } from "./lib/url.js";

--- a/packages/util/lib/string.js
+++ b/packages/util/lib/string.js
@@ -1,0 +1,19 @@
+/**
+ * Substitute variables enclosed in { } braces with data from object
+ * @param {string} string - String to parse
+ * @param {object} object - Properties to use
+ * @returns {string} String with substituted
+ */
+export const supplant = (string, object) => {
+  const replacer = function (match, p1) {
+    const r = object[p1];
+
+    if (typeof r === "string" || typeof r === "number") {
+      return r;
+    }
+
+    return match;
+  };
+
+  return string.replace(/{([^{}]*)}/g, replacer);
+};

--- a/packages/util/lib/string.js
+++ b/packages/util/lib/string.js
@@ -1,4 +1,13 @@
+import { randomBytes } from "node:crypto";
 import slugifyString from "@sindresorhus/slugify";
+
+/**
+ * Generate cryptographically random string
+ * @param {number} [length] - Length of string
+ * @returns {string} Random string
+ */
+export const randomString = (length = 16) =>
+  randomBytes(length).toString("base64url").slice(0, length);
 
 /**
  * Slugify a string

--- a/packages/util/lib/string.js
+++ b/packages/util/lib/string.js
@@ -1,3 +1,26 @@
+import slugifyString from "@sindresorhus/slugify";
+
+/**
+ * Slugify a string
+ * @param {string} string - String to excerpt
+ * @param {string} [separator] - Character used to separate words
+ * @returns {string} Slugified string
+ * @example slugify('Foo bar baz', '_') => 'foo_bar_baz'
+ */
+export const slugify = (string, separator = "-") => {
+  if (typeof string === "string") {
+    const slug = slugifyString(string, {
+      customReplacements: [
+        ["'", ""],
+        ["’", ""],
+      ],
+      decamelize: false,
+      separator,
+    });
+    return slug;
+  }
+};
+
 /**
  * Substitute variables enclosed in { } braces with data from object
  * @param {string} string - String to parse

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/getindiekit/indiekit.git",
     "directory": "packages/util"
   },
+  "dependencies": {
+    "@sindresorhus/slugify": "^2.1.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/util/tests/unit/string.js
+++ b/packages/util/tests/unit/string.js
@@ -1,5 +1,13 @@
+import { Buffer } from "node:buffer";
 import test from "ava";
-import { slugify, supplant } from "../../lib/string.js";
+import { randomString, slugify, supplant } from "../../lib/string.js";
+
+test("Generates cryptographically random string", (t) => {
+  const result = randomString(8);
+
+  t.is(result.length, 8);
+  t.true(Buffer.from(result, "base64url").toString("base64url") === result);
+});
 
 test("Slugifies a string", (t) => {
   t.is(slugify("Foo bar baz", "_"), "foo_bar_baz");

--- a/packages/util/tests/unit/string.js
+++ b/packages/util/tests/unit/string.js
@@ -1,5 +1,11 @@
 import test from "ava";
-import { supplant } from "../../lib/string.js";
+import { slugify, supplant } from "../../lib/string.js";
+
+test("Slugifies a string", (t) => {
+  t.is(slugify("Foo bar baz", "_"), "foo_bar_baz");
+  t.is(slugify("McLaren's Lando Norris"), "mclarens-lando-norris");
+  t.is(slugify("McLaren’s Lando Norris"), "mclarens-lando-norris");
+});
 
 test("Substitutes variables enclosed in { } braces with data from object", (t) => {
   const string = "{array} {string} {number}";

--- a/packages/util/tests/unit/string.js
+++ b/packages/util/tests/unit/string.js
@@ -1,0 +1,14 @@
+import test from "ava";
+import { supplant } from "../../lib/string.js";
+
+test("Substitutes variables enclosed in { } braces with data from object", (t) => {
+  const string = "{array} {string} {number}";
+  const object = {
+    array: ["Array"],
+    string: "string",
+    number: 1,
+  };
+  const result = supplant(string, object);
+
+  t.is(result, "{array} string 1");
+});


### PR DESCRIPTION
Consolidates a number of string utility functions duplicated across different packages:

* `randomString`, used by:
  * `endpoint-auth`
  * `endpoint-media`
  * `endpoint-micropub`
  * `indiekit`
* `slugify`, used by:
  * `endpoint-micropub`
  * `frontend`
* `supplant`, used by:
  * `endpoint-media`
  * `endpoint-micropub`

This reduces the number of tests, down from 619 to 617.