### PR TITLE
Ask user what type of post they want to create

### DIFF
--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -1,6 +1,7 @@
 import express from "express";
 import { deleteController } from "./lib/controllers/delete.js";
 import { formController } from "./lib/controllers/form.js";
+import { newController } from "./lib/controllers/new.js";
 import { postController } from "./lib/controllers/post.js";
 import { postsController } from "./lib/controllers/posts.js";
 import { postData } from "./lib/middleware/post-data.js";
@@ -28,6 +29,9 @@ export default class PostsEndpoint {
 
   get routes() {
     router.get("/", postsController);
+
+    router.get("/new", newController.get);
+    router.post("/new", newController.post);
 
     router.get("/create", postData.create, formController.get);
     router.post("/create", postData.create, validate, formController.post);

--- a/packages/endpoint-posts/lib/controllers/form.js
+++ b/packages/endpoint-posts/lib/controllers/form.js
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { checkScope } from "@indiekit/endpoint-micropub/lib/scope.js";
 import { jf2ToMf2 } from "@indiekit/endpoint-micropub/lib/mf2.js";
 import { validationResult } from "express-validator";
@@ -10,10 +11,15 @@ export const formController = {
    * @type {import("express").RequestHandler}
    */
   async get(request, response) {
-    const { action, postsPath, postTypeName, scope } = response.locals;
+    const { action, postsPath, postType, postTypeName, scope } =
+      response.locals;
 
     if (scope && checkScope(scope, action)) {
       return response.render("post-form", {
+        back: {
+          href: `${path.join(postsPath, "new")}?type=${postType}`,
+          text: response.locals.__(`posts.form.back`),
+        },
         title: response.locals.__(
           `posts.${action}.title`,
           postTypeName.toLowerCase().replace("rsvp", "RSVP")

--- a/packages/endpoint-posts/lib/controllers/new.js
+++ b/packages/endpoint-posts/lib/controllers/new.js
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { checkScope } from "@indiekit/endpoint-micropub/lib/scope.js";
+
+export const newController = {
+  /**
+   * Get new post type to create
+   * @type {import("express").RequestHandler}
+   */
+  async get(request, response) {
+    const action = "create";
+    const { application, publication } = request.app.locals;
+    const postsPath = path.dirname(request.baseUrl + request.path);
+    const postType = request.query.type || "article";
+    const { scope } = request.session;
+
+    const postTypeItems = publication.postTypes
+      .filter((postType) =>
+        application.supportedPostTypes.includes(postType.type)
+      )
+      .sort((a, b) => {
+        return a.name.localeCompare(b.name);
+      })
+      .map((postType) => ({
+        text: postType.name,
+        value: postType.type,
+      }));
+
+    response.locals = {
+      action,
+      postsPath,
+      postType,
+      postTypeItems,
+      scope,
+      ...response.locals,
+    };
+
+    if (scope && checkScope(scope, action)) {
+      return response.render("new", {
+        title: response.locals.__(`posts.new.title`),
+      });
+    }
+
+    response.redirect(postsPath);
+  },
+
+  /**
+   * Redirect to post creation form for selected post type
+   * @type {import("express").RequestHandler}
+   */
+  async post(request, response) {
+    try {
+      const { type } = request.body;
+
+      response.redirect(`${request.baseUrl}/create?type=${type}`);
+    } catch (error) {
+      response.status(error.status || 500);
+      response.render("new", {
+        title: response.locals.__(`posts.new.title`),
+        error,
+      });
+    }
+  },
+};

--- a/packages/endpoint-posts/lib/controllers/posts.js
+++ b/packages/endpoint-posts/lib/controllers/posts.js
@@ -67,7 +67,7 @@ export const postsController = async (request, response, next) => {
       actions: [
         scope && checkScope(scope, "create")
           ? {
-              href: path.join(request.baseUrl + request.path, "/create"),
+              href: path.join(request.baseUrl + request.path, "/new"),
               icon: "createPost",
               text: response.locals.__("posts.create.action"),
             }

--- a/packages/endpoint-posts/locales/de.json
+++ b/packages/endpoint-posts/locales/de.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "Erweiterte Optionen",
+      "back": "Beitragstyp ändern",
       "bookmark-of": {
         "label": "Lesezeichen für"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "Inhalt"
       },
+      "continue": "Fortsetzen",
       "geo": {
         "hint": "Breitengrad und Längengrad, zum Beispiel %s",
         "label": "Koordinaten des Standorts"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "Sichtbarkeit"
       }
+    },
+    "new": {
+      "title": "Welche Art von Beitrag möchtest du erstellen?"
     },
     "post": {
       "properties": "Eigenschaften",

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -32,6 +32,9 @@
       "syndicated": "Syndicated",
       "unlisted": "Unlisted"
     },
+    "new": {
+      "title": "What type of post do you want to create?"
+    },
     "create": {
       "action": "New post",
       "title": "Create a new %s post"
@@ -53,6 +56,8 @@
     },
     "form": {
       "advancedOptions": "Advanced options",
+      "back": "Change post type",
+      "continue": "Continue",
       "publish": "Publish post",
       "update": "Update post",
       "publishDraft": "Save draft",

--- a/packages/endpoint-posts/locales/es.json
+++ b/packages/endpoint-posts/locales/es.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "Opciones avanzadas",
+      "back": "Cambiar tipo de publicación",
       "bookmark-of": {
         "label": "Marcador de"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "Contenido"
       },
+      "continue": "Continuar",
       "geo": {
         "hint": "Latitud y longitud, por ejemplo %s",
         "label": "Coordenadas de ubicación"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "Visibilidad"
       }
+    },
+    "new": {
+      "title": "¿Qué tipo de publicación quieres crear?"
     },
     "post": {
       "properties": "Propiedades",

--- a/packages/endpoint-posts/locales/fr.json
+++ b/packages/endpoint-posts/locales/fr.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "Options avancées",
+      "back": "Modifier le type de publication",
       "bookmark-of": {
         "label": "Signet de"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "Contenu"
       },
+      "continue": "Continuer",
       "geo": {
         "hint": "Latitude et longitude, par exemple %s",
         "label": "Coordonnées de localisation"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "Visibilité"
       }
+    },
+    "new": {
+      "title": "Quel type de publication souhaitez-vous créer ?"
     },
     "post": {
       "properties": "Propriétés",

--- a/packages/endpoint-posts/locales/id.json
+++ b/packages/endpoint-posts/locales/id.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "Opsi lanjutan",
+      "back": "Ubah jenis posting",
       "bookmark-of": {
         "label": "Penanda dari"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "Konten"
       },
+      "continue": "Lanjutkan",
       "geo": {
         "hint": "Lintang dan bujur, misalnya %s",
         "label": "Koordinat lokasi"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "Visibilitas"
       }
+    },
+    "new": {
+      "title": "Jenis posting apa yang ingin Anda buat?"
     },
     "post": {
       "properties": "Properti",

--- a/packages/endpoint-posts/locales/nl.json
+++ b/packages/endpoint-posts/locales/nl.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "Geavanceerde opties",
+      "back": "Berichttype wijzigen",
       "bookmark-of": {
         "label": "Bladwijzer van"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "Inhoud"
       },
+      "continue": "Doorgaan",
       "geo": {
         "hint": "Lengte- en breedtegraad, bijvoorbeeld %s",
         "label": "Locatiecoördinaten"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "Zichtbaarheid"
       }
+    },
+    "new": {
+      "title": "Wat voor soort post wil je maken?"
     },
     "post": {
       "properties": "Eigenschappen",

--- a/packages/endpoint-posts/locales/pl.json
+++ b/packages/endpoint-posts/locales/pl.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "Zaawansowane opcje",
+      "back": "Zmień typ posta",
       "bookmark-of": {
         "label": "Zakładka z"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "Zawartość"
       },
+      "continue": "Kontynuuj",
       "geo": {
         "hint": "Szerokość i długość geograficzna, na przykład %s",
         "label": "Współrzędne lokalizacji"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "Widoczność"
       }
+    },
+    "new": {
+      "title": "Jaki rodzaj postu chcesz utworzyć?"
     },
     "post": {
       "properties": "Właściwości",

--- a/packages/endpoint-posts/locales/pt.json
+++ b/packages/endpoint-posts/locales/pt.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "Opções avançadas",
+      "back": "Alterar tipo de postagem",
       "bookmark-of": {
         "label": "Marcador de"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "Conteúdo"
       },
+      "continue": "Continuar",
       "geo": {
         "hint": "Latitude e longitude, por exemplo %s",
         "label": "Coordenadas de localização"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "Visibilidade"
       }
+    },
+    "new": {
+      "title": "Que tipo de postagem você quer criar?"
     },
     "post": {
       "properties": "Propriedades",

--- a/packages/endpoint-posts/locales/sr.json
+++ b/packages/endpoint-posts/locales/sr.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "Napredne opcije",
+      "back": "Promenite tip posta",
       "bookmark-of": {
         "label": "Bookmark of"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "Sadržaj"
       },
+      "continue": "Nastavi",
       "geo": {
         "hint": "Geografska širina i dužina, na primer %s",
         "label": "Koordinate lokacije"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "Vidljivost"
       }
+    },
+    "new": {
+      "title": "Koju vrstu posta želite da kreirate?"
     },
     "post": {
       "properties": "Svojstva",

--- a/packages/endpoint-posts/locales/zh-Hans-CN.json
+++ b/packages/endpoint-posts/locales/zh-Hans-CN.json
@@ -35,6 +35,7 @@
     },
     "form": {
       "advancedOptions": "高级选项",
+      "back": "更改帖子类型",
       "bookmark-of": {
         "label": "书签来自"
       },
@@ -45,6 +46,7 @@
       "content": {
         "label": "内容"
       },
+      "continue": "继续",
       "geo": {
         "hint": "纬度和经度，例如 %s",
         "label": "位置坐标"
@@ -84,6 +86,9 @@
       "visibility": {
         "label": "可见度"
       }
+    },
+    "new": {
+      "title": "你想创建什么类型的帖子？"
     },
     "post": {
       "properties": "属性",

--- a/packages/endpoint-posts/tests/integration/200-get-new.js
+++ b/packages/endpoint-posts/tests/integration/200-get-new.js
@@ -1,0 +1,19 @@
+import test from "ava";
+import supertest from "supertest";
+import { JSDOM } from "jsdom";
+import { testServer } from "@indiekit-test/server";
+import { testCookie } from "@indiekit-test/session";
+
+test("Returns create new post page", async (t) => {
+  const server = await testServer();
+  const request = supertest.agent(server);
+  const response = await request
+    .get("/posts/new")
+    .set("cookie", [testCookie()]);
+  const dom = new JSDOM(response.text);
+  const result = dom.window.document.querySelector("title").textContent;
+
+  t.is(result, "What type of post do you want to create? - Test configuration");
+
+  server.close(t);
+});

--- a/packages/endpoint-posts/views/new.njk
+++ b/packages/endpoint-posts/views/new.njk
@@ -1,0 +1,22 @@
+{% extends "form.njk" %}
+
+{% block fieldset %}
+  {{ radios({
+    idPrefix: "type",
+    name: "type",
+    values: postType,
+    items: postTypeItems
+  }) | indent(2) }}
+{% endblock %}
+
+{% block buttons %}
+  <div class="button-group">
+    {{ button({
+      text: __("posts.form.continue")
+    }) | indent(4) }}
+
+    {{ prose({
+      text: "[" + __("posts.form.cancel") + "](" + postsPath + ")"
+    }) | indent(4) }}
+  </div>
+{% endblock %}

--- a/packages/frontend/layouts/default.njk
+++ b/packages/frontend/layouts/default.njk
@@ -70,7 +70,8 @@
   details: error.stack if error
 }) if error or success or notice }}
 {{- backLink({
-  href: back
+  href: back.href or back,
+  text: back.text
 }) if back }}
 {% block main %}
 {% endblock %}


### PR DESCRIPTION
Fixes #631.

When clicking ‘New post’, prior to showing a post screen that defaults to the Note post type, instead show a screen that asks the user which type of post they want to create:

<img src="https://github.com/getindiekit/indiekit/assets/813383/2df5bf94-db47-4345-9684-155a0c5f857a" alt="Screenshot of form asking the user ‘What type of post do you want to create?’, with available post types listed as radio options below."> 

If you select a post type from the dashboard, this selection screen is skipped.