### PR TITLE
Mastodon syndicator: use same post visibility when syndicating status

### DIFF
--- a/helpers/fixtures/jf2/note-visibility-unlisted.jf2
+++ b/helpers/fixtures/jf2/note-visibility-unlisted.jf2
@@ -1,0 +1,7 @@
+{
+  "type": "entry",
+  "content": {
+    "html": "<p>I ate a cheese sandwich, which was nice.</p>"
+  },
+  "visibility": "unlisted"
+}

--- a/packages/syndicator-mastodon/README.md
+++ b/packages/syndicator-mastodon/README.md
@@ -26,6 +26,14 @@ Add `@indiekit/syndicator-mastodon` to your list of plug-ins, specifying options
 }
 ```
 
+When sharing content to Mastodon using this syndicator, any post visibility setting will be used for the syndicated status:
+
+| Micropub post visibility | Mastodon status visibility |
+| ------------------------ | -------------------------- |
+| Public                   | Public                     |
+| Unlisted                 | Unlisted                   |
+| Private                  | Followers only             |
+
 ## Options
 
 | Option           | Type      | Description                                                                                                   |

--- a/packages/syndicator-mastodon/lib/utils.js
+++ b/packages/syndicator-mastodon/lib/utils.js
@@ -65,6 +65,11 @@ export const createStatus = (properties, options = {}) => {
     }
   }
 
+  // If post visibility set, use the same setting when sharing to Mastodon
+  if (properties.visibility) {
+    parameters.visibility = properties.visibility;
+  }
+
   return parameters;
 };
 

--- a/packages/syndicator-mastodon/tests/unit/utils.js
+++ b/packages/syndicator-mastodon/tests/unit/utils.js
@@ -18,6 +18,18 @@ test("Creates a status with article post name and URL", (t) => {
   t.is(result.status, "What I had for lunch https://foo.bar/lunchtime");
 });
 
+test("Creates a status that is unlisted", (t) => {
+  const result = createStatus(
+    JSON.parse(getFixture("jf2/note-visibility-unlisted.jf2")),
+    {
+      serverUrl: "https://mastodon.example",
+    }
+  );
+
+  t.is(result.status, "I ate a cheese sandwich, which was nice.");
+  t.is(result.visibility, "unlisted");
+});
+
 test("Creates a status with HTML content", (t) => {
   const result = createStatus(
     JSON.parse(getFixture("jf2/note-content-provided-html.jf2")),


### PR DESCRIPTION
Partial (or perhaps full) fix for #590.

If the `visibility` property has been set for a post, this same status is used when syndicating the post to Mastodon. As these properties have 1:1 relationship, no conversion is needed.

Now, is it the case that you might want a post to be public on your own website, but private or unlisted on Mastodon? Quite possibly. However, this takes us down the road of setting post visibility for each syndication target, which adds perhaps undue complexity.