### PR TITLE
Exclude current document from aggregated post count

### DIFF
--- a/packages/endpoint-micropub/lib/post-type-count.js
+++ b/packages/endpoint-micropub/lib/post-type-count.js
@@ -17,6 +17,7 @@ export const postTypeCount = {
 
     // Post type
     const postType = properties["post-type"];
+    const postUrl = properties.url;
     const startDate = new Date(new Date(properties.published).toDateString());
     const endDate = new Date(startDate);
     endDate.setDate(endDate.getDate() + 1);
@@ -32,6 +33,7 @@ export const postTypeCount = {
         {
           $match: {
             "properties.post-type": postType,
+            "properties.url": { $ne: postUrl },
             convertedDate: {
               $gte: startDate,
               $lt: endDate,


### PR DESCRIPTION
When updating a post, the `renderPath` function is called as it is when creating a post. That in turn calls the `postTypeCount` function. This currently gets a value for all posts, that have the same `post-type`, posted on the same day. However, that will include the post being updated, incrementing the previous count by one, and thus changing the posts URL if it includes an `{n}` token.

This PR updates the MongoDB aggregation query such that it excludes from the aggregation match any posts that have the same URL as that being updated.

Fixes #621.