### PR TITLE
Add `uid` to post and media item queries

### DIFF
--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -5,6 +5,21 @@ import newbase60 from "newbase60";
 import { mediaTypeCount } from "./media-type-count.js";
 
 /**
+ * Get media properties
+ * @param {object} mediaData - Media data
+ * @returns {object} Media properties
+ */
+export const getMediaProperties = (mediaData) => {
+  return {
+    uid: mediaData._id,
+    "content-type": mediaData.properties["content-type"],
+    "media-type": mediaData.properties["media-type"],
+    published: mediaData.properties.published,
+    url: mediaData.properties.url,
+  };
+};
+
+/**
  * Render path from URI template and properties
  * @param {string} path - URI template path
  * @param {object} properties - Properties to use

--- a/packages/endpoint-media/tests/integration/200-query-source.js
+++ b/packages/endpoint-media/tests/integration/200-query-source.js
@@ -21,6 +21,7 @@ test("Returns list of uploaded files", async (t) => {
     .set("accept", "application/json")
     .query({ q: "source" });
 
+  t.truthy(result.body.items[0].uid);
   t.is(result.body.items[0]["content-type"], "image/jpeg");
   t.is(result.body.items[0]["media-type"], "photo");
   t.truthy(result.body.items[0].published);

--- a/packages/endpoint-micropub/lib/controllers/query.js
+++ b/packages/endpoint-micropub/lib/controllers/query.js
@@ -35,21 +35,21 @@ export const queryController = async (request, response, next) => {
       case "source": {
         if (url) {
           // Return mf2 for a given URL (optionally filtered by properties)
-          let item;
+          let postData;
 
           if (application.hasDatabase) {
-            item = await application.posts.findOne({
+            postData = await application.posts.findOne({
               "properties.url": url,
             });
           }
 
-          if (!item) {
+          if (!postData) {
             throw IndiekitError.badRequest(
               response.locals.__("BadRequestError.missingResource", "post"),
             );
           }
 
-          const mf2 = jf2ToMf2(item.properties);
+          const mf2 = jf2ToMf2(postData);
           response.json(getMf2Properties(mf2, properties));
         } else {
           // Return mf2 for  published posts
@@ -64,7 +64,7 @@ export const queryController = async (request, response, next) => {
           }
 
           response.json({
-            items: cursor.items.map((post) => jf2ToMf2(post.properties)),
+            items: cursor.items.map((postData) => jf2ToMf2(postData)),
             paging: {
               ...(cursor.hasNext && { after: cursor.lastItem }),
               ...(cursor.hasPrev && { before: cursor.firstItem }),

--- a/packages/endpoint-micropub/lib/mf2.js
+++ b/packages/endpoint-micropub/lib/mf2.js
@@ -35,28 +35,33 @@ export const getMf2Properties = (mf2, requestedProperties) => {
 };
 
 /**
- * Convert JF2 to mf2
- * @param {object} jf2 - JF2
+ * Convert JF2 post data to mf2
+ * @param {object} postData - Post data
+ * @param {boolean} [includeObjectId] - Include ObjectID from post data
  * @returns {object} mf2
  */
-export const jf2ToMf2 = (jf2) => {
+export const jf2ToMf2 = (postData, includeObjectId = true) => {
+  const { properties, _id } = postData;
+
   const mf2 = {
-    type: [`h-${jf2.type}`],
-    properties: {},
+    type: [`h-${properties.type}`],
+    properties: {
+      ...(includeObjectId && _id && { uid: [_id] }),
+    },
   };
 
-  delete jf2.type;
+  delete properties.type;
 
   // Move values to property object
-  for (const key in jf2) {
+  for (const key in properties) {
     // Convert nested vocabulary to mf2 (i.e. h-card, h-geo, h-adr)
-    if (Object.prototype.hasOwnProperty.call(jf2[key], "type")) {
-      mf2.properties[key] = [jf2ToMf2(jf2[key])];
+    if (Object.prototype.hasOwnProperty.call(properties[key], "type")) {
+      mf2.properties[key] = [jf2ToMf2({ properties: properties[key] }, false)];
     }
 
     // Convert values to arrays (i.e. 'a' => ['a'])
-    else if (Object.prototype.hasOwnProperty.call(jf2, key)) {
-      const value = jf2[key];
+    else if (Object.prototype.hasOwnProperty.call(properties, key)) {
+      const value = properties[key];
       mf2.properties[key] = Array.isArray(value) ? value : [value];
     }
   }
@@ -67,7 +72,7 @@ export const jf2ToMf2 = (jf2) => {
     mf2.properties.content[0] &&
     mf2.properties.content[0].text
   ) {
-    mf2.properties.content[0].value = jf2.content.text;
+    mf2.properties.content[0].value = properties.content.text;
     delete mf2.properties.content[0].text;
   }
 

--- a/packages/endpoint-micropub/tests/unit/mf2.js
+++ b/packages/endpoint-micropub/tests/unit/mf2.js
@@ -3,12 +3,14 @@ import { getFixture } from "@indiekit-test/fixtures";
 import { jf2ToMf2 } from "../../lib/mf2.js";
 
 test("Convert JF2 to mf2", (t) => {
-  const jf2 = JSON.parse(getFixture("jf2/all-properties.jf2"));
-  const result = jf2ToMf2(jf2);
+  const properties = JSON.parse(getFixture("jf2/all-properties.jf2"));
+  const postData = { _id: 123, properties };
+  const result = jf2ToMf2(postData);
 
   t.deepEqual(result, {
     type: ["h-entry"],
     properties: {
+      uid: [123],
       url: ["https://website.example/posts/cheese-sandwich"],
       name: ["What I had for lunch"],
       content: [

--- a/packages/endpoint-posts/lib/controllers/form.js
+++ b/packages/endpoint-posts/lib/controllers/form.js
@@ -105,7 +105,7 @@ export const formController = {
         }
       }
 
-      const mf2 = jf2ToMf2(values);
+      const mf2 = jf2ToMf2({ properties: values });
 
       let jsonBody = mf2;
       if (action === "update") {


### PR DESCRIPTION
`properties.uid` returns the value for `_id`, which uses MongoDB’s `ObjectId()`.