### PR TITLE
Query posts and media using `uid`

### DIFF
--- a/helpers/mock-agent/endpoint-files.js
+++ b/helpers/mock-agent/endpoint-files.js
@@ -13,7 +13,27 @@ export function mockClient() {
   const mediaOrigin = "https://website.example/photo.jpg";
   const mediaBadOrigin = "https://website.example/401.jpg";
 
-  // Get source information from external media endpoint
+  // Get source information for all items from external media endpoint
+  agent
+    .get(mediaEndpointOrigin)
+    .intercept({
+      path: /\/\?q=source/,
+    })
+    .reply(200, {
+      items: [
+        {
+          uid: "123",
+          url: "https://website.example/photo.jpg",
+        },
+        {
+          uid: "401",
+          url: "https://website.example/401.jpg",
+        },
+      ],
+    })
+    .persist();
+
+  // Get source information for single item from external media endpoint
   agent
     .get(mediaEndpointOrigin)
     .intercept({

--- a/packages/endpoint-files/index.js
+++ b/packages/endpoint-files/index.js
@@ -32,11 +32,11 @@ export default class FilesEndpoint {
     router.get("/upload", fileData.upload, formController.get);
     router.post("/upload", fileData.upload, validate, formController.post);
 
-    router.use("/:id/:action?", fileData.read);
-    router.get("/:id", fileController);
+    router.use("/:uid/:action?", fileData.read);
+    router.get("/:uid", fileController);
 
-    router.get("/:id/delete", deleteController.get);
-    router.post("/:id/delete", deleteController.post);
+    router.get("/:uid/delete", deleteController.get);
+    router.post("/:uid/delete", deleteController.post);
 
     return router;
   }

--- a/packages/endpoint-files/lib/controllers/files.js
+++ b/packages/endpoint-files/lib/controllers/files.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { endpoint } from "../endpoint.js";
-import { getFileId, getFileName } from "../utils.js";
+import { getFileName } from "../utils.js";
 
 /**
  * List uploaded files
@@ -30,13 +30,13 @@ export const filesController = async (request, response, next) => {
     let files;
     if (mediaResponse?.items?.length > 0) {
       files = mediaResponse.items.map((item) => {
-        item.id = getFileId(item.url);
+        item.id = item.uid;
         item.icon = item["media-type"];
         item.photo = {
           url: item.url,
         };
         item.title = item.url ? getFileName(item.url) : "File";
-        item.url = path.join(request.baseUrl, request.path, item.id);
+        item.url = path.join(request.baseUrl, request.path, item.uid);
 
         return item;
       });

--- a/packages/endpoint-files/lib/middleware/file-data.js
+++ b/packages/endpoint-files/lib/middleware/file-data.js
@@ -19,14 +19,18 @@ export const fileData = {
   async read(request, response, next) {
     try {
       const { application } = request.app.locals;
-      const { id } = request.params;
+      const { uid } = request.params;
       const { access_token, scope } = request.session;
 
       const properties = await getFileProperties(
-        id,
+        uid,
         application.mediaEndpoint,
         access_token,
       );
+
+      if (!properties) {
+        throw IndiekitError.notFound(response.locals.__("NotFoundError.page"));
+      }
 
       response.locals = {
         accessToken: access_token,
@@ -39,15 +43,7 @@ export const fileData = {
 
       next();
     } catch (error) {
-      let nextError = error;
-
-      if (error.message === "Invalid URL") {
-        nextError = IndiekitError.notFound(
-          response.locals.__("NotFoundError.page"),
-        );
-      }
-
-      next(nextError);
+      next(error);
     }
   },
 };

--- a/packages/endpoint-files/lib/utils.js
+++ b/packages/endpoint-files/lib/utils.js
@@ -2,29 +2,23 @@ import { Buffer } from "node:buffer";
 import { endpoint } from "./endpoint.js";
 
 /**
- * Get file ID from URL
- * @param {string} url - URL
- * @returns {string} File ID
- */
-export const getFileId = (url) => {
-  return Buffer.from(url).toString("base64url");
-};
-
-/**
  * Query Micropub media endpoint for file data
- * @param {string} id - Post ID
+ * @param {string} uid - Item UID
  * @param {string} mediaEndpoint - Micropub media endpoint
  * @param {string} accessToken - Access token
  * @returns {Promise<object>} JF2 properties
  */
-export const getFileProperties = async (id, mediaEndpoint, accessToken) => {
+export const getFileProperties = async (uid, mediaEndpoint, accessToken) => {
   const mediaUrl = new URL(mediaEndpoint);
   mediaUrl.searchParams.append("q", "source");
-  mediaUrl.searchParams.append("url", getFileUrl(id));
 
-  const properties = await endpoint.get(mediaUrl.href, accessToken);
+  const mediaResponse = await endpoint.get(mediaUrl.href, accessToken);
 
-  return properties;
+  if (mediaResponse?.items?.length > 0) {
+    return mediaResponse.items.find((item) => item.uid === uid);
+  }
+
+  return false;
 };
 
 /**

--- a/packages/endpoint-files/tests/integration/200-file.js
+++ b/packages/endpoint-files/tests/integration/200-file.js
@@ -4,21 +4,19 @@ import supertest from "supertest";
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { testServer } from "@indiekit-test/server";
 import { testCookie } from "@indiekit-test/session";
-import { getFileId } from "../../lib/utils.js";
 
 await mockAgent("endpoint-files");
 
 test("Returns uploaded file", async (t) => {
-  const id = getFileId("https://website.example/photo.jpg");
   const server = await testServer({
     application: { mediaEndpoint: "https://media-endpoint.example" },
   });
   const request = supertest.agent(server);
   const response = await request
-    .get(`/files/${id}`)
+    .get(`/files/123`)
     .set("cookie", [testCookie()]);
-  const fileDom = new JSDOM(response.text);
-  const result = fileDom.window.document.querySelector("title").textContent;
+  const dom = new JSDOM(response.text);
+  const result = dom.window.document.querySelector("title").textContent;
 
   t.is(result, `photo.jpg - Test configuration`);
 

--- a/packages/endpoint-files/tests/integration/200-get-delete.js
+++ b/packages/endpoint-files/tests/integration/200-get-delete.js
@@ -1,31 +1,20 @@
-import { Buffer } from "node:buffer";
 import test from "ava";
 import supertest from "supertest";
 import { JSDOM } from "jsdom";
-import { getFixture } from "@indiekit-test/fixtures";
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { testServer } from "@indiekit-test/server";
 import { testCookie } from "@indiekit-test/session";
 
-await mockAgent("endpoint-media");
+await mockAgent("endpoint-files");
 
 test("Gets delete confirmation page", async (t) => {
-  const cookie = testCookie();
-
-  // Upload file
-  const server = await testServer();
+  const server = await testServer({
+    application: { mediaEndpoint: "https://media-endpoint.example" },
+  });
   const request = supertest.agent(server);
-  const uploadResponse = await request
-    .post("/media")
-    .set("accept", "application/json")
-    .set("cookie", [cookie])
-    .attach("file", getFixture("file-types/photo.jpg", false), "photo.jpg");
-  const id = Buffer.from(uploadResponse.headers.location).toString("base64url");
-
-  // Request delete page
   const response = await request
-    .get(`/files/${id}/delete`)
-    .set("cookie", [cookie]);
+    .get(`/files/123/delete`)
+    .set("cookie", [testCookie()]);
   const dom = new JSDOM(response.text);
   const result = dom.window.document.querySelector("title").textContent;
 

--- a/packages/endpoint-files/tests/integration/302-get-delete.js
+++ b/packages/endpoint-files/tests/integration/302-get-delete.js
@@ -1,30 +1,19 @@
-import { Buffer } from "node:buffer";
 import test from "ava";
 import supertest from "supertest";
-import { getFixture } from "@indiekit-test/fixtures";
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { testServer } from "@indiekit-test/server";
 import { testCookie } from "@indiekit-test/session";
 
-await mockAgent("endpoint-media");
+await mockAgent("endpoint-files");
 
 test("Redirects to file page if no delete permissions", async (t) => {
-  const cookie = testCookie({ scope: "media" });
-
-  // Upload file
-  const server = await testServer();
+  const server = await testServer({
+    application: { mediaEndpoint: "https://media-endpoint.example" },
+  });
   const request = supertest.agent(server);
-  const uploadResponse = await request
-    .post("/media")
-    .set("accept", "application/json")
-    .set("cookie", [cookie])
-    .attach("file", getFixture("file-types/photo.jpg", false), "photo.jpg");
-  const id = Buffer.from(uploadResponse.headers.location).toString("base64url");
-
-  // Request delete page
   const result = await request
-    .get(`/files/${id}/delete`)
-    .set("cookie", [cookie]);
+    .get(`/files/123/delete`)
+    .set("cookie", [testCookie({ scope: "media" })]);
 
   t.is(result.status, 302);
   t.regex(result.text, /Found. Redirecting to \/files\/(.*)/);

--- a/packages/endpoint-files/tests/integration/302-post-delete.js
+++ b/packages/endpoint-files/tests/integration/302-post-delete.js
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import test from "ava";
 import supertest from "supertest";
 import { mockAgent } from "@indiekit-test/mock-agent";
@@ -12,12 +11,10 @@ test("Deletes file and redirects to files page", async (t) => {
     application: { mediaEndpoint: "https://media-endpoint.example" },
   });
   const request = supertest.agent(server);
-  const url = "https://website.example/photo.jpg";
-  const id = Buffer.from(url).toString("base64url");
   const result = await request
-    .post(`/files/${id}/delete`)
+    .post(`/files/123/delete`)
     .set("cookie", [testCookie()])
-    .send({ url });
+    .send({ url: "https://website.example/photo.jpg" });
 
   t.is(result.status, 302);
   t.regex(result.text, /Found. Redirecting to \/files\?success/);

--- a/packages/endpoint-files/tests/integration/401-post-delete-unauthorized.js
+++ b/packages/endpoint-files/tests/integration/401-post-delete-unauthorized.js
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import test from "ava";
 import supertest from "supertest";
 import { mockAgent } from "@indiekit-test/mock-agent";
@@ -14,12 +13,10 @@ test("Returns 401 error deleting file", async (t) => {
     },
   });
   const request = supertest.agent(server);
-  const url = "https://website.example/401.jpg";
-  const id = Buffer.from(url).toString("base64url");
   const result = await request
-    .post(`/files/${id}/delete`)
+    .post(`/files/401/delete`)
     .set("cookie", [testCookie()])
-    .send({ url });
+    .send({ url: "https://website.example/401.jpg" });
 
   t.is(result.status, 401);
 

--- a/packages/endpoint-files/tests/integration/404-file.js
+++ b/packages/endpoint-files/tests/integration/404-file.js
@@ -6,9 +6,7 @@ import { testCookie } from "@indiekit-test/session";
 test("Returns 404 error file not found", async (t) => {
   const server = await testServer();
   const request = supertest.agent(server);
-  const result = await request
-    .get("/files/5ffcc8025c561a7bf53bd6e8")
-    .set("cookie", [testCookie()]);
+  const result = await request.get("/files/404").set("cookie", [testCookie()]);
 
   t.is(result.status, 404);
   t.true(

--- a/packages/endpoint-files/tests/unit/utils.js
+++ b/packages/endpoint-files/tests/unit/utils.js
@@ -1,12 +1,5 @@
 import test from "ava";
-import { getFileId, getFileName, getFileUrl } from "../../lib/utils.js";
-
-test("Gets file ID", (t) => {
-  t.is(
-    getFileId("https://website.example/foobar"),
-    "aHR0cHM6Ly93ZWJzaXRlLmV4YW1wbGUvZm9vYmFy",
-  );
-});
+import { getFileName, getFileUrl } from "../../lib/utils.js";
 
 test("Gets file name from a URL", (t) => {
   t.is(getFileName("http://foo.bar/baz.jpg"), "baz.jpg");

--- a/packages/endpoint-micropub/lib/post-type-count.js
+++ b/packages/endpoint-micropub/lib/post-type-count.js
@@ -1,3 +1,5 @@
+import { ObjectId } from "mongodb";
+
 export const postTypeCount = {
   /**
    * Count the number of posts of a given type
@@ -17,7 +19,7 @@ export const postTypeCount = {
 
     // Post type
     const postType = properties["post-type"];
-    const postUrl = properties.url;
+    const postUid = properties.uid;
     const startDate = new Date(new Date(properties.published).toDateString());
     const endDate = new Date(startDate);
     endDate.setDate(endDate.getDate() + 1);
@@ -32,8 +34,8 @@ export const postTypeCount = {
         },
         {
           $match: {
+            _id: new ObjectId(postUid),
             "properties.post-type": postType,
-            "properties.url": { $ne: postUrl },
             convertedDate: {
               $gte: startDate,
               $lt: endDate,

--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -36,14 +36,14 @@ export default class PostsEndpoint {
     router.get("/create", postData.create, formController.get);
     router.post("/create", postData.create, validate, formController.post);
 
-    router.use("/:id/:action?", postData.read);
-    router.get("/:id", postController);
+    router.use("/:uid/:action?", postData.read);
+    router.get("/:uid", postController);
 
-    router.get("/:id/update", formController.get);
-    router.post("/:id/update", validate, formController.post);
+    router.get("/:uid/update", formController.get);
+    router.post("/:uid/update", validate, formController.post);
 
-    router.get("/:id/:action(delete|undelete)", deleteController.get);
-    router.post("/:id/:action(delete|undelete)", deleteController.post);
+    router.get("/:uid/:action(delete|undelete)", deleteController.get);
+    router.post("/:uid/:action(delete|undelete)", deleteController.post);
 
     return router;
   }

--- a/packages/endpoint-posts/lib/controllers/post.js
+++ b/packages/endpoint-posts/lib/controllers/post.js
@@ -44,7 +44,7 @@ export const postController = async (request, response) => {
           }
         : {},
     ],
-    redirectUri: path.join(request.baseUrl, request.params.id),
+    redirectUri: path.join(request.baseUrl, request.params.uid),
     success: request.query.success,
   });
 };

--- a/packages/endpoint-posts/lib/controllers/posts.js
+++ b/packages/endpoint-posts/lib/controllers/posts.js
@@ -3,7 +3,7 @@ import { checkScope } from "@indiekit/endpoint-micropub/lib/scope.js";
 import { mf2tojf2 } from "@paulrobertlloyd/mf2tojf2";
 import { endpoint } from "../endpoint.js";
 import { statusTypes } from "../status-types.js";
-import { getPostStatusBadges, getPostId, getPostName } from "../utils.js";
+import { getPostStatusBadges, getPostName } from "../utils.js";
 
 /**
  * List published posts
@@ -36,12 +36,12 @@ export const postsController = async (request, response, next) => {
       const items = jf2.children || [jf2];
 
       posts = items.map((item) => {
-        item.id = getPostId(item.url);
+        item.id = item.uid;
         item.icon = item["post-type"];
         item.photo = item.photo ? item.photo[0] : false;
         item.description = item.summary || item.content?.text;
         item.title = getPostName(publication, item);
-        item.url = path.join(request.baseUrl, request.path, item.id);
+        item.url = path.join(request.baseUrl, request.path, item.uid);
         item.badges = getPostStatusBadges(item, response);
 
         return item;

--- a/packages/endpoint-posts/lib/middleware/post-data.js
+++ b/packages/endpoint-posts/lib/middleware/post-data.js
@@ -43,14 +43,18 @@ export const postData = {
   async read(request, response, next) {
     try {
       const { application, publication } = request.app.locals;
-      const { action, id } = request.params;
+      const { action, uid } = request.params;
       const { access_token, scope } = request.session;
 
       const properties = await getPostProperties(
-        id,
+        uid,
         application.micropubEndpoint,
         access_token,
       );
+
+      if (!properties) {
+        throw IndiekitError.notFound(response.locals.__("NotFoundError.page"));
+      }
 
       if (properties.location) {
         properties.geo = [
@@ -80,15 +84,7 @@ export const postData = {
 
       next();
     } catch (error) {
-      let nextError = error;
-
-      if (error.message === "Invalid URL") {
-        nextError = IndiekitError.notFound(
-          response.locals.__("NotFoundError.page"),
-        );
-      }
-
-      next(nextError);
+      next(error);
     }
   },
 };

--- a/packages/endpoint-posts/lib/utils.js
+++ b/packages/endpoint-posts/lib/utils.js
@@ -55,15 +55,6 @@ export const getPostStatusBadges = (post, response) => {
 };
 
 /**
- * Get post ID from URL
- * @param {string} url - URL
- * @returns {string} Post ID
- */
-export const getPostId = (url) => {
-  return Buffer.from(url).toString("base64url");
-};
-
-/**
  * Get post name, falling back to post type name
  * @param {string} publication - Publication configuration
  * @param {object} properties - Post properties
@@ -79,20 +70,24 @@ export const getPostName = (publication, properties) => {
 
 /**
  * Query Micropub endpoint for post data
- * @param {string} id - Post ID
+ * @param {string} uid - Item UID
  * @param {string} micropubEndpoint - Micropub endpoint
  * @param {string} accessToken - Access token
  * @returns {Promise<object>} JF2 properties
  */
-export const getPostProperties = async (id, micropubEndpoint, accessToken) => {
+export const getPostProperties = async (uid, micropubEndpoint, accessToken) => {
   const micropubUrl = new URL(micropubEndpoint);
   micropubUrl.searchParams.append("q", "source");
-  micropubUrl.searchParams.append("url", getPostUrl(id));
 
   const micropubResponse = await endpoint.get(micropubUrl.href, accessToken);
-  const properties = mf2tojf2({ items: [micropubResponse] });
 
-  return properties;
+  if (micropubResponse?.items?.length > 0) {
+    const jf2 = mf2tojf2(micropubResponse);
+    const items = jf2.children || [jf2];
+    return items.find((item) => item.uid === uid);
+  }
+
+  return false;
 };
 
 /**

--- a/packages/endpoint-posts/tests/integration/404-post.js
+++ b/packages/endpoint-posts/tests/integration/404-post.js
@@ -7,7 +7,7 @@ test("Returns 404 error post not found", async (t) => {
   const server = await testServer();
   const request = supertest.agent(server);
   const result = await request
-    .get("/posts/5ffcc8025c561a7bf53bd6e8")
+    .get("/posts/404")
     .auth(testToken(), { type: "bearer" });
 
   t.is(result.status, 404);

--- a/packages/endpoint-posts/tests/unit/utils.js
+++ b/packages/endpoint-posts/tests/unit/utils.js
@@ -1,7 +1,6 @@
 import test from "ava";
 import {
   getLocationProperty,
-  getPostId,
   getPostName,
   getPostStatusBadges,
   getPostTypeName,
@@ -45,13 +44,6 @@ test("Gets location property", (t) => {
     longitude: "-65.4321",
     name: "12° 20′ 44.16″ N 65° 25′ 55.56″ W",
   });
-});
-
-test("Gets post ID", (t) => {
-  t.is(
-    getPostId("https://website.example/foobar"),
-    "aHR0cHM6Ly93ZWJzaXRlLmV4YW1wbGUvZm9vYmFy",
-  );
 });
 
 test("Gets post name", (t) => {


### PR DESCRIPTION
Now that posts advertise their `uid`, we can use this to query posts and media items, and use UIDs in the frontend URL scheme. Removes quite a bit of complexity, and removes obscuration and lengthy slugs in the URL scheme.