### PR TITLE
Only allow slug to be editable when creating a new post

### DIFF
--- a/packages/endpoint-posts/lib/controllers/form.js
+++ b/packages/endpoint-posts/lib/controllers/form.js
@@ -16,6 +16,7 @@ export const formController = {
 
     if (scope && checkScope(scope, action)) {
       return response.render("post-form", {
+        action,
         back: {
           href: `${path.join(postsPath, "new")}?type=${postType}`,
           text: response.locals.__(`posts.form.back`),

--- a/packages/endpoint-posts/lib/middleware/post-data.js
+++ b/packages/endpoint-posts/lib/middleware/post-data.js
@@ -21,8 +21,7 @@ export const postData = {
     const checkTargets = Object.entries(request.body).length === 0;
 
     // Only show advanced options if one of those fields has been updated
-    const showAdvancedOptions =
-      post.category || post.geo || post["mp-slug"] || post.visibility;
+    const showAdvancedOptions = post.category || post.geo || post.visibility;
 
     response.locals = {
       accessToken: access_token,

--- a/packages/endpoint-posts/locales/de.json
+++ b/packages/endpoint-posts/locales/de.json
@@ -58,6 +58,7 @@
         "label": "Wie von"
       },
       "mp-slug": {
+        "hint": "Slug kann nicht geändert werden, sobald der Beitrag gespeichert wurde",
         "label": "Slug"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -86,7 +86,8 @@
         "label": "Title"
       },
       "mp-slug": {
-        "label": "URL slug"
+        "label": "URL slug",
+        "hint": "Slug cannot be changed once post has been saved"
       },
       "mp-syndicate-to": {
         "label": "Syndicate to"

--- a/packages/endpoint-posts/locales/es.json
+++ b/packages/endpoint-posts/locales/es.json
@@ -58,6 +58,7 @@
         "label": "Como de"
       },
       "mp-slug": {
+        "hint": "El slug no se puede cambiar una vez que se ha guardado la publicación",
         "label": "URL slug"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/locales/fr.json
+++ b/packages/endpoint-posts/locales/fr.json
@@ -58,6 +58,7 @@
         "label": "J’aime"
       },
       "mp-slug": {
+        "hint": "Slug cannot be changed once post has been saved",
         "label": "URL d’entrée"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/locales/id.json
+++ b/packages/endpoint-posts/locales/id.json
@@ -58,6 +58,7 @@
         "label": "Seperti"
       },
       "mp-slug": {
+        "hint": "Slug tidak dapat diubah setelah posting telah disimpan",
         "label": "URL siput"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/locales/nl.json
+++ b/packages/endpoint-posts/locales/nl.json
@@ -58,6 +58,7 @@
         "label": "Zoals van"
       },
       "mp-slug": {
+        "hint": "Slug kan niet worden gewijzigd nadat het bericht is opgeslagen",
         "label": "URL-slug"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/locales/pl.json
+++ b/packages/endpoint-posts/locales/pl.json
@@ -58,6 +58,7 @@
         "label": "Jak z"
       },
       "mp-slug": {
+        "hint": "Ślimak nie może zostać zmieniony po zapisaniu postu",
         "label": "Ślimak URL"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/locales/pt.json
+++ b/packages/endpoint-posts/locales/pt.json
@@ -58,6 +58,7 @@
         "label": "Como de"
       },
       "mp-slug": {
+        "hint": "O Slug não pode ser alterado depois que a postagem for salva",
         "label": "Slug de URL"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/locales/sr.json
+++ b/packages/endpoint-posts/locales/sr.json
@@ -58,6 +58,7 @@
         "label": "Kao od"
       },
       "mp-slug": {
+        "hint": "Slug se ne može promeniti nakon što je poruka sačuvana",
         "label": "URL slag"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/locales/zh-Hans-CN.json
+++ b/packages/endpoint-posts/locales/zh-Hans-CN.json
@@ -58,6 +58,7 @@
         "label": "像这样"
       },
       "mp-slug": {
+        "hint": "帖子保存后无法更改 Slug",
         "label": "网址 slug"
       },
       "mp-syndicate-to": {

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -193,11 +193,8 @@
       label: {
         text: __("posts.form.mp-slug.label")
       },
-      optional: true,
-      attributes: {
-        readonly: true if post["mp-slug"]
-      }
-    }) | indent(4) }}
+      optional: true
+    }) if action == "create" | indent(4) }}
 
     {{ radios({
       classes: "radios--inline",

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -193,6 +193,9 @@
       label: {
         text: __("posts.form.mp-slug.label")
       },
+      hint: {
+        text: __("posts.form.mp-slug.hint")
+      },
       optional: true
     }) if action == "create" | indent(4) }}
 


### PR DESCRIPTION
#635 opened a can of worms, reminding me of Indiekit’s current inability to submit any updates to a post that would effect its saved file location, certainly when interacting with certain Git providers. However, a good initial change to attempt to resolve the original issue is to:

* add hint text to explain that a post slug cannot be changed once a post has been saved
* prevent editing a slug for saved posts