### PR TITLE
Fetch references for form-encoded requests

### DIFF
--- a/indiekit.config.js
+++ b/indiekit.config.js
@@ -23,6 +23,7 @@ const config = {
   publication: {
     me: process.env.PUBLICATION_URL,
     categories: ["internet", "indieweb", "indiekit", "test", "testing"],
+    enrichPostData: true,
   },
   "@indiekit/store-github": {
     user: process.env.GITHUB_USER,

--- a/packages/endpoint-micropub/lib/controllers/action.js
+++ b/packages/endpoint-micropub/lib/controllers/action.js
@@ -44,7 +44,7 @@ export const actionController = async (request, response, next) => {
         // Create and normalise JF2 data
         jf2 = request.is("json")
           ? await mf2ToJf2(body, publication.enrichPostData)
-          : formEncodedToJf2(body);
+          : await formEncodedToJf2(body, publication.enrichPostData);
 
         // Attach files
         jf2 = files

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -1,5 +1,6 @@
 import { getDate, randomString, slugify } from "@indiekit/util";
 import { mf2tojf2, mf2tojf2referenced } from "@paulrobertlloyd/mf2tojf2";
+import { fetchReferences } from "@paulrobertlloyd/mf2tojf2/lib/fetch-references.js";
 import { markdownToHtml, htmlToMarkdown } from "./markdown.js";
 import { reservedProperties } from "./reserved-properties.js";
 import {
@@ -12,9 +13,10 @@ import {
 /**
  * Create JF2 object from form-encoded request
  * @param {object} body - Form-encoded request body
- * @returns {object} Micropub action
+ * @param {boolean} requestReferences - Request data for any referenced URLs
+ * @returns {Promise<object>} Micropub action
  */
-export const formEncodedToJf2 = (body) => {
+export const formEncodedToJf2 = async (body, requestReferences) => {
   const jf2 = {
     type: body.h || "entry",
   };
@@ -35,6 +37,10 @@ export const formEncodedToJf2 = (body) => {
       // Adds values to JF2 object
       jf2[key] = value;
     }
+  }
+
+  if (requestReferences) {
+    return fetchReferences(jf2);
   }
 
   return jf2;

--- a/packages/endpoint-micropub/tests/unit/jf2.js
+++ b/packages/endpoint-micropub/tests/unit/jf2.js
@@ -30,8 +30,8 @@ test.beforeEach((t) => {
   };
 });
 
-test("Creates JF2 object from form-encoded request", (t) => {
-  const result = formEncodedToJf2({
+test("Creates JF2 object from form-encoded request", async (t) => {
+  const result = await formEncodedToJf2({
     h: "entry",
     content: "I+ate+a+cheese+sandwich,+which+was+nice.",
     category: ["foo", "bar"],


### PR DESCRIPTION
If a post was created using form-encoded data, if the `publication.enrichPosts` option was enabled, post data wasn’t being enriched.

We can enrich JF2 using `fetchReferences` exported from `mf2tojf2`, though not from the main export of that module. Maybe it should be a top-level export? Will consider that as a feature to be added to `mf2tojf2`

Fixes #671.