### PR TITLE
Offer MongoURL guidance in options

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -94,12 +94,12 @@ _Optional_, defaults to `"[application.url]/micropub"`. For example:
 
 A [MongoDB connection string](https://www.mongodb.com/docs/manual/reference/connection-string/). Used by features that require a database.
 
-_Optional_, defaults to `process.env.MONGO_URL`. For example:
+_Optional_, defaults to `process.env.MONGO_URL`. Make sure to include a database name in the path. For example:
 
 ```json
 {
   "application": {
-    "mongodbUrl": "mongodb://mongodb0.example.com:27017"
+    "mongodbUrl": "mongodb://mongodb0.example.com:27017/indiekit"
   }
 }
 ```

--- a/packages/frontend/components/input/styles.css
+++ b/packages/frontend/components/input/styles.css
@@ -40,6 +40,10 @@
     }
   }
 
+  &[type="datetime-local"] {
+    min-block-size: 2.5rem;
+  }
+
   &[type="file"] {
     background: none;
     border: 0;


### PR DESCRIPTION
I struggled to get my MongoDB configuration working (I kept being told it wasn't configured when it clearly was!)

I saw elsewhere that IndieKit expects MongoDB URIs to have a path element (to define the database name), I added `/indiekit` to my URI and things started working.

_Assuming_ I've correctly understood the problem and a suitable fix, I thought I'd update guidance in the docs!

There may be ways to set this as a default if it's unspecified, but I'm not familiar enough with the codebase to offer a fix yet. Feel free to replace this PR with a code-based one instead!