### PR TITLE
Prevent empty updates

### DIFF
--- a/packages/endpoint-micropub/lib/controllers/action.js
+++ b/packages/endpoint-micropub/lib/controllers/action.js
@@ -69,6 +69,18 @@ export const actionController = async (request, response, next) => {
 
         data = await postData.update(application, publication, url, body);
 
+        if (!data) {
+          content = {
+            status: 200,
+            location: url,
+            json: {
+              success: "update",
+              success_description: `Post at ${url} not updated as no properties changed`,
+            },
+          };
+          break;
+        }
+
         // Draft mode: Only update posts that have `draft` post status
         if (draftMode && data.properties["post-status"] !== "draft") {
           throw IndiekitError.insufficientScope(

--- a/packages/endpoint-micropub/tests/integration/200-action-update-ignored.js
+++ b/packages/endpoint-micropub/tests/integration/200-action-update-ignored.js
@@ -1,0 +1,40 @@
+import test from "ava";
+import supertest from "supertest";
+import { mockAgent } from "@indiekit-test/mock-agent";
+import { testServer } from "@indiekit-test/server";
+import { testToken } from "@indiekit-test/token";
+
+await mockAgent("endpoint-micropub");
+
+test("Updates post", async (t) => {
+  // Create post
+  const server = await testServer();
+  const request = supertest.agent(server);
+  const response = await request
+    .post("/micropub")
+    .auth(testToken(), { type: "bearer" })
+    .send({
+      type: ["h-entry"],
+      properties: {
+        name: ["Foobar"],
+      },
+    });
+
+  // Update post
+  const result = await request
+    .post("/micropub")
+    .auth(testToken(), { type: "bearer" })
+    .send({
+      action: "update",
+      url: response.header.location,
+      replace: {
+        name: ["Foobar"],
+      },
+    });
+
+  t.is(result.status, 200);
+  t.regex(result.headers.location, /\bfoobar\b/);
+  t.regex(result.body.success_description, /\bnot updated\b/);
+
+  server.close(t);
+});

--- a/packages/endpoint-syndicate/tests/integration/200-target-error.js
+++ b/packages/endpoint-syndicate/tests/integration/200-target-error.js
@@ -30,7 +30,7 @@ test("Returns 500 error syndicating URL", async (t) => {
   t.is(result.status, 200);
   t.is(
     result.body.success_description,
-    "Post updated at https://website.example/notes/foobar/. The following target(s) did not return a URL: https://web.archive.org/",
+    "Post at https://website.example/notes/foobar/ not updated as no properties changed. The following target(s) did not return a URL: https://web.archive.org/",
   );
 
   server.close(t);

--- a/packages/util/lib/date.js
+++ b/packages/util/lib/date.js
@@ -19,7 +19,7 @@ export const formatDate = (string, tokens, lang = "en") => {
 /**
  * Converts date to use configured time zone
  * @param {string} setting - Time zone setting
- * @param {string} dateString - Date string
+ * @param {string} [dateString] - Date string
  * @returns {string} Converted date
  *
  * setting options:
@@ -27,7 +27,7 @@ export const formatDate = (string, tokens, lang = "en") => {
  *   `server`: use server’s time zone
  *   [IANA tz timezone]: use specified time zone
  */
-export const getDate = (setting, dateString) => {
+export const getDate = (setting, dateString = "") => {
   if (setting === "client") {
     // Return given date string or create ISO string using current date
     return dateString || new Date().toISOString();


### PR DESCRIPTION
If an update action is performed that results in no properties being updated, the Micropub endpoint continues as if there were, and indeed then makes only one change, adding/updated the `updated` property. This can result in unnecessary posts to a content store.

The above can be the result of a few cases:

* Syndication shenanigans such as those described in #638
* Submitting the post editing form without making any changes

This PR changes this such that:

1. Incoming post properties are saved
2. The update actions are performed
3. The updated properties are then compared with those saved earlier; if no changes are detected, the update action is cancelled, and the following is returned to the client:

  ```txt
  HTTP/1.1 200 OK
  Location: https://website.example/my-great-post
  Content-type: application/json

  {
    success: "update",
    success_description: "Post at https://website.example/my-great-post
      not updated as no properties changed",
  }
  ```

Fixes #638 