### PR TITLE
Add option to generate Docker files during setup

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -61,7 +61,7 @@ The wizard will walk you through every step of configuring a new server, and wil
 - details about your [content store](concepts.md#content-store)
 - if you want to [syndicate your posts](concepts.md#syndicator) to other websites
 
-Once you have completed the configuration wizard, you will have a folder containing a configuration file (`.indiekitrc.json`), as well as a few other files required by Node.js to run your server.
+Once you have completed the configuration wizard, you will have a folder containing the files required by Node.js to run your server.
 
 View the full list of [configuration options](configuration/index.md) to see how you can further customise your Indiekit server.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -60,8 +60,11 @@ The wizard will walk you through every step of configuring a new server, and wil
 - if you want to use a [publication preset](concepts.md#publication-preset)
 - details about your [content store](concepts.md#content-store)
 - if you want to [syndicate your posts](concepts.md#syndicator) to other websites
+- if you want to deploy your server using [Docker](https://www.docker.com)
 
 Once you have completed the configuration wizard, you will have a folder containing the files required by Node.js to run your server.
+
+If you chose server deployment using Docker, `docker-compose.yml`, `Dockerfile` and `.dockerignore` files will also be generated.
 
 View the full list of [configuration options](configuration/index.md) to see how you can further customise your Indiekit server.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15763,7 +15763,8 @@
     },
     "node_modules/yaml": {
       "version": "2.3.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "engines": {
         "node": ">= 14"
       }
@@ -15893,7 +15894,8 @@
         "@indiekit/util": "^1.0.0-beta.4",
         "base-create": "^3.0.7",
         "chalk": "^5.0.0",
-        "prompts": "^2.4.2"
+        "prompts": "^2.4.2",
+        "yaml": "^2.3.1"
       },
       "bin": {
         "create-indiekit": "bin/create.js"

--- a/packages/create-indiekit/files/template.dockerfile
+++ b/packages/create-indiekit/files/template.dockerfile
@@ -1,0 +1,24 @@
+# Adjust NODE_VERSION as desired
+ARG NODE_VERSION=20.5.0
+FROM node:${NODE_VERSION}-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Set production environment
+ENV NODE_ENV=production
+
+# Install node modules
+COPY package*.json ./
+
+# Can’t use `npm ci` due to https://github.com/npm/cli/issues/4828
+RUN npm i --omit=dev --package-lock=false
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 3000
+
+# Start the server by default, this can be overwritten at runtime
+CMD [ "npx", "indiekit", "serve" ]

--- a/packages/create-indiekit/files/template.dockerignore
+++ b/packages/create-indiekit/files/template.dockerignore
@@ -1,0 +1,14 @@
+# Docker
+.docker
+.dockerignore
+
+# Environment
+.env
+
+# Git
+.git
+.gitignore
+
+# Node
+node_modules
+npm-debug.log

--- a/packages/create-indiekit/files/template.gitignore
+++ b/packages/create-indiekit/files/template.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/create-indiekit/index.js
+++ b/packages/create-indiekit/index.js
@@ -4,6 +4,7 @@ import create from "base-create";
 import chalk from "chalk";
 import prompts from "prompts";
 import { setupPrompts } from "./lib/setup-prompts.js";
+import { getFiles } from "./lib/files.js";
 import { getPackageValues } from "./lib/package.js";
 // eslint-ignore import/order
 const require = createRequire(import.meta.url);
@@ -29,18 +30,12 @@ export async function init() {
   // Get values for package.json based on answers
   const { config, dependencies } = await getPackageValues(setup);
 
+  // Get files to be generated
+  const files = await getFiles(setup);
+
   create({
     dependencies,
-    files: [
-      {
-        path: "README.md",
-        contents: `# Indiekit server for ${setup.me}\n\nLearn more at <https://getindiekit.com>\n`,
-      },
-      {
-        path: ".gitignore",
-        contents: "node_modules/",
-      },
-    ],
+    files,
     package: {
       description: `Indiekit server for ${setup.me}`,
       keywords: ["indiekit", "indieweb"],

--- a/packages/create-indiekit/index.js
+++ b/packages/create-indiekit/index.js
@@ -4,7 +4,7 @@ import create from "base-create";
 import chalk from "chalk";
 import prompts from "prompts";
 import { setupPrompts } from "./lib/setup-prompts.js";
-import { addPluginConfig } from "./lib/utils.js";
+import { getPackageValues } from "./lib/package.js";
 // eslint-ignore import/order
 const require = createRequire(import.meta.url);
 const { name, version, bugs } = require("./package.json");
@@ -26,48 +26,23 @@ export async function init() {
   // Ask setup questions
   const setup = await prompts(setupPrompts);
 
-  const { me, presetPlugin, storePlugin, syndicatorPlugins } = setup;
-  const dependencies = ["@indiekit/indiekit"];
-  const config = {
-    plugins: [],
-    publication: { me },
-  };
-
-  if (presetPlugin) {
-    dependencies.push(presetPlugin);
-    await addPluginConfig(presetPlugin, config);
-  }
-
-  if (storePlugin) {
-    dependencies.push(storePlugin);
-    await addPluginConfig(storePlugin, config);
-  }
-
-  if (syndicatorPlugins) {
-    for await (const syndicatorPlugin of syndicatorPlugins) {
-      dependencies.push(syndicatorPlugin);
-      await addPluginConfig(syndicatorPlugin, config);
-    }
-  }
+  // Get values for package.json based on answers
+  const { config, dependencies } = await getPackageValues(setup);
 
   create({
     dependencies,
     files: [
       {
         path: "README.md",
-        contents: `# Indiekit server for ${me}\n\nLearn more at <https://getindiekit.com>\n`,
+        contents: `# Indiekit server for ${setup.me}\n\nLearn more at <https://getindiekit.com>\n`,
       },
       {
         path: ".gitignore",
         contents: "node_modules/",
       },
-      {
-        path: ".indiekitrc.json",
-        contents: config,
-      },
     ],
     package: {
-      description: `Indiekit server for ${me}`,
+      description: `Indiekit server for ${setup.me}`,
       keywords: ["indiekit", "indieweb"],
       scripts: {
         start: "indiekit serve",
@@ -76,6 +51,7 @@ export async function init() {
         node: nodeVersion.toString(),
       },
       type: "module",
+      indiekit: config,
     },
     skipGitignore: true,
   });

--- a/packages/create-indiekit/lib/docker.js
+++ b/packages/create-indiekit/lib/docker.js
@@ -1,0 +1,70 @@
+import YAML from "yaml";
+import { getPlugin } from "./utils.js";
+
+/**
+ * Get Docker Compose file contents
+ * @param {Array} environment - Environment variables
+ * @returns {string} Docker Compose file contents
+ */
+export const getDockerComposeFileContent = (environment) => {
+  const compose = {
+    version: "3.9",
+    services: {
+      indiekit: {
+        container_name: "indiekit",
+        image: "getindiekit/indiekit",
+        restart: "always",
+        build: ".",
+        ports: ["${HTTP_PORT:-3000}:3000"],
+        environment: [
+          "MONGO_URL=mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@mongo",
+          "PASSWORD_SECRET",
+          "SECRET",
+          ...environment,
+        ],
+      },
+      mongo: {
+        container_name: "mongo",
+        image: "mongo:4",
+        restart: "always",
+        volumes: ["mongo:/data/db"],
+        environment: [
+          "MONGO_INITDB_ROOT_USERNAME",
+          "MONGO_INITDB_ROOT_PASSWORD",
+        ],
+      },
+    },
+    volumes: {
+      mongo: {
+        external: true,
+      },
+    },
+  };
+
+  return YAML.stringify(compose);
+};
+
+/**
+ * Get environment variables required by plug-ins
+ * @param {object} setup - Setup answers
+ * @returns {Promise<Array>} Environment variables
+ */
+export const getDockerEnvironment = async (setup) => {
+  const { storePlugin, syndicatorPlugins } = setup;
+
+  let variables = [];
+
+  if (storePlugin) {
+    const { environment } = await getPlugin(storePlugin);
+    variables = [...variables, ...(environment || [])];
+  }
+
+  if (syndicatorPlugins) {
+    for await (const syndicatorPlugin of syndicatorPlugins) {
+      const { environment } = await getPlugin(syndicatorPlugin);
+      variables = [...variables, ...(environment || [])];
+    }
+  }
+
+  return variables;
+};

--- a/packages/create-indiekit/lib/files.js
+++ b/packages/create-indiekit/lib/files.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+import path from "node:path";
+
+/**
+ * Get file contents
+ * @param {string} fileName - Filename
+ * @returns {Promise<string>} File contents
+ */
+export const getFileContents = async (fileName) => {
+  try {
+    const filesDirectory = path.join(import.meta.url, "../../files/");
+    const filePath = new URL(fileName, filesDirectory);
+    const contents = await readFile(filePath, { encoding: "utf8" });
+
+    return contents;
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+};
+
+/**
+ * Get files to create
+ * @param {object} setup - Setup answers
+ * @returns {Promise<Array>} - Files to create
+ */
+export const getFiles = async (setup) => {
+  const { me } = setup;
+
+  const files = [
+    {
+      path: "README.md",
+      contents: `# Indiekit server for ${me}\n\nLearn more at <https://getindiekit.com>\n`,
+    },
+    {
+      path: ".gitignore",
+      contents: await getFileContents("template.gitignore"),
+    },
+  ];
+
+  return files;
+};

--- a/packages/create-indiekit/lib/files.js
+++ b/packages/create-indiekit/lib/files.js
@@ -2,6 +2,7 @@
 import { readFile } from "node:fs/promises";
 import process from "node:process";
 import path from "node:path";
+import { getDockerComposeFileContent, getDockerEnvironment } from "./docker.js";
 
 /**
  * Get file contents
@@ -27,7 +28,7 @@ export const getFileContents = async (fileName) => {
  * @returns {Promise<Array>} - Files to create
  */
 export const getFiles = async (setup) => {
-  const { me } = setup;
+  const { me, useDocker } = setup;
 
   const files = [
     {
@@ -39,6 +40,25 @@ export const getFiles = async (setup) => {
       contents: await getFileContents("template.gitignore"),
     },
   ];
+
+  if (useDocker) {
+    const environment = await getDockerEnvironment(setup);
+
+    files.push(
+      {
+        path: "docker-compose.yml",
+        contents: getDockerComposeFileContent(environment),
+      },
+      {
+        path: "Dockerfile",
+        contents: await getFileContents("template.dockerfile"),
+      },
+      {
+        path: ".dockerignore",
+        contents: await getFileContents("template.dockerignore"),
+      },
+    );
+  }
 
   return files;
 };

--- a/packages/create-indiekit/lib/package.js
+++ b/packages/create-indiekit/lib/package.js
@@ -1,0 +1,39 @@
+import { addPluginConfig } from "./utils.js";
+
+/**
+ * Get package values
+ * @param {object} setup - Setup answers
+ * @returns {Promise<object>} Package values
+ */
+export const getPackageValues = async (setup) => {
+  const { me, presetPlugin, storePlugin, syndicatorPlugins } = setup;
+
+  const config = {
+    plugins: [],
+    publication: { me },
+  };
+
+  const dependencies = ["@indiekit/indiekit"];
+
+  if (presetPlugin) {
+    dependencies.push(presetPlugin);
+    await addPluginConfig(presetPlugin, config);
+  }
+
+  if (storePlugin) {
+    dependencies.push(storePlugin);
+    await addPluginConfig(storePlugin, config);
+  }
+
+  if (syndicatorPlugins) {
+    for await (const syndicatorPlugin of syndicatorPlugins) {
+      dependencies.push(syndicatorPlugin);
+      await addPluginConfig(syndicatorPlugin, config);
+    }
+  }
+
+  return {
+    config,
+    dependencies,
+  };
+};

--- a/packages/create-indiekit/lib/setup-prompts.js
+++ b/packages/create-indiekit/lib/setup-prompts.js
@@ -78,4 +78,9 @@ export const setupPrompts = [
       },
     ],
   },
+  {
+    type: "confirm",
+    name: "useDocker",
+    message: "Do you want to deploy your server using Docker?",
+  },
 ];

--- a/packages/create-indiekit/lib/utils.js
+++ b/packages/create-indiekit/lib/utils.js
@@ -18,9 +18,11 @@ export const addPluginConfig = async (pluginName, config) => {
   // Add plug-in to list of installed plug-ins
   config.plugins.push(pluginName);
 
-  // Add plug-in configuration values
+  // Add any plug-in configuration values
   const pluginConfig = await prompts(plugin.prompts);
-  config[pluginName] = pluginConfig;
+  if (Object.keys(pluginConfig).length > 0) {
+    config[pluginName] = pluginConfig;
+  }
 
   return config;
 };

--- a/packages/create-indiekit/package.json
+++ b/packages/create-indiekit/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "bin",
+    "files",
     "lib",
     "index.js"
   ],

--- a/packages/create-indiekit/package.json
+++ b/packages/create-indiekit/package.json
@@ -47,7 +47,8 @@
     "@indiekit/util": "^1.0.0-beta.4",
     "base-create": "^3.0.7",
     "chalk": "^5.0.0",
-    "prompts": "^2.4.2"
+    "prompts": "^2.4.2",
+    "yaml": "^2.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/create-indiekit/tests/unit/docker.js
+++ b/packages/create-indiekit/tests/unit/docker.js
@@ -1,0 +1,31 @@
+import test from "ava";
+import {
+  getDockerComposeFileContent,
+  getDockerEnvironment,
+} from "../../lib/docker.js";
+
+test("Gets Docker Compose file contents", async (t) => {
+  const result = await getDockerComposeFileContent(["FOO", "BAR"]);
+
+  t.true(result.includes('version: "3.9"'));
+  t.regex(result, /- FOO\n/);
+  t.regex(result, /- BAR\n/);
+});
+
+test("Gets environment variables required by plug-ins", async (t) => {
+  const setup = {
+    storePlugin: "@indiekit-test/store", // Plug-in with no environment
+    syndicatorPlugins: [
+      "@indiekit/syndicator-internet-archive",
+      "@indiekit/syndicator-mastodon",
+    ],
+  };
+
+  const result = await getDockerEnvironment(setup);
+
+  t.deepEqual(result, [
+    "INTERNET_ARCHIVE_ACCESS_KEY",
+    "INTERNET_ARCHIVE_SECRET_KEY",
+    "MASTODON_ACCESS_TOKEN",
+  ]);
+});

--- a/packages/create-indiekit/tests/unit/files.js
+++ b/packages/create-indiekit/tests/unit/files.js
@@ -39,3 +39,14 @@ test("Gets files to create", async (t) => {
     },
   ]);
 });
+
+test("Gets files to create, including docker files", async (t) => {
+  const result = await getFiles({
+    me: "https://website.example",
+    useDocker: true,
+  });
+
+  t.is(result[2].path, "docker-compose.yml");
+  t.is(result[3].path, "Dockerfile");
+  t.is(result[4].path, ".dockerignore");
+});

--- a/packages/create-indiekit/tests/unit/files.js
+++ b/packages/create-indiekit/tests/unit/files.js
@@ -1,0 +1,41 @@
+import process from "node:process";
+import test from "ava";
+import sinon from "sinon";
+import { getFileContents, getFiles } from "../../lib/files.js";
+
+test("Gets file contents", async (t) => {
+  const result = await getFileContents("template.gitignore");
+
+  t.is(result, "node_modules/\n");
+});
+
+test("Throws error getting file contents", async (t) => {
+  sinon.stub(console, "error");
+  sinon.stub(process, "exit");
+
+  await getFileContents("template.foo");
+
+  t.true(
+    console.error.calledWith(
+      sinon.match((value) =>
+        value.includes("ENOENT: no such file or directory"),
+      ),
+    ),
+  );
+  t.true(process.exit.calledWith(1));
+});
+
+test("Gets files to create", async (t) => {
+  const result = await getFiles({ me: "https://website.example" });
+
+  t.deepEqual(result, [
+    {
+      path: "README.md",
+      contents: `# Indiekit server for https://website.example\n\nLearn more at <https://getindiekit.com>\n`,
+    },
+    {
+      path: ".gitignore",
+      contents: "node_modules/\n",
+    },
+  ]);
+});

--- a/packages/create-indiekit/tests/unit/package.js
+++ b/packages/create-indiekit/tests/unit/package.js
@@ -1,0 +1,28 @@
+import test from "ava";
+import sinon from "sinon";
+import { getPackageValues } from "../../lib/package.js";
+
+test("Gets package values", async (t) => {
+  sinon.stub(console, "info");
+
+  const result = await getPackageValues({
+    me: "https://website.example",
+    presetPlugin: "@indiekit/preset-jekyll",
+    storePlugin: "@indiekit-test/store",
+    syndicationPlugins: [],
+  });
+
+  t.deepEqual(result, {
+    config: {
+      plugins: ["@indiekit/preset-jekyll", "@indiekit-test/store"],
+      publication: {
+        me: "https://website.example",
+      },
+    },
+    dependencies: [
+      "@indiekit/indiekit",
+      "@indiekit/preset-jekyll",
+      "@indiekit-test/store",
+    ],
+  });
+});

--- a/packages/create-indiekit/tests/unit/utils.js
+++ b/packages/create-indiekit/tests/unit/utils.js
@@ -13,7 +13,6 @@ test("Adds plug-in to Indiekit configuration", async (t) => {
   });
 
   t.deepEqual(result, {
-    "@indiekit/preset-jekyll": {},
     plugins: ["@indiekit/preset-jekyll"],
   });
 });

--- a/packages/store-bitbucket/index.js
+++ b/packages/store-bitbucket/index.js
@@ -25,6 +25,10 @@ export default class BitbucketStore {
     this.options = { ...defaults, ...options };
   }
 
+  get environment() {
+    return ["BITBUCKET_PASSWORD"];
+  }
+
   get info() {
     const { repo, user } = this.options;
 

--- a/packages/store-bitbucket/tests/index.js
+++ b/packages/store-bitbucket/tests/index.js
@@ -13,6 +13,10 @@ test.beforeEach((t) => {
   t.context.bitbucketUrl = "https://api.bitbucket.org";
 });
 
+test("Gets plug-in environment", (t) => {
+  t.deepEqual(bitbucket.environment, ["BITBUCKET_PASSWORD"]);
+});
+
 test("Gets plug-in info", (t) => {
   t.is(bitbucket.name, "Bitbucket store");
   t.is(bitbucket.info.name, "username/repo on Bitbucket");

--- a/packages/store-ftp/index.js
+++ b/packages/store-ftp/index.js
@@ -30,6 +30,10 @@ export default class FtpStore {
     this.options = { ...defaults, ...options };
   }
 
+  get environment() {
+    return ["FTP_PASSWORD", "FTP_USER"];
+  }
+
   get info() {
     const { directory, host, user } = this.options;
 

--- a/packages/store-ftp/tests/index.js
+++ b/packages/store-ftp/tests/index.js
@@ -8,6 +8,10 @@ const ftp = new FtpStore({
   password: "password",
 });
 
+test("Gets plug-in environment", (t) => {
+  t.deepEqual(ftp.environment, ["FTP_PASSWORD", "FTP_USER"]);
+});
+
 test("Gets plug-in info", (t) => {
   t.is(ftp.name, "FTP store");
   t.is(ftp.info.name, "username on ftp.server.example");

--- a/packages/store-gitea/index.js
+++ b/packages/store-gitea/index.js
@@ -24,6 +24,10 @@ export default class GiteaStore {
     this.options = { ...defaults, ...options };
   }
 
+  get environment() {
+    return ["GITEA_TOKEN"];
+  }
+
   get info() {
     const { instance, repo, user } = this.options;
 

--- a/packages/store-gitea/tests/index.js
+++ b/packages/store-gitea/tests/index.js
@@ -18,6 +18,10 @@ const giteaInstance = new GiteaStore({
   repo: "repo",
 });
 
+test("Gets plug-in environment", (t) => {
+  t.deepEqual(gitea.environment, ["GITEA_TOKEN"]);
+});
+
 test("Gets plug-in info", (t) => {
   t.is(gitea.name, "Gitea store");
   t.is(gitea.info.name, "username/repo on Gitea");

--- a/packages/store-github/index.js
+++ b/packages/store-github/index.js
@@ -23,6 +23,10 @@ export default class GithubStore {
     this.options = { ...defaults, ...options };
   }
 
+  get environment() {
+    return ["GITHUB_TOKEN"];
+  }
+
   get info() {
     const { repo, user } = this.options;
 

--- a/packages/store-github/tests/index.js
+++ b/packages/store-github/tests/index.js
@@ -11,6 +11,10 @@ const github = new GithubStore({
   repo: "repo",
 });
 
+test("Gets plug-in environment", (t) => {
+  t.deepEqual(github.environment, ["GITHUB_TOKEN"]);
+});
+
 test("Gets plug-in info", (t) => {
   t.is(github.name, "GitHub store");
   t.is(github.info.name, "user/repo on GitHub");

--- a/packages/store-gitlab/index.js
+++ b/packages/store-gitlab/index.js
@@ -30,6 +30,10 @@ export default class GitlabStore {
     this.projectId = options.projectId || `${options.user}/${options.repo}`;
   }
 
+  get environment() {
+    return ["GITLAB_TOKEN"];
+  }
+
   get info() {
     const { instance, repo, user } = this.options;
 

--- a/packages/store-gitlab/tests/index.js
+++ b/packages/store-gitlab/tests/index.js
@@ -17,6 +17,10 @@ const gitlabInstance = new GitlabStore({
   instance: "https://gitlab.instance",
 });
 
+test("Gets plug-in environment", (t) => {
+  t.deepEqual(gitlab.environment, ["GITLAB_TOKEN"]);
+});
+
 test("Gets plug-in info", (t) => {
   t.is(gitlab.name, "GitLab store");
   t.is(gitlab.info.name, "username/repo on GitLab");

--- a/packages/syndicator-internet-archive/index.js
+++ b/packages/syndicator-internet-archive/index.js
@@ -25,6 +25,10 @@ export default class InternetArchiveSyndicator {
     this.options = { ...defaults, ...options };
   }
 
+  get environment() {
+    return ["INTERNET_ARCHIVE_ACCESS_KEY", "INTERNET_ARCHIVE_SECRET_KEY"];
+  }
+
   get info() {
     return {
       checked: this.options.checked,

--- a/packages/syndicator-internet-archive/tests/index.js
+++ b/packages/syndicator-internet-archive/tests/index.js
@@ -16,6 +16,13 @@ test.beforeEach((t) => {
   };
 });
 
+test("Gets plug-in environment", (t) => {
+  t.deepEqual(internetArchive.environment, [
+    "INTERNET_ARCHIVE_ACCESS_KEY",
+    "INTERNET_ARCHIVE_SECRET_KEY",
+  ]);
+});
+
 test("Gets plug-in info", (t) => {
   t.is(internetArchive.name, "Internet Archive syndicator");
   t.false(internetArchive.info.checked);

--- a/packages/syndicator-mastodon/index.js
+++ b/packages/syndicator-mastodon/index.js
@@ -42,6 +42,10 @@ export default class MastodonSyndicator {
     throw new Error("Mastodon user name required");
   }
 
+  get environment() {
+    return ["MASTODON_ACCESS_TOKEN"];
+  }
+
   get info() {
     const { checked } = this.options;
     const user = this.#user;

--- a/packages/syndicator-mastodon/tests/index.js
+++ b/packages/syndicator-mastodon/tests/index.js
@@ -23,6 +23,10 @@ test.beforeEach((t) => {
   };
 });
 
+test("Gets plug-in environment", (t) => {
+  t.deepEqual(mastodon.environment, ["MASTODON_ACCESS_TOKEN"]);
+});
+
 test("Gets plug-in info", (t) => {
   t.is(mastodon.name, "Mastodon syndicator");
   t.false(mastodon.info.checked);


### PR DESCRIPTION
This PR adds a question to the setup flow provided by the initialisation script. It asks a final question:

> Do you want to deploy your server using Docker?

If you select yes, `docker-compose.yml`, `Dockerfile` and `.dockerignore` files will be generated.

As the `docker-compose.yml` file needs to have any environment variables declared, and as some plugins require secrets to be provided via environment variables, a new `environment` getter has been added to plug-ins, and is used to provide the names of such variables to the function that generates the `docker-compose.yml` file.

There is also some light refactoring around the creation of files and package data, abstracting parts of the code into separate functions.

Closes #101.