### PR TITLE
‘Add another‘ component

### DIFF
--- a/helpers/frontend/views/frontend-form.njk
+++ b/helpers/frontend/views/frontend-form.njk
@@ -1,6 +1,24 @@
 {% extends "form.njk" %}
 
 {% block fieldset %}
+{% call addAnother({
+  name: "thing",
+  fieldset: {
+    legend: "Things"
+  }
+}) %}
+  {{ input({
+    errorMessage: { text: "Add another input error" } if errors,
+    name: "add-another-input[0]",
+    label: "Add another input",
+    field: {
+      attributes: {
+        "data-add-another-target": "field"
+      }
+    }
+  }) | indent(2) }}
+{% endcall %}
+
 {{ input({
   errorMessage: { text: "Input error" } if errors,
   name: "input",

--- a/packages/endpoint-posts/lib/controllers/form.js
+++ b/packages/endpoint-posts/lib/controllers/form.js
@@ -72,6 +72,13 @@ export const formController = {
         }
       }
 
+      // Convert media values object to Array
+      for (const key of ["audio", "photo", "video"]) {
+        if (values[key]) {
+          values[key] = Object.values(values[key]);
+        }
+      }
+
       // Convert geo value to object
       if (values.geo) {
         values.location = getLocationProperty(values.geo);

--- a/packages/endpoint-posts/locales/de.json
+++ b/packages/endpoint-posts/locales/de.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Erweiterte Optionen",
       "audio": {
         "label": "Audio",
-        "title": "Audio %s"
+        "name": "audiodatei"
       },
       "back": "Beitragstyp ändern",
       "bookmark-of": {
@@ -76,8 +76,8 @@
         "label": "Titel"
       },
       "photo": {
-        "label": "Foto",
-        "title": "Foto %s"
+        "label": "Fotos",
+        "name": "foto"
       },
       "publish": "Beitrag veröffentlichen",
       "publishDraft": "Entwurf speichern",
@@ -97,8 +97,8 @@
       "update": "Beitrag aktualisieren",
       "updateDraft": "Entwurf aktualisieren",
       "video": {
-        "label": "Video",
-        "title": "Video %s"
+        "label": "Videos",
+        "name": "video"
       },
       "visibility": {
         "label": "Sichtbarkeit"

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -62,7 +62,7 @@
       "cancel": "Cancel",
       "audio": {
         "label": "Audio",
-        "title": "Audio %s"
+        "name": "audio file"
       },
       "bookmark-of": {
         "label": "Bookmark of"
@@ -101,8 +101,8 @@
         "label": "Syndicate to"
       },
       "photo": {
-        "label": "Photo",
-        "title": "Photo %s"
+        "label": "Photos",
+        "name": "photo"
       },
       "repost-of": {
         "label": "Repost of"
@@ -118,8 +118,8 @@
         "label": "Summary"
       },
       "video": {
-        "label": "Video",
-        "title": "Video %s"
+        "label": "Videos",
+        "name": "video"
       },
       "visibility": {
         "label": "Visibility"

--- a/packages/endpoint-posts/locales/es-419.json
+++ b/packages/endpoint-posts/locales/es-419.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Opciones avanzadas",
       "audio": {
         "label": "Audio",
-        "title": "Audio %s"
+        "name": "archivo de audio"
       },
       "back": "Cambiar tipo de publicación",
       "bookmark-of": {
@@ -76,8 +76,8 @@
         "label": "Título"
       },
       "photo": {
-        "label": "Foto",
-        "title": "Foto %s"
+        "label": "Fotos",
+        "name": "foto"
       },
       "publish": "Publicar publicación",
       "publishDraft": "Guardar borrador",
@@ -97,8 +97,8 @@
       "update": "Actualizar publicación",
       "updateDraft": "Actualizar borrador",
       "video": {
-        "label": "Vídeo",
-        "title": "Video %s"
+        "label": "Vídeos",
+        "name": "vídeo"
       },
       "visibility": {
         "label": "Visibilidad"

--- a/packages/endpoint-posts/locales/es.json
+++ b/packages/endpoint-posts/locales/es.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Opciones avanzadas",
       "audio": {
         "label": "Sonido",
-        "title": "Sonido %s"
+        "name": "archivo de audio"
       },
       "back": "Cambiar tipo de publicación",
       "bookmark-of": {
@@ -76,8 +76,8 @@
         "label": "Título"
       },
       "photo": {
-        "label": "Foto",
-        "title": "Foto %s"
+        "label": "Fotos",
+        "name": "foto"
       },
       "publish": "Publicar publicación",
       "publishDraft": "Guardar borrador",
@@ -97,8 +97,8 @@
       "update": "Actualizar publicación",
       "updateDraft": "Actualizar borrador",
       "video": {
-        "label": "Vídeo",
-        "title": "Vídeo %s"
+        "label": "Vídeos",
+        "name": "vídeo"
       },
       "visibility": {
         "label": "Visibilidad"

--- a/packages/endpoint-posts/locales/fr.json
+++ b/packages/endpoint-posts/locales/fr.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Options avancées",
       "audio": {
         "label": "Audio",
-        "title": "Audio %s"
+        "name": "fichier audio"
       },
       "back": "Modifier le type de publication",
       "bookmark-of": {
@@ -76,8 +76,8 @@
         "label": "Titre"
       },
       "photo": {
-        "label": "Photo",
-        "title": "Photo %s"
+        "label": "Photos",
+        "name": "photo"
       },
       "publish": "Publier la publication",
       "publishDraft": "Enregistrer le brouillon",
@@ -97,8 +97,8 @@
       "update": "Mettre à jour la publication",
       "updateDraft": "Mettre à jour le brouillon",
       "video": {
-        "label": "Vidéo",
-        "title": "Vidéo %s"
+        "label": "Vidéos",
+        "name": "vidéo"
       },
       "visibility": {
         "label": "Visibilité"

--- a/packages/endpoint-posts/locales/id.json
+++ b/packages/endpoint-posts/locales/id.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Opsi lanjutan",
       "audio": {
         "label": "Audio",
-        "title": "Audio %s"
+        "name": "audio file"
       },
       "back": "Ubah jenis posting",
       "bookmark-of": {
@@ -77,7 +77,7 @@
       },
       "photo": {
         "label": "Foto",
-        "title": "Foto %s"
+        "name": "photo"
       },
       "publish": "Publikasikan postingan",
       "publishDraft": "Simpan draf",
@@ -98,7 +98,7 @@
       "updateDraft": "Perbarui draf",
       "video": {
         "label": "Video",
-        "title": "Video %s"
+        "name": "video"
       },
       "visibility": {
         "label": "Visibilitas"

--- a/packages/endpoint-posts/locales/nl.json
+++ b/packages/endpoint-posts/locales/nl.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Geavanceerde opties",
       "audio": {
         "label": "Audio",
-        "title": "Audio %s"
+        "name": "audiobestand"
       },
       "back": "Berichttype wijzigen",
       "bookmark-of": {
@@ -76,8 +76,8 @@
         "label": "Titel"
       },
       "photo": {
-        "label": "Foto",
-        "title": "Foto %s"
+        "label": "Foto’s",
+        "name": "foto"
       },
       "publish": "Post publiceren",
       "publishDraft": "Concept opslaan",
@@ -97,8 +97,8 @@
       "update": "Post bijwerken",
       "updateDraft": "Concept bijwerken",
       "video": {
-        "label": "Video",
-        "title": "Video %s"
+        "label": "Video’s",
+        "name": "video"
       },
       "visibility": {
         "label": "Zichtbaarheid"

--- a/packages/endpoint-posts/locales/pl.json
+++ b/packages/endpoint-posts/locales/pl.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Zaawansowane opcje",
       "audio": {
         "label": "Audio",
-        "title": "Audio %s"
+        "name": "plik audio"
       },
       "back": "Zmień typ posta",
       "bookmark-of": {
@@ -76,8 +76,8 @@
         "label": "Tytuł"
       },
       "photo": {
-        "label": "Zdjęcie",
-        "title": "Zdjęcie %s"
+        "label": "Zdjęcia",
+        "name": "zdjęcie"
       },
       "publish": "Opublikuj post",
       "publishDraft": "Zapisz szkic",
@@ -98,7 +98,7 @@
       "updateDraft": "Zaktualizuj wersję roboczą",
       "video": {
         "label": "Wideo",
-        "title": "Wideo %s"
+        "name": "wideo"
       },
       "visibility": {
         "label": "Widoczność"

--- a/packages/endpoint-posts/locales/pt.json
+++ b/packages/endpoint-posts/locales/pt.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Opções avançadas",
       "audio": {
         "label": "Áudio",
-        "title": "Áudio %s"
+        "name": "arquivo de áudio"
       },
       "back": "Alterar tipo de postagem",
       "bookmark-of": {
@@ -76,8 +76,8 @@
         "label": "Título"
       },
       "photo": {
-        "label": "Foto",
-        "title": "Foto %s"
+        "label": "Fotos",
+        "name": "foto"
       },
       "publish": "Publicar postagem",
       "publishDraft": "Salvar rascunho",
@@ -97,8 +97,8 @@
       "update": "Atualizar postagem",
       "updateDraft": "Atualizar rascunho",
       "video": {
-        "label": "Vídeo",
-        "title": "Vídeo %s"
+        "label": "Vídeos",
+        "name": "vídeo"
       },
       "visibility": {
         "label": "Visibilidade"

--- a/packages/endpoint-posts/locales/sr.json
+++ b/packages/endpoint-posts/locales/sr.json
@@ -34,7 +34,7 @@
       "advancedOptions": "Napredne opcije",
       "audio": {
         "label": "Audio",
-        "title": "Audio %s"
+        "name": "audio fajl"
       },
       "back": "Promenite tip posta",
       "bookmark-of": {
@@ -76,8 +76,8 @@
         "label": "Naslov"
       },
       "photo": {
-        "label": "Fotografija",
-        "title": "Fotografija %s"
+        "label": "Fotografije",
+        "name": "photo"
       },
       "publish": "Objavi post",
       "publishDraft": "Sačuvaj nacrt",
@@ -97,8 +97,8 @@
       "update": "Ažuriraj post",
       "updateDraft": "Ažurirajte nacrt",
       "video": {
-        "label": "Video",
-        "title": "Video %s"
+        "label": "Video snimci",
+        "name": "video"
       },
       "visibility": {
         "label": "Vidljivost"

--- a/packages/endpoint-posts/locales/zh-Hans-CN.json
+++ b/packages/endpoint-posts/locales/zh-Hans-CN.json
@@ -34,7 +34,7 @@
       "advancedOptions": "高级选项",
       "audio": {
         "label": "音频",
-        "title": "音频 %s"
+        "name": "音频文件"
       },
       "back": "更改帖子类型",
       "bookmark-of": {
@@ -77,7 +77,7 @@
       },
       "photo": {
         "label": "照片",
-        "title": "照片 %s"
+        "name": "照片"
       },
       "publish": "发布帖子",
       "publishDraft": "保存草稿",
@@ -98,7 +98,7 @@
       "updateDraft": "更新草稿",
       "video": {
         "label": "视频",
-        "title": "视频 %s"
+        "name": "视频"
       },
       "visibility": {
         "label": "可见度"

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -17,11 +17,7 @@
   postType === "rsvp"
 %}
 
-{% macro audioFieldset(index, audio) %}
-{% call fieldset({
-  classes: "fieldset--group",
-  legend: __("posts.form.audio.title", index + 1)
-}) %}
+{% macro audioFieldset(index) %}
   {{ input({
     name: "audio[" + index + "]",
     type: "url",
@@ -30,15 +26,21 @@
     attributes: {
       placeholder: "https://"
     },
+    field: {
+      attributes: {
+        "data-add-another-target": "field"
+      }
+    },
     errorMessage: fieldData("audio[" + index + "]").errorMessage
   }) | indent(2) }}
-{% endcall %}
 {% endmacro %}
 
-{% macro photoFieldset(index, photo) %}
+{% macro photoFieldset(index) %}
 {% call fieldset({
   classes: "fieldset--group",
-  legend: __("posts.form.photo.title", index + 1)
+  attributes: {
+    "data-add-another-target": "field"
+  }
 }) %}
   {{ input({
     name: "photo[" + index + "][url]",
@@ -61,11 +63,7 @@
 {% endcall %}
 {% endmacro %}
 
-{% macro videoFieldset(index, video) %}
-{% call fieldset({
-  classes: "fieldset--group",
-  legend: __("posts.form.video.title", index + 1)
-}) %}
+{% macro videoFieldset(index) %}
   {{ input({
     name: "video[" + index + "]",
     type: "url",
@@ -74,9 +72,13 @@
     attributes: {
       placeholder: "https://"
     },
+    field: {
+      attributes: {
+        "data-add-another-target": "field"
+      }
+    },
     errorMessage: fieldData("video[" + index + "]").errorMessage
   }) | indent(2) }}
-{% endcall %}
 {% endmacro %}
 
 {% block fieldset %}
@@ -183,27 +185,42 @@
   }) if postType === "article" }}
 
 {% if postType === "audio" %}
-  {% for audio in data.audio %}
-    {{ audioFieldset(loop.index0, audio) }}
+{% call addAnother({
+  fieldset: { legend: __("posts.form.audio.label") },
+  name: __("posts.form.audio.name")
+}) %}
+  {% for audio in fieldData("audio").value %}
+    {{ audioFieldset(loop.index0) }}
   {% else %}
-    {{ audioFieldset(0, false) }}
+    {{ audioFieldset(0) }}
   {% endfor %}
+{% endcall %}
 {% endif %}
 
 {% if postType === "photo" %}
-  {% for photo in data.photo %}
-    {{ photoFieldset(loop.index0, photo) }}
+{% call addAnother({
+  fieldset: { legend: __("posts.form.photo.label") },
+  name: __("posts.form.photo.name")
+}) %}
+  {% for photo in fieldData("photo").value %}
+    {{ photoFieldset(loop.index0) }}
   {% else %}
-    {{ photoFieldset(0, false) }}
+    {{ photoFieldset(0) }}
   {% endfor %}
+{% endcall %}
 {% endif %}
 
 {% if postType === "video" %}
-  {% for video in data.video %}
-    {{ videoFieldset(loop.index0, video) }}
+{% call addAnother({
+  name: __("posts.form.video.name"),
+  fieldset: { legend: __("posts.form.video.label") }
+}) %}
+  {% for video in fieldData("video").value %}
+    {{ videoFieldset(loop.index0) }}
   {% else %}
-    {{ videoFieldset(0, false) }}
+    {{ videoFieldset(0) }}
   {% endfor %}
+{% endcall %}
 {% endif %}
 
   {{ checkboxes({

--- a/packages/frontend/components/add-another/index.js
+++ b/packages/frontend/components/add-another/index.js
@@ -1,0 +1,170 @@
+import { Controller } from "@hotwired/stimulus";
+import { wrapElement } from "../../lib/utils/wrap-element.js";
+
+const focusableSelector = `button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]`;
+
+export const AddAnotherController = class extends Controller {
+  static targets = ["field", "list", "item"];
+
+  initialize() {
+    this.setupItems();
+    this.updateItems();
+    this.createAddButton();
+  }
+
+  /**
+   * Add item to list
+   * @param {Event} event - Add button event
+   */
+  add(event) {
+    event.preventDefault();
+    const newItem = this.createItem();
+    this.listTarget.append(newItem);
+    this.updateItems();
+    newItem.querySelector(focusableSelector).focus();
+  }
+
+  /**
+   * Delete item from list
+   * @param {Event} event - Delete button event
+   */
+  delete(event) {
+    event.preventDefault();
+    event.target.closest("li").remove();
+    this.updateItems();
+    this.focusHeading();
+  }
+
+  /**
+   * Get heading
+   * @returns {HTMLLegendElement} - Group legend
+   */
+  getHeading() {
+    return this.element.querySelector("legend");
+  }
+
+  /**
+   * Focus heading
+   */
+  focusHeading() {
+    const heading = this.getHeading();
+
+    heading.setAttribute("tabindex", "-1");
+    heading.focus();
+  }
+
+  /**
+   * Create add button
+   */
+  createAddButton() {
+    const addButtonTemplate = document.querySelector("#add-another-add-button");
+    const addButton = addButtonTemplate.content.cloneNode(true);
+
+    this.element.append(addButton);
+  }
+
+  /**
+   * Get delete button
+   * @param {HTMLElement} element - Containing element
+   * @returns {HTMLButtonElement} - Delete button
+   */
+  getDeleteButton(element) {
+    return element.querySelector(".button--warning");
+  }
+
+  /**
+   * Create delete button
+   * @param {HTMLElement} element - Containing element
+   */
+  createDeleteButton(element) {
+    const deleteButtonTemplate = document.querySelector(
+      "#add-another-delete-button",
+    );
+    const deleteButton =
+      deleteButtonTemplate.content.firstElementChild.cloneNode(true);
+
+    element.append(deleteButton);
+  }
+
+  /**
+   * Update delete button
+   * @param {HTMLElement} element - Containing element
+   */
+  updateDeleteButton(element) {
+    const deleteButton = this.getDeleteButton(element);
+    deleteButton.setAttribute("aria-labelledby", `delete-title ${element.id}`);
+  }
+
+  /**
+   * Take existing form fields and warp in list item
+   */
+  setupItems() {
+    const fields = this.fieldTargets;
+
+    for (const field of fields.values()) {
+      const item = document.createElement("li");
+      item.classList.add("add-another__item");
+      item.dataset.addAnotherTarget = "item";
+
+      wrapElement(field, item);
+    }
+  }
+
+  /**
+   * Create new item by cloning first item in list and updating its attributes
+   * @returns {HTMLLIElement} - List item containing form field(s)
+   */
+  createItem() {
+    const item = this.itemTargets.at(0).cloneNode(true);
+    const uid = Date.now().toString();
+
+    const fields = item.querySelectorAll("input, select, textarea");
+    for (const field of fields) {
+      field.id = field.id.replace("-0", `-${uid}`);
+      field.name = field.name.replace("[0]", `[${uid}]`);
+      field.value = "";
+    }
+
+    const labels = item.querySelectorAll("label");
+    for (const label of labels) {
+      const forAttribute = label.getAttribute("for");
+      label.setAttribute("for", forAttribute.replace("-0", `-${uid}`));
+    }
+
+    item.id = `${this.element.id}-${uid}`;
+
+    return item;
+  }
+
+  /**
+   * Update all items
+   * - Update ID’s to use for labelling remove button
+   * - Update ARIA label to reference item’s position in list
+   * - Add remove buttons (or remove if only one item remaining in list)
+   */
+  updateItems() {
+    const items = this.itemTargets;
+
+    for (const [index, item] of items.entries()) {
+      item.id = item.id || `${this.element.id}-${index}`;
+      item.setAttribute("aria-label", `Item ${index + 1}`);
+
+      // If no delete button, add one (if more than 1 item in list)
+      // Used when initializing
+      if (!this.getDeleteButton(item) && items.length > 1) {
+        this.createDeleteButton(item);
+      }
+
+      // If has delete button
+      if (this.getDeleteButton(item)) {
+        if (items.length === 1) {
+          // If only 1 item in list, remove button
+          this.getDeleteButton(item).remove();
+        } else {
+          // Else update button attributes
+          this.updateDeleteButton(item);
+        }
+      }
+    }
+  }
+};

--- a/packages/frontend/components/add-another/macro.njk
+++ b/packages/frontend/components/add-another/macro.njk
@@ -1,0 +1,3 @@
+{% macro addAnother(opts) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/frontend/components/add-another/styles.css
+++ b/packages/frontend/components/add-another/styles.css
@@ -1,0 +1,56 @@
+[data-controller="add-another"] {
+  --counter-size: 1.5em;
+}
+
+.add-another {
+  counter-reset: items;
+}
+
+.add-another__item {
+  --label-font: var(--font-body);
+  margin-block-end: var(--space-m);
+  padding-inline-start: calc(var(--counter-size) + var(--space-s));
+  position: relative;
+
+  &::before {
+    align-items: center;
+    background-color: var(--color-offset);
+    block-size: var(--counter-size);
+    border-radius: var(--border-radius-small);
+    color: var(--color-on-offset);
+    content: counter(items);
+    counter-increment: items;
+    display: flex;
+    font: var(--font-label);
+    inline-size: var(--counter-size);
+    inset: 0;
+    justify-content: center;
+    position: absolute;
+  }
+
+  &:not([hidden]) {
+    display: flex;
+  }
+
+  & > :first-child {
+    flex: 1;
+  }
+}
+
+.add-another__add.button {
+  display: flex;
+  inline-size: calc(100% - var(--counter-size) - var(--space-s));
+  margin-inline-start: calc(var(--counter-size) + var(--space-s));
+}
+
+.add-another__delete.button {
+  --button-padding: 0;
+  --icon-size: 0.875em;
+
+  block-size: var(--counter-size);
+  display: flex;
+  inline-size: var(--counter-size);
+  inset-block-start: calc(var(--counter-size) + var(--space-s));
+  inset-inline-start: 0;
+  position: absolute;
+}

--- a/packages/frontend/components/add-another/template.njk
+++ b/packages/frontend/components/add-another/template.njk
@@ -1,0 +1,50 @@
+{% from "../button/macro.njk" import button with context %}
+{% from "../button/macro.njk" import button with context %}
+{% from "../field/macro.njk" import field with context %}
+{% from "../fieldset/macro.njk" import fieldset with context %}
+{% set id = opts.id or opts.name | slugify({ decamelize: true }) %}
+{# `fieldset` is false by default #}
+{%- set hasFieldset = true if opts.fieldset else false %}
+{# Capture the HTML so we can optionally nest it within a fieldset #}
+{%- set innerHtml %}
+<ol class="{{ classes("add-another", opts) }}"{{- attributes(opts.attributes) }} role="list" data-add-another-target="list">
+  {{ caller() if caller }}
+</ol>
+{% endset %}
+{% call field({
+  attributes: {
+    id: id,
+    "data-controller": "add-another"
+  },
+  errorMessage: opts.errorMessage
+}) %}
+{% if opts.fieldset %}
+  {% call fieldset({
+    describedBy: describedBy,
+    classes: opts.fieldset.classes,
+    attributes: opts.fieldset.attributes,
+    legend: opts.fieldset.legend
+  }) %}{{ innerHtml | trim | safe }}{% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{% endif %}
+  <template id="add-another-add-button">
+    {{ button({
+      classes: "add-another__add button--secondary",
+      text: __("addAnother.add", opts.name),
+      attributes: {
+        "data-action": "add-another#add"
+      }
+    }) | indent(4) }}
+  </template>
+  <template id="add-another-delete-button">
+    {{ button({
+      classes: "add-another__delete button--warning",
+      icon: "delete",
+      iconText: __("addAnother.delete"),
+      attributes: {
+        "data-action": "add-another#delete"
+      }
+    }) | indent(4) }}
+  </template>
+{% endcall %}

--- a/packages/frontend/layouts/default.njk
+++ b/packages/frontend/layouts/default.njk
@@ -1,3 +1,4 @@
+{% from "add-another/macro.njk" import addAnother with context %}
 {% from "back-link/macro.njk" import backLink with context %}
 {% from "badge/macro.njk" import badge with context %}
 {% from "bookmarklet/macro.njk" import bookmarklet with context %}

--- a/packages/frontend/locales/de.json
+++ b/packages/frontend/locales/de.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Füge ein weiteres %s hinzu",
+    "delete": "Löschen"
+  },
   "backLink": {
     "text": "Zurück"
   },

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Add another %s",
+    "delete": "Delete"
+  },
   "backLink": {
     "text": "Back"
   },

--- a/packages/frontend/locales/es-419.json
+++ b/packages/frontend/locales/es-419.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Agregar otro %s",
+    "delete": "Eliminar"
+  },
   "backLink": {
     "text": "Atrás"
   },

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Agregar otro %s",
+    "delete": "Eliminar"
+  },
   "backLink": {
     "text": "Atrás"
   },

--- a/packages/frontend/locales/fr.json
+++ b/packages/frontend/locales/fr.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Ajouter un autre %s",
+    "delete": "Supprimer"
+  },
   "backLink": {
     "text": "Retour"
   },

--- a/packages/frontend/locales/id.json
+++ b/packages/frontend/locales/id.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Add another %s",
+    "delete": "Delete"
+  },
   "backLink": {
     "text": "Kembali"
   },

--- a/packages/frontend/locales/nl.json
+++ b/packages/frontend/locales/nl.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Nog een %s toevoegen",
+    "delete": "Verwijderen"
+  },
   "backLink": {
     "text": "Terug"
   },

--- a/packages/frontend/locales/pl.json
+++ b/packages/frontend/locales/pl.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Dodaj kolejne %s",
+    "delete": "Usuń"
+  },
   "backLink": {
     "text": "Wstecz"
   },

--- a/packages/frontend/locales/pt.json
+++ b/packages/frontend/locales/pt.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Adicionar outro %s",
+    "delete": "Apagar"
+  },
   "backLink": {
     "text": "Voltar"
   },

--- a/packages/frontend/locales/sr.json
+++ b/packages/frontend/locales/sr.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "Dodaj još %s",
+    "delete": "Izbriši"
+  },
   "backLink": {
     "text": "Nazad"
   },

--- a/packages/frontend/locales/zh-Hans-CN.json
+++ b/packages/frontend/locales/zh-Hans-CN.json
@@ -1,4 +1,8 @@
 {
+  "addAnother": {
+    "add": "再添加一个 %s",
+    "delete": "删除"
+  },
   "backLink": {
     "text": "返回"
   },

--- a/packages/frontend/scripts/app.js
+++ b/packages/frontend/scripts/app.js
@@ -1,5 +1,6 @@
 /* global Stimulus */
 import { Application } from "@hotwired/stimulus";
+import { AddAnotherController } from "../components/add-another/index.js";
 import { ErrorSummaryController } from "../components/error-summary/index.js";
 import { GeoInputController } from "../components/geo-input/index.js";
 import { PreviewController } from "../components/preview/index.js";
@@ -8,6 +9,7 @@ import { TagInputController } from "../components/tag-input/index.js";
 import { TextareaController } from "../components/textarea/index.js";
 
 window.Stimulus = Application.start();
+Stimulus.register("add-another", AddAnotherController);
 Stimulus.register("error-summary", ErrorSummaryController);
 Stimulus.register("geo-input", GeoInputController);
 Stimulus.register("notification", NotificationController);


### PR DESCRIPTION
Adds ‘add another’ component, and uses it to implement adding/editing multiple audio, photo and video fields in a post. Based on [MoJ’s Add another component](https://design-patterns.service.justice.gov.uk/components/add-another/), but rewritten as a Stimulus component.

Accessibility considerations:

* Adding a new item focuses the first input in that item.
* Removing an item moves focus back to the group `<legend>`.
* Items are labelled as Item 1, Item 2, etc. These item numbers are updated when an item is deleted.
* Remove button is labelled by the SVG’ `<title>` and the item’s title combined.

Likely more that could be done to improve accessibility, but should be a good baseline to work from.

<img width="750" alt="Screenshot of the add another component used to add/delete multiple photos." src="https://github.com/getindiekit/indiekit/assets/813383/ea17a7ee-9257-4635-b325-0adec5438b89">
