### PR TITLE
Add option to include permalink in Mastodon status

### DIFF
--- a/packages/syndicator-mastodon/README.md
+++ b/packages/syndicator-mastodon/README.md
@@ -35,10 +35,11 @@ When sharing content to Mastodon using this syndicator, any post visibility sett
 
 ## Options
 
-| Option           | Type      | Description                                                                                                   |
-| :--------------- | :-------- | :------------------------------------------------------------------------------------------------------------ |
-| `accessToken`    | `string`  | Your Mastodon access token. _Required_, defaults to `process.env.MASTODON_ACCESS_TOKEN`.                      |
-| `url`            | `string`  | Your Mastodon server, i.e. `https://mastodon.social`. _Required_.                                             |
-| `user`           | `string`  | Your Mastodon username (without the `@`). _Required_.                                                         |
-| `characterLimit` | `number`  | Maximum number of characters before a post is truncated. _Optional_, defaults to `500`.                       |
-| `checked`        | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`. |
+| Option             | Type      | Description                                                                                                   |
+| :----------------- | :-------- | :------------------------------------------------------------------------------------------------------------ |
+| `accessToken`      | `string`  | Your Mastodon access token. _Required_, defaults to `process.env.MASTODON_ACCESS_TOKEN`.                      |
+| `url`              | `string`  | Your Mastodon server, i.e. `https://mastodon.social`. _Required_.                                             |
+| `user`             | `string`  | Your Mastodon username (without the `@`). _Required_.                                                         |
+| `characterLimit`   | `number`  | Maximum number of characters before a post is truncated. _Optional_, defaults to `500`.                       |
+| `checked`          | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`. |
+| `includePermalink` | `boolean` | Always include a link to the original post. _Optional_, defaults to `false`.                                  |

--- a/packages/syndicator-mastodon/index.js
+++ b/packages/syndicator-mastodon/index.js
@@ -7,6 +7,7 @@ const defaults = {
   accessToken: process.env.MASTODON_ACCESS_TOKEN,
   characterLimit: 500,
   checked: false,
+  includePermalink: false,
 };
 
 export default class MastodonSyndicator {
@@ -88,6 +89,7 @@ export default class MastodonSyndicator {
       return await mastodon({
         accessToken: this.options.accessToken,
         characterLimit: this.options.characterLimit,
+        includePermalink: this.options.includePermalink,
         serverUrl: `${this.#url.protocol}//${this.#url.hostname}`,
       }).post(properties, publication.me);
     } catch (error) {

--- a/packages/syndicator-mastodon/lib/mastodon.js
+++ b/packages/syndicator-mastodon/lib/mastodon.js
@@ -3,7 +3,12 @@ import { getCanonicalUrl, isSameOrigin } from "@indiekit/util";
 import { createRestAPIClient } from "masto";
 import { createStatus, getStatusIdFromUrl } from "./utils.js";
 
-export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
+export const mastodon = ({
+  accessToken,
+  characterLimit,
+  includePermalink,
+  serverUrl,
+}) => ({
   client() {
     return createRestAPIClient({
       accessToken,
@@ -138,6 +143,7 @@ export const mastodon = ({ accessToken, characterLimit, serverUrl }) => ({
 
     const status = createStatus(properties, {
       characterLimit,
+      includePermalink,
       mediaIds,
       serverUrl,
     });

--- a/packages/syndicator-mastodon/lib/utils.js
+++ b/packages/syndicator-mastodon/lib/utils.js
@@ -8,12 +8,13 @@ import { htmlToText } from "html-to-text";
  * @param {object} properties - A JF2 properties object
  * @param {object} [options] - Options
  * @param {number} [options.characterLimit] - Character limit
+ * @param {number} [options.includePermalink] - Always include permalink
  * @param {Array} [options.mediaIds] - Mastodon media IDs
  * @param {string} [options.serverUrl] - Server URL
  * @returns {object} Status parameters
  */
 export const createStatus = (properties, options = {}) => {
-  const { characterLimit, mediaIds, serverUrl } = options;
+  const { characterLimit, includePermalink, mediaIds, serverUrl } = options;
   const parameters = {};
 
   let status;
@@ -36,12 +37,20 @@ export const createStatus = (properties, options = {}) => {
 
   // Truncate status if longer than 500 characters
   if (status) {
-    parameters.status = brevity.shorten(
+    const statusText = brevity.shorten(
       status,
       properties.url,
-      false, // https://indieweb.org/permashortlink
+      includePermalink // https://indieweb.org/permashortlink
+        ? properties.url
+        : false,
       false, // https://indieweb.org/permashortcitation
       characterLimit,
+    );
+
+    // Show permalink below status, not within brackets
+    parameters.status = statusText.replace(
+      `(${properties.url})`,
+      `\n\n${properties.url}`,
     );
   }
 


### PR DESCRIPTION
Defaults to `false`, but enables the option to include a permalink for shorter statues, not just those that go over the character limit.

I don’t like how the permalink looks inside brackets, so am updating the output from Brevity to instead show the permalink below the status text following 2 line breaks.

Fixes #568.