### PR TITLE
Basic media post type support

### DIFF
--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -57,6 +57,7 @@ export default class PostsEndpoint {
       "bookmark",
       "reply",
       "like",
+      "photo",
       "rsvp",
       "repost",
     ];

--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -60,6 +60,7 @@ export default class PostsEndpoint {
       "photo",
       "rsvp",
       "repost",
+      "video",
     ];
   }
 }

--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -53,6 +53,7 @@ export default class PostsEndpoint {
     Indiekit.config.application.postsEndpoint = this.mountPath;
     Indiekit.config.application.supportedPostTypes = [
       "article",
+      "audio",
       "note",
       "bookmark",
       "reply",

--- a/packages/endpoint-posts/lib/middleware/validation.js
+++ b/packages/endpoint-posts/lib/middleware/validation.js
@@ -43,6 +43,15 @@ export const validate = [
     )
     .notEmpty()
     .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+  check("photo")
+    .if((value, { req }) => req.body?.["post-type"] === "photo")
+    .exists()
+    .isURL()
+    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+  check("mp-photo-alt")
+    .if((value, { req }) => req.body?.["post-type"] === "photo")
+    .notEmpty()
+    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
   check("geo")
     .if((value, { req }) => req.body?.geo)
     .custom((value) => value.match(LAT_LONG_RE))

--- a/packages/endpoint-posts/lib/middleware/validation.js
+++ b/packages/endpoint-posts/lib/middleware/validation.js
@@ -2,6 +2,11 @@ import { check } from "express-validator";
 import { LAT_LONG_RE } from "../utils.js";
 
 export const validate = [
+  check("audio")
+    .if((value, { req }) => req.body?.["post-type"] === "audio")
+    .exists()
+    .isURL()
+    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
   check("bookmark-of")
     .if((value, { req }) => req.body?.["post-type"] === "bookmark")
     .exists()

--- a/packages/endpoint-posts/lib/middleware/validation.js
+++ b/packages/endpoint-posts/lib/middleware/validation.js
@@ -58,4 +58,9 @@ export const validate = [
     .withMessage((value, { req, path }) =>
       req.__(`posts.error.${path}.invalid`),
     ),
+  check("video")
+    .if((value, { req }) => req.body?.["post-type"] === "video")
+    .exists()
+    .isURL()
+    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
 ];

--- a/packages/endpoint-posts/lib/middleware/validation.js
+++ b/packages/endpoint-posts/lib/middleware/validation.js
@@ -6,12 +6,16 @@ export const validate = [
     .if((value, { req }) => req.body?.["post-type"] === "audio")
     .exists()
     .isURL()
-    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+    .withMessage((value, { req }) =>
+      req.__(`posts.error.url.empty`, "https://example.org/audio.mp3"),
+    ),
   check("bookmark-of")
     .if((value, { req }) => req.body?.["post-type"] === "bookmark")
     .exists()
     .isURL()
-    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+    .withMessage((value, { req }) =>
+      req.__(`posts.error.url.empty`, "https://example.org"),
+    ),
   check("in-reply-to")
     .if(
       (value, { req }) =>
@@ -20,17 +24,23 @@ export const validate = [
     )
     .exists()
     .isURL()
-    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+    .withMessage((value, { req }) =>
+      req.__(`posts.error.url.empty`, "https://example.org"),
+    ),
   check("like-of")
     .if((value, { req }) => req.body?.["post-type"] === "like")
     .exists()
     .isURL()
-    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+    .withMessage((value, { req }) =>
+      req.__(`posts.error.url.empty`, "https://example.org"),
+    ),
   check("repost-of")
     .if((value, { req }) => req.body?.["post-type"] === "repost")
     .exists()
     .isURL()
-    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+    .withMessage((value, { req }) =>
+      req.__(`posts.error.url.empty`, "https://example.org"),
+    ),
   check("name")
     .if(
       (value, { req }) =>
@@ -52,7 +62,9 @@ export const validate = [
     .if((value, { req }) => req.body?.["post-type"] === "photo")
     .exists()
     .isURL()
-    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+    .withMessage((value, { req }) =>
+      req.__(`posts.error.url.empty`, "https://example.org/photo.jpg"),
+    ),
   check("mp-photo-alt")
     .if((value, { req }) => req.body?.["post-type"] === "photo")
     .notEmpty()
@@ -67,5 +79,7 @@ export const validate = [
     .if((value, { req }) => req.body?.["post-type"] === "video")
     .exists()
     .isURL()
-    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+    .withMessage((value, { req }) =>
+      req.__(`posts.error.url.empty`, "https://example.org/video.mp4"),
+    ),
 ];

--- a/packages/endpoint-posts/locales/de.json
+++ b/packages/endpoint-posts/locales/de.json
@@ -11,30 +11,31 @@
       "title": "Möchtest du diesen Beitrag wirklich löschen?"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "Geben Sie eine Webadresse wie https://example.org"
-      },
       "content": {
         "empty": "Geben Sie einige Inhalte ein"
       },
       "geo": {
         "invalid": "Geben Sie gültige Koordinaten ein"
       },
-      "in-reply-to": {
-        "empty": "Geben Sie eine Webadresse wie https://example.org"
-      },
-      "like-of": {
-        "empty": "Geben Sie eine Webadresse wie https://example.org"
+      "mp-photo-alt": {
+        "empty": "Geben Sie eine Beschreibung dieses Fotos ein"
       },
       "name": {
         "empty": "Titel eingeben"
       },
-      "repost-of": {
-        "empty": "Geben Sie eine Webadresse wie https://example.org"
+      "url": {
+        "empty": "Geben Sie eine Webadresse wie %s"
       }
     },
     "form": {
       "advancedOptions": "Erweiterte Optionen",
+      "audio": {
+        "label": "Audio",
+        "title": "Audio %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "back": "Beitragstyp ändern",
       "bookmark-of": {
         "label": "Lesezeichen für"
@@ -68,6 +69,16 @@
       "name": {
         "label": "Titel"
       },
+      "photo": {
+        "alt": {
+          "label": "Barrierefreie Beschreibung"
+        },
+        "label": "Foto",
+        "title": "Foto %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "publish": "Beitrag veröffentlichen",
       "publishDraft": "Entwurf speichern",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "Beitrag aktualisieren",
       "updateDraft": "Entwurf aktualisieren",
+      "video": {
+        "label": "Video",
+        "title": "Video %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "visibility": {
         "label": "Sichtbarkeit"
       }

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -27,6 +27,9 @@
       },
       "repost-of": {
         "empty": "Enter a web address like https://example.org"
+      },
+      "video": {
+        "empty": "Enter a web address like https://example.org/video.mp4"
       }
     },
     "status": {
@@ -121,6 +124,13 @@
       },
       "summary": {
         "label": "Summary"
+      },
+      "video": {
+        "label": "Video",
+        "title": "Video %s",
+        "url": {
+          "label": "URL"
+        }
       },
       "visibility": {
         "label": "Visibility"

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -1,6 +1,9 @@
 {
   "posts": {
     "error": {
+      "audio": {
+        "empty": "Enter a web address like https://example.org/audio.mp3"
+      },
       "bookmark-of": {
         "empty": "Enter a web address like https://example.org"
       },
@@ -72,6 +75,13 @@
       "publishDraft": "Save draft",
       "updateDraft": "Update draft",
       "cancel": "Cancel",
+      "audio": {
+        "label": "Audio",
+        "title": "Audio %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "bookmark-of": {
         "label": "Bookmark of"
       },

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -16,8 +16,14 @@
       "like-of": {
         "empty": "Enter a web address like https://example.org"
       },
+      "mp-photo-alt": {
+        "empty": "Enter a description of this photo"
+      },
       "name": {
         "empty": "Enter a title"
+      },
+      "photo": {
+        "empty": "Enter a web address like https://example.org/photo.jpg"
       },
       "repost-of": {
         "empty": "Enter a web address like https://example.org"
@@ -86,6 +92,16 @@
       },
       "name": {
         "label": "Title"
+      },
+      "photo": {
+        "label": "Photo",
+        "title": "Photo %s",
+        "alt": {
+          "label": "Accessible description"
+        },
+        "url": {
+          "label": "URL"
+        }
       },
       "mp-slug": {
         "label": "URL slug"

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -1,23 +1,11 @@
 {
   "posts": {
     "error": {
-      "audio": {
-        "empty": "Enter a web address like https://example.org/audio.mp3"
-      },
-      "bookmark-of": {
-        "empty": "Enter a web address like https://example.org"
-      },
       "content": {
         "empty": "Enter some content"
       },
       "geo": {
         "invalid": "Enter valid coordinates"
-      },
-      "in-reply-to": {
-        "empty": "Enter a web address like https://example.org"
-      },
-      "like-of": {
-        "empty": "Enter a web address like https://example.org"
       },
       "mp-photo-alt": {
         "empty": "Enter a description of this photo"
@@ -25,14 +13,8 @@
       "name": {
         "empty": "Enter a title"
       },
-      "photo": {
-        "empty": "Enter a web address like https://example.org/photo.jpg"
-      },
-      "repost-of": {
-        "empty": "Enter a web address like https://example.org"
-      },
-      "video": {
-        "empty": "Enter a web address like https://example.org/video.mp4"
+      "url": {
+        "empty": "Enter a web address like %s"
       }
     },
     "status": {

--- a/packages/endpoint-posts/locales/es.json
+++ b/packages/endpoint-posts/locales/es.json
@@ -11,30 +11,31 @@
       "title": "¿Seguro que quieres eliminar esta publicación?"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "Ingrese una dirección web como https://example.org"
-      },
       "content": {
         "empty": "Introducir algún contenido"
       },
       "geo": {
         "invalid": "Introduce coordenadas válidas"
       },
-      "in-reply-to": {
-        "empty": "Ingrese una dirección web como https://example.org"
-      },
-      "like-of": {
-        "empty": "Ingrese una dirección web como https://example.org"
+      "mp-photo-alt": {
+        "empty": "Introduce una descripción de esta foto"
       },
       "name": {
         "empty": "Pon un título"
       },
-      "repost-of": {
-        "empty": "Ingrese una dirección web como https://example.org"
+      "url": {
+        "empty": "Introduce una dirección web como %s"
       }
     },
     "form": {
       "advancedOptions": "Opciones avanzadas",
+      "audio": {
+        "label": "Sonido",
+        "title": "Sonido %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "back": "Cambiar tipo de publicación",
       "bookmark-of": {
         "label": "Marcador de"
@@ -68,6 +69,16 @@
       "name": {
         "label": "Título"
       },
+      "photo": {
+        "alt": {
+          "label": "Descripción accesible"
+        },
+        "label": "Foto",
+        "title": "Foto %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "publish": "Publicar publicación",
       "publishDraft": "Guardar borrador",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "Actualizar publicación",
       "updateDraft": "Actualizar borrador",
+      "video": {
+        "label": "Vídeo",
+        "title": "Vídeo %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "visibility": {
         "label": "Visibilidad"
       }

--- a/packages/endpoint-posts/locales/fr.json
+++ b/packages/endpoint-posts/locales/fr.json
@@ -11,30 +11,31 @@
       "title": "Êtes-vous sûr de vouloir supprimer cette publication ?"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "Saisir une adresse Web telle que https://example.org"
-      },
       "content": {
         "empty": "Saisir du contenu"
       },
       "geo": {
         "invalid": "Saisir des coordonnées valides"
       },
-      "in-reply-to": {
-        "empty": "Saisir une adresse Web telle que https://example.org"
-      },
-      "like-of": {
-        "empty": "Saisir une adresse Web telle que https://example.org"
+      "mp-photo-alt": {
+        "empty": "Entrez une description de cette photo"
       },
       "name": {
         "empty": "Saisir un titre"
       },
-      "repost-of": {
-        "empty": "Saisir une adresse Web telle que https://example.org"
+      "url": {
+        "empty": "Saisir une adresse Web telle que %s"
       }
     },
     "form": {
       "advancedOptions": "Options avancées",
+      "audio": {
+        "label": "Audio",
+        "title": "Audio %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "back": "Modifier le type de publication",
       "bookmark-of": {
         "label": "Signet de"
@@ -68,6 +69,16 @@
       "name": {
         "label": "Titre"
       },
+      "photo": {
+        "alt": {
+          "label": "Description accessible"
+        },
+        "label": "Photo",
+        "title": "Photo %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "publish": "Publier la publication",
       "publishDraft": "Enregistrer le brouillon",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "Mettre à jour la publication",
       "updateDraft": "Mettre à jour le brouillon",
+      "video": {
+        "label": "Vidéo",
+        "title": "Vidéo %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "visibility": {
         "label": "Visibilité"
       }

--- a/packages/endpoint-posts/locales/id.json
+++ b/packages/endpoint-posts/locales/id.json
@@ -11,30 +11,31 @@
       "title": "Yakin ingin menghapus postingan ini?"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "Masukkan alamat web misalnya https://example.org"
-      },
       "content": {
         "empty": "Masukkan beberapa konten"
       },
       "geo": {
         "invalid": "Masukkan koordinat yang valid"
       },
-      "in-reply-to": {
-        "empty": "Masukkan alamat web misalnya https://example.org"
-      },
-      "like-of": {
-        "empty": "Masukkan alamat web misalnya https://example.org"
+      "mp-photo-alt": {
+        "empty": "Masukkan deskripsi foto ini"
       },
       "name": {
         "empty": "Masukkan judul"
       },
-      "repost-of": {
-        "empty": "Masukkan alamat web misalnya https://example.org"
+      "url": {
+        "empty": "Masukkan alamat web misalnya %s"
       }
     },
     "form": {
       "advancedOptions": "Opsi lanjutan",
+      "audio": {
+        "label": "Audio",
+        "title": "Audio %s",
+        "url": {
+          "label": "Tautan (URL)"
+        }
+      },
       "back": "Ubah jenis posting",
       "bookmark-of": {
         "label": "Penanda dari"
@@ -68,6 +69,16 @@
       "name": {
         "label": "Judul"
       },
+      "photo": {
+        "alt": {
+          "label": "Deskripsi yang dapat diakses"
+        },
+        "label": "Foto",
+        "title": "Foto %s",
+        "url": {
+          "label": "Tautan (URL)"
+        }
+      },
       "publish": "Publikasikan postingan",
       "publishDraft": "Simpan draf",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "Perbarui pos",
       "updateDraft": "Perbarui draf",
+      "video": {
+        "label": "Video",
+        "title": "Video %s",
+        "url": {
+          "label": "Tautan (URL)"
+        }
+      },
       "visibility": {
         "label": "Visibilitas"
       }

--- a/packages/endpoint-posts/locales/nl.json
+++ b/packages/endpoint-posts/locales/nl.json
@@ -11,30 +11,31 @@
       "title": "Bent u zeker dat u dit post wilt verwijderen?"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "Voer een webadres in zoals https://example.org"
-      },
       "content": {
         "empty": "Voer wat inhoud in"
       },
       "geo": {
         "invalid": "Voer geldige coördinaten in"
       },
-      "in-reply-to": {
-        "empty": "Voer een webadres in zoals https://example.org"
-      },
-      "like-of": {
-        "empty": "Voer een webadres in zoals https://example.org"
+      "mp-photo-alt": {
+        "empty": "Voer een beschrijving van deze foto in"
       },
       "name": {
         "empty": "Geef een titel in"
       },
-      "repost-of": {
-        "empty": "Voer een webadres in zoals https://example.org"
+      "url": {
+        "empty": "Voer een webadres in zoals %s"
       }
     },
     "form": {
       "advancedOptions": "Geavanceerde opties",
+      "audio": {
+        "label": "Audio",
+        "title": "Audio %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "back": "Berichttype wijzigen",
       "bookmark-of": {
         "label": "Bladwijzer van"
@@ -68,6 +69,16 @@
       "name": {
         "label": "Titel"
       },
+      "photo": {
+        "alt": {
+          "label": "Toegankelijke beschrijving"
+        },
+        "label": "Foto",
+        "title": "Foto %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "publish": "Post publiceren",
       "publishDraft": "Concept opslaan",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "Post bijwerken",
       "updateDraft": "Concept bijwerken",
+      "video": {
+        "label": "Video",
+        "title": "Video %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "visibility": {
         "label": "Zichtbaarheid"
       }

--- a/packages/endpoint-posts/locales/pl.json
+++ b/packages/endpoint-posts/locales/pl.json
@@ -11,30 +11,31 @@
       "title": "Czy na pewno chcesz usunąć ten post?"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "Wpisz adres internetowy, taki jak https://example.org"
-      },
       "content": {
         "empty": "Wprowadź jakąś zawartość"
       },
       "geo": {
         "invalid": "Wprowadź poprawne współrzędne"
       },
-      "in-reply-to": {
-        "empty": "Wpisz adres internetowy, taki jak https://example.org"
-      },
-      "like-of": {
-        "empty": "Wpisz adres internetowy, taki jak https://example.org"
+      "mp-photo-alt": {
+        "empty": "Wprowadź opis tego zdjęcia"
       },
       "name": {
         "empty": "Wprowadź tytuł"
       },
-      "repost-of": {
-        "empty": "Wpisz adres internetowy, taki jak https://example.org"
+      "url": {
+        "empty": "Wpisz adres internetowy, taki jak %s"
       }
     },
     "form": {
       "advancedOptions": "Zaawansowane opcje",
+      "audio": {
+        "label": "Audio",
+        "title": "Audio %s",
+        "url": {
+          "label": "Adres URL"
+        }
+      },
       "back": "Zmień typ posta",
       "bookmark-of": {
         "label": "Zakładka z"
@@ -68,6 +69,16 @@
       "name": {
         "label": "Tytuł"
       },
+      "photo": {
+        "alt": {
+          "label": "Dostępny opis"
+        },
+        "label": "Zdjęcie",
+        "title": "Zdjęcie %s",
+        "url": {
+          "label": "Adres URL"
+        }
+      },
       "publish": "Opublikuj post",
       "publishDraft": "Zapisz szkic",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "Aktualizuj post",
       "updateDraft": "Zaktualizuj wersję roboczą",
+      "video": {
+        "label": "Wideo",
+        "title": "Wideo %s",
+        "url": {
+          "label": "Adres URL"
+        }
+      },
       "visibility": {
         "label": "Widoczność"
       }

--- a/packages/endpoint-posts/locales/pt.json
+++ b/packages/endpoint-posts/locales/pt.json
@@ -11,30 +11,31 @@
       "title": "Tem certeza de que deseja excluir este post?"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "Insira um endereço da web como https://example.org"
-      },
       "content": {
         "empty": "Insira algum conteúdo"
       },
       "geo": {
         "invalid": "Insira coordenadas válidas"
       },
-      "in-reply-to": {
-        "empty": "Insira um endereço da web como https://example.org"
-      },
-      "like-of": {
-        "empty": "Insira um endereço da web como https://example.org"
+      "mp-photo-alt": {
+        "empty": "Insira uma descrição desta foto"
       },
       "name": {
         "empty": "Introduza um título"
       },
-      "repost-of": {
-        "empty": "Insira um endereço da web como https://example.org"
+      "url": {
+        "empty": "Insira um endereço da web como %s"
       }
     },
     "form": {
       "advancedOptions": "Opções avançadas",
+      "audio": {
+        "label": "Áudio",
+        "title": "Áudio %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "back": "Alterar tipo de postagem",
       "bookmark-of": {
         "label": "Marcador de"
@@ -68,6 +69,16 @@
       "name": {
         "label": "Título"
       },
+      "photo": {
+        "alt": {
+          "label": "Descrição acessível"
+        },
+        "label": "Foto",
+        "title": "Foto %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "publish": "Publicar postagem",
       "publishDraft": "Salvar rascunho",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "Atualizar postagem",
       "updateDraft": "Atualizar rascunho",
+      "video": {
+        "label": "Vídeo",
+        "title": "Vídeo %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "visibility": {
         "label": "Visibilidade"
       }

--- a/packages/endpoint-posts/locales/sr.json
+++ b/packages/endpoint-posts/locales/sr.json
@@ -11,30 +11,31 @@
       "title": "Da li ste sigurni da želite da izbrišete ovu objavu?"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "Unesite veb adresu kao što je https://example.org"
-      },
       "content": {
         "empty": "Unesite neki sadržaj"
       },
       "geo": {
         "invalid": "Unesite važeće koordinate"
       },
-      "in-reply-to": {
-        "empty": "Unesite veb adresu kao što je https://example.org"
-      },
-      "like-of": {
-        "empty": "Unesite veb adresu kao što je https://example.org"
+      "mp-photo-alt": {
+        "empty": "Unesite opis ove fotografije"
       },
       "name": {
         "empty": "Unesite naslov"
       },
-      "repost-of": {
-        "empty": "Unesite veb adresu kao što je https://example.org"
+      "url": {
+        "empty": "Unesite veb adresu kao što je %s"
       }
     },
     "form": {
       "advancedOptions": "Napredne opcije",
+      "audio": {
+        "label": "Audio",
+        "title": "Audio %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "back": "Promenite tip posta",
       "bookmark-of": {
         "label": "Bookmark of"
@@ -68,6 +69,16 @@
       "name": {
         "label": "Naslov"
       },
+      "photo": {
+        "alt": {
+          "label": "Pristupačan opis"
+        },
+        "label": "Fotografija",
+        "title": "Fotografija %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "publish": "Objavi post",
       "publishDraft": "Sačuvaj nacrt",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "Ažuriraj post",
       "updateDraft": "Ažurirajte nacrt",
+      "video": {
+        "label": "Video",
+        "title": "Video %s",
+        "url": {
+          "label": "URL"
+        }
+      },
       "visibility": {
         "label": "Vidljivost"
       }

--- a/packages/endpoint-posts/locales/zh-Hans-CN.json
+++ b/packages/endpoint-posts/locales/zh-Hans-CN.json
@@ -11,30 +11,31 @@
       "title": "您确定要删除这个帖子吗？"
     },
     "error": {
-      "bookmark-of": {
-        "empty": "输入像 https://example.org 这样的网址"
-      },
       "content": {
         "empty": "输入一些内容"
       },
       "geo": {
         "invalid": "输入有效坐标"
       },
-      "in-reply-to": {
-        "empty": "输入像 https://example.org 这样的网址"
-      },
-      "like-of": {
-        "empty": "输入像 https://example.org 这样的网址"
+      "mp-photo-alt": {
+        "empty": "输入这张照片的描述"
       },
       "name": {
         "empty": "输入标题"
       },
-      "repost-of": {
-        "empty": "输入像 https://example.org 这样的网址"
+      "url": {
+        "empty": "输入像 %s 这样的网址"
       }
     },
     "form": {
       "advancedOptions": "高级选项",
+      "audio": {
+        "label": "音频",
+        "title": "音频 %s",
+        "url": {
+          "label": "网址"
+        }
+      },
       "back": "更改帖子类型",
       "bookmark-of": {
         "label": "书签来自"
@@ -68,6 +69,16 @@
       "name": {
         "label": "标题"
       },
+      "photo": {
+        "alt": {
+          "label": "无障碍描述"
+        },
+        "label": "照片",
+        "title": "照片 %s",
+        "url": {
+          "label": "网址"
+        }
+      },
       "publish": "发布帖子",
       "publishDraft": "保存草稿",
       "repost-of": {
@@ -85,6 +96,13 @@
       },
       "update": "更新帖子",
       "updateDraft": "更新草稿",
+      "video": {
+        "label": "视频",
+        "title": "视频 %s",
+        "url": {
+          "label": "网址"
+        }
+      },
       "visibility": {
         "label": "可见度"
       }

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -57,6 +57,31 @@
 {% endcall %}
 {% endmacro %}
 
+{% macro videoFieldset(index, video) %}
+{% call fieldset({
+  classes: "fieldset--group",
+  legend: {
+    text: __("posts.form.video.title", index) if video else __("posts.form.video.label")
+  }
+}) %}
+  {{ input({
+    id: "video",
+    name: "video",
+    type: "url",
+    value: errors.video.value or video.url,
+    label: {
+      text: __("posts.form.video.url.label")
+    },
+    attributes: {
+      placeholder: "https://"
+    },
+    errorMessage: {
+      text: errors.video.msg
+    } if errors.video
+  }) | indent(2) }}
+{% endcall %}
+{% endmacro %}
+
 {% block fieldset %}
   {{ input({
     name: "type",
@@ -201,6 +226,14 @@
     {{ photoFieldset(loop.index, photo) }}
   {% else %}
     {{ photoFieldset(1, false) }}
+  {% endfor %}
+{% endif %}
+
+{% if postType === "video" %}
+  {% for video in post.video %}
+    {{ videoFieldset(loop.index, video) }}
+  {% else %}
+    {{ videoFieldset(1, false) }}
   {% endfor %}
 {% endif %}
 

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -19,6 +19,44 @@
 
 {% set geo = [post.location.latitude, post.location.longitude] | join(",") if post.location %}
 
+{% macro photoFieldset(index, photo) %}
+{% call fieldset({
+  classes: "fieldset--group",
+  legend: {
+    text: __("posts.form.photo.title", index) if photo else __("posts.form.photo.label")
+  }
+}) %}
+  {{ input({
+    id: "photo",
+    name: "photo",
+    type: "url",
+    value: errors.photo.value or photo.url,
+    label: {
+      text: __("posts.form.photo.url.label")
+    },
+    attributes: {
+      placeholder: "https://"
+    },
+    errorMessage: {
+      text: errors.photo.msg
+    } if errors.photo
+  }) | indent(2) }}
+
+  {{ textarea({
+    id: "mp-photo-alt",
+    name: "mp-photo-alt",
+    value: errors["mp-photo-alt"].value or photo.alt,
+    label: {
+      text: __("posts.form.photo.alt.label")
+    },
+    rows: 1,
+    errorMessage: {
+      text: errors["mp-photo-alt"].msg
+    } if errors["mp-photo-alt"]
+  }) | indent(2) }}
+{% endcall %}
+{% endmacro %}
+
 {% block fieldset %}
   {{ input({
     name: "type",
@@ -157,6 +195,14 @@
     optional: true,
     rows: 1
   }) if postType === "article" }}
+
+{% if postType === "photo" %}
+  {% for photo in post.photo %}
+    {{ photoFieldset(loop.index, photo) }}
+  {% else %}
+    {{ photoFieldset(1, false) }}
+  {% endfor %}
+{% endif %}
 
   {{ checkboxes({
     idPrefix: "mp-syndicate-to",

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -19,6 +19,31 @@
 
 {% set geo = [post.location.latitude, post.location.longitude] | join(",") if post.location %}
 
+{% macro audioFieldset(index, audio) %}
+{% call fieldset({
+  classes: "fieldset--group",
+  legend: {
+    text: __("posts.form.audio.title", index) if audio else __("posts.form.audio.label")
+  }
+}) %}
+  {{ input({
+    id: "audio",
+    name: "audio",
+    type: "url",
+    value: errors.audio.value or audio.url,
+    label: {
+      text: __("posts.form.audio.url.label")
+    },
+    attributes: {
+      placeholder: "https://"
+    },
+    errorMessage: {
+      text: errors.audio.msg
+    } if errors.audio
+  }) | indent(2) }}
+{% endcall %}
+{% endmacro %}
+
 {% macro photoFieldset(index, photo) %}
 {% call fieldset({
   classes: "fieldset--group",
@@ -220,6 +245,14 @@
     optional: true,
     rows: 1
   }) if postType === "article" }}
+
+{% if postType === "audio" %}
+  {% for audio in post.audio %}
+    {{ audioFieldset(loop.index, audio) }}
+  {% else %}
+    {{ audioFieldset(1, false) }}
+  {% endfor %}
+{% endif %}
 
 {% if postType === "photo" %}
   {% for photo in post.photo %}

--- a/packages/frontend/components/fieldset/styles.css
+++ b/packages/frontend/components/fieldset/styles.css
@@ -12,8 +12,17 @@
 }
 
 .fieldset--group {
-  --fieldset-flow-space: var(--space-xs);
+  --fieldset-flow-space: var(--space-m);
   --label-font: var(--font-body);
+  background-color: var(--color-offset);
+  border-radius: var(--border-radius-small);
+  color: var(--color-on-offset);
   display: flex;
-  gap: var(--space-xl);
+  flex-direction: column;
+  padding: var(--space-m);
+
+  & .fieldset__legend {
+    inset-block-start: var(--space-l);
+    position: relative;
+  }
 }


### PR DESCRIPTION
Partially address #538, #539 and #540.

Adds very basic and rudimentary support for creating and editing audio, photo and video posts.

## Create

To add a media post, you can first upload a file using the Files interface. That will give you a URL that you can then paste into the URL field for the given media post type. The photo post type form also asks for an accessible description, which is required:

<img width="755" alt="Screenshot of form for creating a new photo post." src="https://github.com/getindiekit/indiekit/assets/813383/a84b3f11-4f34-4c7f-ba24-acca5d306ad0">

## Update

You can now update a media post in so much as existing values can be edited (useful for updating alt text on a published photo):

<img width="755" alt="Screenshot of form for editing a photo post." src="https://github.com/getindiekit/indiekit/assets/813383/e0293de9-2d71-493d-b68a-b7af9cf7adb1">

With these additions, `audio`, `photo` and `video` post types are now marked as supported, and will show up on the dashboard and new post creation pages.

Subsequent updates will enable adding multiple media items, and adding/removing when updating.