### PR TITLE
FTP store: Use `ssh2-sftp-client`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@indiekit-test/session": "*",
         "@indiekit-test/store": "*",
         "@indiekit-test/token": "*",
+        "@micham/sftp-mock-server": "^0.0.6",
         "@types/cookie-session": "^2.0.44",
         "@types/express": "^4.17.17",
         "@types/express-fileupload": "^1.4.1",
@@ -66,30 +67,39 @@
       }
     },
     "helpers/access-token": {
+      "name": "@indiekit-test/token",
       "license": "MIT"
     },
     "helpers/config": {
+      "name": "@indiekit-test/config",
       "license": "MIT"
     },
     "helpers/fixtures": {
+      "name": "@indiekit-test/fixtures",
       "license": "MIT"
     },
     "helpers/frontend": {
+      "name": "@indiekit-test/frontend",
       "license": "MIT"
     },
     "helpers/media-data": {
+      "name": "@indiekit-test/media-data",
       "license": "MIT"
     },
     "helpers/mock-agent": {
+      "name": "@indiekit-test/mock-agent",
       "license": "MIT"
     },
     "helpers/post-data": {
+      "name": "@indiekit-test/post-data",
       "license": "MIT"
     },
     "helpers/publication": {
+      "name": "@indiekit-test/publication",
       "license": "MIT"
     },
     "helpers/server": {
+      "name": "@indiekit-test/server",
       "license": "MIT",
       "dependencies": {
         "get-port": "^7.0.0"
@@ -107,9 +117,11 @@
       }
     },
     "helpers/session": {
+      "name": "@indiekit-test/session",
       "license": "MIT"
     },
     "helpers/store": {
+      "name": "@indiekit-test/store",
       "license": "MIT"
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2839,6 +2851,18 @@
         "make-plural": "^7.0.0"
       }
     },
+    "node_modules/@micham/sftp-mock-server": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@micham/sftp-mock-server/-/sftp-mock-server-0.0.6.tgz",
+      "integrity": "sha512-3B4GRDTvsWNCGQikT43ib3NC51kLxfslZmeCvaAiBYC6RjZj/PM6dC8iVJOQ2pj5jnh0Caoytx/nU1z27jmZEw==",
+      "dev": true,
+      "dependencies": {
+        "ssh2": "^1.11.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
@@ -5210,6 +5234,14 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -5366,14 +5398,6 @@
         }
       ]
     },
-    "node_modules/basic-ftp": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-      "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/bcrypt": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
@@ -5385,6 +5409,14 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/bcrypt/node_modules/node-addon-api": {
@@ -5597,6 +5629,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -6883,6 +6924,20 @@
         "cosmiconfig": ">=7",
         "ts-node": ">=10",
         "typescript": ">=4"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.9.tgz",
+      "integrity": "sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.17.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/create-indiekit": {
@@ -12459,6 +12514,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
@@ -15955,6 +16016,36 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/ssh2": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.14.0.tgz",
+      "integrity": "sha512-AqzD1UCqit8tbOKoj6ztDDi1ffJZ2rV2SwlgrVVrHPkV5vWqGJOVp5pmtj18PunkPJAuKQsnInyKV+/Nb2bUnA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.8",
+        "nan": "^2.17.0"
+      }
+    },
+    "node_modules/ssh2-sftp-client": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-9.1.0.tgz",
+      "integrity": "sha512-Hzdr9OE6GxZjcmyM9tgBSIFVyrHAp9c6U2Y4yBkmYOHoQvZ7pIm27dmltvcmRfxcWiIcg8HBvG5iAikDf+ZuzQ==",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "promise-retry": "^2.0.1",
+        "ssh2": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=10.24.1"
+      }
+    },
     "node_modules/ssri": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -17210,6 +17301,11 @@
         "domino": "^2.1.6"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -18330,6 +18426,7 @@
       }
     },
     "packages/endpoint-auth": {
+      "name": "@indiekit/endpoint-auth",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18346,6 +18443,7 @@
       }
     },
     "packages/endpoint-files": {
+      "name": "@indiekit/endpoint-files",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18358,6 +18456,7 @@
       }
     },
     "packages/endpoint-image": {
+      "name": "@indiekit/endpoint-image",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18369,6 +18468,7 @@
       }
     },
     "packages/endpoint-json-feed": {
+      "name": "@indiekit/endpoint-json-feed",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18380,6 +18480,7 @@
       }
     },
     "packages/endpoint-media": {
+      "name": "@indiekit/endpoint-media",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18394,6 +18495,7 @@
       }
     },
     "packages/endpoint-micropub": {
+      "name": "@indiekit/endpoint-micropub",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18411,6 +18513,7 @@
       }
     },
     "packages/endpoint-posts": {
+      "name": "@indiekit/endpoint-posts",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18426,6 +18529,7 @@
       }
     },
     "packages/endpoint-share": {
+      "name": "@indiekit/endpoint-share",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18438,6 +18542,7 @@
       }
     },
     "packages/endpoint-syndicate": {
+      "name": "@indiekit/endpoint-syndicate",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18450,6 +18555,7 @@
       }
     },
     "packages/error": {
+      "name": "@indiekit/error",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "engines": {
@@ -18457,6 +18563,7 @@
       }
     },
     "packages/frontend": {
+      "name": "@indiekit/frontend",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18484,6 +18591,7 @@
       }
     },
     "packages/indiekit": {
+      "name": "@indiekit/indiekit",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18546,6 +18654,7 @@
       }
     },
     "packages/preset-hugo": {
+      "name": "@indiekit/preset-hugo",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18619,6 +18728,7 @@
       }
     },
     "packages/preset-jekyll": {
+      "name": "@indiekit/preset-jekyll",
       "version": "1.0.0-beta.4",
       "license": "MIT",
       "dependencies": {
@@ -18629,6 +18739,7 @@
       }
     },
     "packages/store-bitbucket": {
+      "name": "@indiekit/store-bitbucket",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18640,6 +18751,7 @@
       }
     },
     "packages/store-file-system": {
+      "name": "@indiekit/store-file-system",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18650,17 +18762,19 @@
       }
     },
     "packages/store-ftp": {
+      "name": "@indiekit/store-ftp",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.5",
-        "basic-ftp": "^5.0.0"
+        "ssh2-sftp-client": "^9.1.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "packages/store-gitea": {
+      "name": "@indiekit/store-gitea",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18671,6 +18785,7 @@
       }
     },
     "packages/store-github": {
+      "name": "@indiekit/store-github",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18681,6 +18796,7 @@
       }
     },
     "packages/store-gitlab": {
+      "name": "@indiekit/store-gitlab",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18692,6 +18808,7 @@
       }
     },
     "packages/syndicator-internet-archive": {
+      "name": "@indiekit/syndicator-internet-archive",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18702,6 +18819,7 @@
       }
     },
     "packages/syndicator-mastodon": {
+      "name": "@indiekit/syndicator-mastodon",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
@@ -18716,6 +18834,7 @@
       }
     },
     "packages/util": {
+      "name": "@indiekit/util",
       "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@indiekit-test/session": "*",
     "@indiekit-test/store": "*",
     "@indiekit-test/token": "*",
+    "@micham/sftp-mock-server": "^0.0.6",
     "@types/cookie-session": "^2.0.44",
     "@types/express": "^4.17.17",
     "@types/express-fileupload": "^1.4.1",

--- a/packages/store-ftp/package.json
+++ b/packages/store-ftp/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.5",
-    "basic-ftp": "^5.0.0"
+    "ssh2-sftp-client": "^9.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/store-ftp/tests/index.js
+++ b/packages/store-ftp/tests/index.js
@@ -1,11 +1,32 @@
 import test from "ava";
 import { Indiekit } from "@indiekit/indiekit";
+import { closeServer, createSftpMockServer } from "@micham/sftp-mock-server";
 import FtpStore from "../index.js";
 
 const ftp = new FtpStore({
-  host: "ftp.server.example",
+  host: "127.0.0.1",
+  port: 9393,
   user: "username",
   password: "password",
+});
+
+const unauthorizedFtp = new FtpStore({
+  host: "127.0.0.1",
+  port: 9393,
+  user: "foo",
+  password: "foo",
+});
+
+test.before(async (t) => {
+  t.context.server = await createSftpMockServer({
+    hostname: "127.0.0.1",
+    port: 9393,
+    users: { username: { password: "password" } },
+  });
+});
+
+test.after(async (t) => {
+  await closeServer(t.context.server);
 });
 
 test("Gets plug-in environment", (t) => {
@@ -14,8 +35,8 @@ test("Gets plug-in environment", (t) => {
 
 test("Gets plug-in info", (t) => {
   t.is(ftp.name, "FTP store");
-  t.is(ftp.info.name, "username on ftp.server.example");
-  t.is(ftp.info.uid, "sftp://ftp.server.example/");
+  t.is(ftp.info.name, "username on 127.0.0.1");
+  t.is(ftp.info.uid, "sftp://127.0.0.1/");
 });
 
 test("Gets plug-in installation prompts", (t) => {
@@ -26,5 +47,74 @@ test("Initiates plug-in", async (t) => {
   const indiekit = await Indiekit.initialize();
   ftp.init(indiekit);
 
-  t.is(indiekit.publication.store.info.name, "username on ftp.server.example");
+  t.is(indiekit.publication.store.info.name, "username on 127.0.0.1");
+});
+
+test("Throws error connecting to FTP server", async (t) => {
+  await t.throwsAsync(unauthorizedFtp.readFile("foo.md"), {
+    message:
+      "FTP store: connect: getConnection: All configured authentication methods failed",
+  });
+});
+
+test.serial("Creates file", async (t) => {
+  t.is(
+    await ftp.createFile("foo.md", "foobar"),
+    "Uploaded data stream to foo.md",
+  );
+});
+
+test("Throws error creating file", async (t) => {
+  await t.throwsAsync(ftp.createFile(), {
+    message: `FTP store: The "path" argument must be of type string. Received undefined`,
+  });
+});
+
+test.serial("Reads file", async (t) => {
+  t.is(await ftp.readFile("foo.md"), "foobar");
+});
+
+test("Throws error reading file", async (t) => {
+  await t.throwsAsync(ftp.readFile(), {
+    message: `FTP store: The "path" argument must be of type string. Received undefined`,
+  });
+});
+
+test.serial("Updates file", async (t) => {
+  t.is(
+    await ftp.updateFile("foo.md", "foobar"),
+    "Uploaded data stream to foo.md",
+  );
+});
+
+test("Updates and renames file", async (t) => {
+  t.is(
+    await ftp.updateFile("foo.md", "foobar", {
+      newPath: "bar.md",
+    }),
+    "Successfully renamed foo.md to bar.md",
+  );
+});
+
+test("Creates file if original not found", async (t) => {
+  t.is(
+    await ftp.updateFile("qux.md", "foobar"),
+    "Uploaded data stream to qux.md",
+  );
+});
+
+test("Throws error updating file", async (t) => {
+  await t.throwsAsync(ftp.updateFile(undefined, "foobar"), {
+    message: `FTP store: The "path" argument must be of type string. Received undefined`,
+  });
+});
+
+test("Deletes file", async (t) => {
+  t.is(await ftp.deleteFile("foo.md"), "Successfully deleted foo.md");
+});
+
+test("Throws error deleting file", async (t) => {
+  await t.throwsAsync(ftp.deleteFile(), {
+    message: `FTP store: The "path" argument must be of type string. Received undefined`,
+  });
 });


### PR DESCRIPTION
Use `ssh2-sftp-client` to interface with SFTP servers. This then means we can use `@micham/sftp-mock-server` to mock an SFTP server in tests.

This does mean that non-secure FTP servers are no longer supported, but I think that’s probably a good thing.

Fixes #390.