### PR TITLE
Editable post publication date

### DIFF
--- a/packages/endpoint-posts/locales/de.json
+++ b/packages/endpoint-posts/locales/de.json
@@ -81,6 +81,11 @@
       },
       "publish": "Beitrag veröffentlichen",
       "publishDraft": "Entwurf speichern",
+      "published": {
+        "label": "Veröffentlichungsdatum",
+        "now": "Jetzt",
+        "scheduled": "Bestimmtes Datum und Uhrzeit"
+      },
       "repost-of": {
         "label": "Repost von"
       },

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -104,6 +104,11 @@
         "label": "Photos",
         "name": "photo"
       },
+      "published": {
+        "label": "Publication date",
+        "now": "Now",
+        "scheduled": "Specific date and time"
+      },
       "repost-of": {
         "label": "Repost of"
       },

--- a/packages/endpoint-posts/locales/es-419.json
+++ b/packages/endpoint-posts/locales/es-419.json
@@ -81,6 +81,11 @@
       },
       "publish": "Publicar publicación",
       "publishDraft": "Guardar borrador",
+      "published": {
+        "label": "Fecha de publicación",
+        "now": "Ahora",
+        "scheduled": "Fecha y hora específicas"
+      },
       "repost-of": {
         "label": "Republicación de"
       },

--- a/packages/endpoint-posts/locales/es.json
+++ b/packages/endpoint-posts/locales/es.json
@@ -81,6 +81,11 @@
       },
       "publish": "Publicar publicación",
       "publishDraft": "Guardar borrador",
+      "published": {
+        "label": "Fecha de publicación",
+        "now": "Ahora",
+        "scheduled": "Fecha y hora específicas"
+      },
       "repost-of": {
         "label": "Republicación de"
       },

--- a/packages/endpoint-posts/locales/fr.json
+++ b/packages/endpoint-posts/locales/fr.json
@@ -81,6 +81,11 @@
       },
       "publish": "Publier la publication",
       "publishDraft": "Enregistrer le brouillon",
+      "published": {
+        "label": "Date de publication",
+        "now": "Maintenant",
+        "scheduled": "Date et heure spécifiques"
+      },
       "repost-of": {
         "label": "Republication de"
       },

--- a/packages/endpoint-posts/locales/id.json
+++ b/packages/endpoint-posts/locales/id.json
@@ -81,6 +81,11 @@
       },
       "publish": "Publikasikan postingan",
       "publishDraft": "Simpan draf",
+      "published": {
+        "label": "Tanggal penerbitan",
+        "now": "Sekarang",
+        "scheduled": "Tanggal dan waktu tertentu"
+      },
       "repost-of": {
         "label": "Repost dari"
       },

--- a/packages/endpoint-posts/locales/nl.json
+++ b/packages/endpoint-posts/locales/nl.json
@@ -81,6 +81,11 @@
       },
       "publish": "Post publiceren",
       "publishDraft": "Concept opslaan",
+      "published": {
+        "label": "Publicatie datum",
+        "now": "Nu",
+        "scheduled": "Specifieke datum en tijd"
+      },
       "repost-of": {
         "label": "Repost van"
       },

--- a/packages/endpoint-posts/locales/pl.json
+++ b/packages/endpoint-posts/locales/pl.json
@@ -81,6 +81,11 @@
       },
       "publish": "Opublikuj post",
       "publishDraft": "Zapisz szkic",
+      "published": {
+        "label": "Data publikacji",
+        "now": "Teraz",
+        "scheduled": "Konkretna data i godzina"
+      },
       "repost-of": {
         "label": "Repost z"
       },

--- a/packages/endpoint-posts/locales/pt.json
+++ b/packages/endpoint-posts/locales/pt.json
@@ -81,6 +81,11 @@
       },
       "publish": "Publicar postagem",
       "publishDraft": "Salvar rascunho",
+      "published": {
+        "label": "Data de publicação",
+        "now": "Agora",
+        "scheduled": "Data e hora específicas"
+      },
       "repost-of": {
         "label": "Republicação de"
       },

--- a/packages/endpoint-posts/locales/sr.json
+++ b/packages/endpoint-posts/locales/sr.json
@@ -81,6 +81,11 @@
       },
       "publish": "Objavi post",
       "publishDraft": "Sačuvaj nacrt",
+      "published": {
+        "label": "Datum objavljivanja",
+        "now": "Sada",
+        "scheduled": "Specifičan datum i vreme"
+      },
       "repost-of": {
         "label": "Repost od"
       },

--- a/packages/endpoint-posts/locales/zh-Hans-CN.json
+++ b/packages/endpoint-posts/locales/zh-Hans-CN.json
@@ -81,6 +81,11 @@
       },
       "publish": "发布帖子",
       "publishDraft": "保存草稿",
+      "published": {
+        "label": "出版日期",
+        "now": "现在",
+        "scheduled": "具体日期和时间"
+      },
       "repost-of": {
         "label": "重新发布的"
       },

--- a/packages/endpoint-posts/tests/integration/302-post-create.js
+++ b/packages/endpoint-posts/tests/integration/302-post-create.js
@@ -14,7 +14,8 @@ test("Creates post and redirects to posts page", async (t) => {
     .type("form")
     .set("cookie", [testCookie()])
     .send({ type: "entry" })
-    .send({ content: "Foobar" });
+    .send({ content: "Foobar" })
+    .send({ published: "2023-08-28T12:30" });
 
   t.is(result.status, 302);
   t.regex(result.text, /Found. Redirecting to \/posts\?success/);

--- a/packages/endpoint-posts/tests/integration/500-post-create.js
+++ b/packages/endpoint-posts/tests/integration/500-post-create.js
@@ -16,6 +16,7 @@ test("Returns 500 error creating post", async (t) => {
     .set("cookie", [testCookie()])
     .send({ type: "entry" })
     .send({ content: "Foobar" })
+    .send({ published: "2023-08-28T12:30" })
     .send({ slug: "401" });
   const dom = new JSDOM(response.text);
   const result = dom.window.document.querySelector(

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -237,6 +237,32 @@
     summary: __("posts.form.advancedOptions")
   }) %}
     {{ radios({
+      fieldset: {
+        legend: __("posts.form.published.label")
+      },
+      name: "publication-date",
+      values: fieldData("publication-date").value,
+      items: [{
+        label: __("posts.form.published.now"),
+        value: "now",
+        checked: true
+      }, {
+        label: __("posts.form.published.scheduled"),
+        value: "scheduled",
+        conditional: input({
+          name: "published",
+          type: "datetime-local",
+          label: __("posts.form.published.label")
+        })
+      }]
+    }) if postStatus !== "published" else input({
+      name: "published",
+      value: fieldData("published").value | localDate(application.timeZone),
+      type: "datetime-local",
+      label: __("posts.form.published.label")
+    }) | indent(4) }}
+
+    {{ radios({
       classes: "radios--inline",
       name: "visibility",
       values: data.visibility or "public",


### PR DESCRIPTION
Fixes #561.

When creating a new post, provides an advanced option that lets the user choose a specific publication date:

<img width="310" alt="Screenshot of form for choosing a custom publication date." src="https://github.com/getindiekit/indiekit/assets/813383/53f52fc0-8e0b-41d4-a717-39f3de26ef35">

When editing an existing post, shows a date input to change the publication date:
 
<img width="260" alt="Screenshot of form for editing publication date." src="https://github.com/getindiekit/indiekit/assets/813383/003169e0-1230-4f87-80b4-4716048fccf4">

## Implementation note

`input[type="datetime-local"]` only accepts, and will only save, local date times, i.e. `2023-08-28T21:45`. However, we want to save dates with the local time zone; when reading an existing publication date we need to convert a zoned date to local time, and when saving we need to append the timezone designation. For example:

  1. The time is 21:30, Europe/London, observing DST: `2023-08-28T21:30:00+01:00`
  2. This is converted to local time: `2023-08-28T21:30` (removing the time zone and also any seconds)
  3. User edits time to 20:15 local time: `2023-08-28T20:15`
  4. Post is saved, the application’s time zone is set to Europe/London, and so the `published` value for the post is saved as: `2023-08-28T20:15:00+01:00`