### PR TITLE
Event post type

### DIFF
--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -59,6 +59,7 @@ export default class PostsEndpoint {
       "reply",
       "like",
       "photo",
+      "event",
       "rsvp",
       "repost",
       "video",

--- a/packages/endpoint-posts/lib/controllers/form.js
+++ b/packages/endpoint-posts/lib/controllers/form.js
@@ -92,10 +92,9 @@ export const formController = {
         }
       }
 
-      // Convert geo value to object
-      if (values.geo) {
-        values.location = getLocationProperty(values.geo);
-        delete values.geo;
+      // Derive location from location and/or geo values
+      if (values.location || values.geo) {
+        values.location = getLocationProperty(values);
       }
 
       // Delete empty values

--- a/packages/endpoint-posts/lib/middleware/post-data.js
+++ b/packages/endpoint-posts/lib/middleware/post-data.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import { IndiekitError } from "@indiekit/error";
 import { statusTypes } from "../status-types.js";
 import {
+  getGeoValue,
   getPostName,
   getPostProperties,
   getPostTypeName,
@@ -56,11 +57,8 @@ export const postData = {
         throw IndiekitError.notFound(response.locals.__("NotFoundError.page"));
       }
 
-      if (properties.location) {
-        properties.geo = [
-          properties.location.latitude,
-          properties.location.longitude,
-        ].toString();
+      if (properties.location.geo) {
+        properties.geo = getGeoValue(properties.geo);
       }
 
       const postType = properties["post-type"];

--- a/packages/endpoint-posts/lib/middleware/validation.js
+++ b/packages/endpoint-posts/lib/middleware/validation.js
@@ -44,8 +44,13 @@ export const validate = [
     .if(
       (value, { req }) =>
         req.body?.["post-type"] === "article" ||
-        req.body?.["post-type"] === "bookmark",
+        req.body?.["post-type"] === "bookmark" ||
+        req.body?.["post-type"] === "event",
     )
+    .notEmpty()
+    .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
+  check("start")
+    .if((value, { req }) => req.body?.["post-type"] === "event")
     .notEmpty()
     .withMessage((value, { req, path }) => req.__(`posts.error.${path}.empty`)),
   check("content")

--- a/packages/endpoint-posts/lib/utils.js
+++ b/packages/endpoint-posts/lib/utils.js
@@ -8,21 +8,63 @@ export const LAT_LONG_RE =
   /^(?<latitude>(?:-?|\+?)?\d+(?:\.\d+)?),\s*(?<longitude>(?:-?|\+?)?\d+(?:\.\d+)?)$/;
 
 /**
- * Get location property
+ * Get geographic coordinates property
  * @param {string} geo - Latitude and longitude, comma separated
- * @returns {object} JF2 location property
+ * @returns {object} JF2 geo location property
  */
-export const getLocationProperty = (geo) => {
+export const getGeoProperty = (geo) => {
   const { latitude, longitude } = geo.match(LAT_LONG_RE).groups;
 
   return {
     type: "geo",
-    latitude,
-    longitude,
     name: formatcoords(geo).format({
       decimalPlaces: 2,
     }),
+    latitude: Number(latitude),
+    longitude: Number(longitude),
   };
+};
+
+/**
+ * Get comma separated geographic coordinates
+ * @param {object} geo - JF2 geo location property
+ * @returns {string} Latitude and longitude, comma separated
+ */
+export const getGeoValue = (geo) => {
+  return [geo.latitude, geo.longitude].toString();
+};
+
+/**
+ * Get location property
+ * @param {object} values - Latitude and longitude, comma separated
+ * @returns {object} JF2 location property
+ */
+export const getLocationProperty = (values) => {
+  const { location, geo } = values;
+
+  // Determine Microformat type
+  if (location && location.name) {
+    location.type = "card";
+  } else if (location) {
+    location.type = "adr";
+  }
+
+  // Add (or use) any provided geo location properties
+  if (location && geo) {
+    location.geo = getGeoProperty(geo);
+  } else if (geo) {
+    return getGeoProperty(geo);
+  }
+
+  // Delete empty values
+  for (const key in location) {
+    const noValue = !location[key] || location[key] === "";
+    if (Object.prototype.hasOwnProperty.call(location, key) && noValue) {
+      delete location[key];
+    }
+  }
+
+  return location;
 };
 
 /**

--- a/packages/endpoint-posts/locales/de.json
+++ b/packages/endpoint-posts/locales/de.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Titel eingeben"
       },
+      "start": {
+        "empty": "Geben Sie ein Startdatum ein"
+      },
       "url": {
         "empty": "Geben Sie eine Webadresse wie %s"
       }
@@ -50,6 +53,12 @@
         "label": "Inhalt"
       },
       "continue": "Fortsetzen",
+      "event": {
+        "all-day": "Ganztägig",
+        "end": "Endet",
+        "label": "Datum und Uhrzeit",
+        "start": "Beginnt"
+      },
       "geo": {
         "hint": "Breitengrad und Längengrad, zum Beispiel %s",
         "label": "Koordinaten des Standorts"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "Wie von"
+      },
+      "location": {
+        "country-name": "Land",
+        "label": "Standort",
+        "locality": "Stadt oder Ort",
+        "name": "Veranstaltungsort",
+        "postal-code": "Postleitzahl",
+        "street-address": "Straße"
       },
       "media": {
         "label": "Dateipfad oder URL"

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -13,6 +13,9 @@
       "name": {
         "empty": "Enter a title"
       },
+      "start": {
+        "empty": "Enter a start date"
+      },
       "url": {
         "empty": "Enter a web address like %s"
       },
@@ -75,6 +78,12 @@
       "content": {
         "label": "Content"
       },
+      "event": {
+        "label": "Date and time",
+        "start": "Starts",
+        "end": "Ends",
+        "all-day": "All-day"
+      },
       "geo": {
         "label": "Location coordinates",
         "hint": "Latitude and longitude, for example %s"
@@ -84,6 +93,14 @@
       },
       "like-of": {
         "label": "Like of"
+      },
+      "location": {
+        "label": "Location",
+        "name": "Venue",
+        "street-address": "Street address",
+        "locality": "City or town",
+        "country-name": "Country",
+        "postal-code": "Postal code"
       },
       "name": {
         "label": "Title"

--- a/packages/endpoint-posts/locales/es-419.json
+++ b/packages/endpoint-posts/locales/es-419.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Ingresar un título"
       },
+      "start": {
+        "empty": "Introduce una fecha de inicio"
+      },
       "url": {
         "empty": "Introducir una dirección web como %s"
       }
@@ -50,6 +53,12 @@
         "label": "Contenido"
       },
       "continue": "Continuar",
+      "event": {
+        "all-day": "Todo el día",
+        "end": "Termina",
+        "label": "Fecha y hora",
+        "start": "Comienza"
+      },
       "geo": {
         "hint": "Latitud y longitud, por ejemplo %s",
         "label": "Coordenadas de ubicación"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "Como de"
+      },
+      "location": {
+        "country-name": "País",
+        "label": "Ubicación",
+        "locality": "Ciudad o pueblo",
+        "name": "Lugar de eventos",
+        "postal-code": "Código postal",
+        "street-address": "Dirección de la calle"
       },
       "media": {
         "label": "Ruta o URL del archivo"

--- a/packages/endpoint-posts/locales/es.json
+++ b/packages/endpoint-posts/locales/es.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Pon un título"
       },
+      "start": {
+        "empty": "Introduce una fecha de inicio"
+      },
       "url": {
         "empty": "Introduce una dirección web como %s"
       }
@@ -50,6 +53,12 @@
         "label": "Contenido"
       },
       "continue": "Continuar",
+      "event": {
+        "all-day": "Todo el día",
+        "end": "Termina",
+        "label": "Fecha y hora",
+        "start": "Comienza"
+      },
       "geo": {
         "hint": "Latitud y longitud, por ejemplo %s",
         "label": "Coordenadas de ubicación"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "Como de"
+      },
+      "location": {
+        "country-name": "País",
+        "label": "Ubicación",
+        "locality": "Ciudad o pueblo",
+        "name": "Campo",
+        "postal-code": "Código postal",
+        "street-address": "Dirección"
       },
       "media": {
         "label": "Ruta o URL del archivo"

--- a/packages/endpoint-posts/locales/fr.json
+++ b/packages/endpoint-posts/locales/fr.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Saisir un titre"
       },
+      "start": {
+        "empty": "Entrez la date de début"
+      },
       "url": {
         "empty": "Saisir une adresse Web telle que %s"
       }
@@ -50,6 +53,12 @@
         "label": "Contenu"
       },
       "continue": "Continuer",
+      "event": {
+        "all-day": "Toute la journée",
+        "end": "Fin",
+        "label": "Date et heure",
+        "start": "Commence"
+      },
       "geo": {
         "hint": "Latitude et longitude, par exemple %s",
         "label": "Coordonnées de localisation"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "J’aime"
+      },
+      "location": {
+        "country-name": "Pays",
+        "label": "Localisation",
+        "locality": "Ville",
+        "name": "Lieu",
+        "postal-code": "Code postal",
+        "street-address": "Adresse"
       },
       "media": {
         "label": "Chemin du fichier ou URL"

--- a/packages/endpoint-posts/locales/id.json
+++ b/packages/endpoint-posts/locales/id.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Masukkan judul"
       },
+      "start": {
+        "empty": "Masukkan tanggal mulai"
+      },
       "url": {
         "empty": "Masukkan alamat web misalnya %s"
       }
@@ -50,6 +53,12 @@
         "label": "Konten"
       },
       "continue": "Lanjutkan",
+      "event": {
+        "all-day": "Sepanjang hari",
+        "end": "Berakhir",
+        "label": "Tanggal dan waktu",
+        "start": "Mulai"
+      },
       "geo": {
         "hint": "Lintang dan bujur, misalnya %s",
         "label": "Koordinat lokasi"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "Seperti"
+      },
+      "location": {
+        "country-name": "Negara",
+        "label": "Lokasi",
+        "locality": "Kota",
+        "name": "Tempat",
+        "postal-code": "Kode pos",
+        "street-address": "Alamat jalan"
       },
       "media": {
         "label": "Jalur file atau URL"

--- a/packages/endpoint-posts/locales/nl.json
+++ b/packages/endpoint-posts/locales/nl.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Geef een titel in"
       },
+      "start": {
+        "empty": "Voer een startdatum in"
+      },
       "url": {
         "empty": "Voer een webadres in zoals %s"
       }
@@ -50,6 +53,12 @@
         "label": "Inhoud"
       },
       "continue": "Doorgaan",
+      "event": {
+        "all-day": "Hele dag",
+        "end": "Eindigt",
+        "label": "Datum en tijd",
+        "start": "Begint"
+      },
       "geo": {
         "hint": "Lengte- en breedtegraad, bijvoorbeeld %s",
         "label": "Locatiecoördinaten"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "Zoals van"
+      },
+      "location": {
+        "country-name": "Land",
+        "label": "Locatie",
+        "locality": "Stad",
+        "name": "Plaats",
+        "postal-code": "Postcode",
+        "street-address": "Adres"
       },
       "media": {
         "label": "Bestandspad of URL"

--- a/packages/endpoint-posts/locales/pl.json
+++ b/packages/endpoint-posts/locales/pl.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Wprowadź tytuł"
       },
+      "start": {
+        "empty": "Wpisz datę rozpoczęcia"
+      },
       "url": {
         "empty": "Wpisz adres internetowy, taki jak %s"
       }
@@ -50,6 +53,12 @@
         "label": "Zawartość"
       },
       "continue": "Kontynuuj",
+      "event": {
+        "all-day": "Cały dzień",
+        "end": "Kończy się",
+        "label": "Data i godzina",
+        "start": "Rozpoczyna się"
+      },
       "geo": {
         "hint": "Szerokość i długość geograficzna, na przykład %s",
         "label": "Współrzędne lokalizacji"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "Jak z"
+      },
+      "location": {
+        "country-name": "Kraj",
+        "label": "Lokalizacja",
+        "locality": "Miasto",
+        "name": "Miejsce",
+        "postal-code": "Kod pocztowy",
+        "street-address": "Adres"
       },
       "media": {
         "label": "Ścieżka pliku lub adres URL"

--- a/packages/endpoint-posts/locales/pt.json
+++ b/packages/endpoint-posts/locales/pt.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Introduza um título"
       },
+      "start": {
+        "empty": "Insira uma data de início"
+      },
       "url": {
         "empty": "Insira um endereço da web como %s"
       }
@@ -50,6 +53,12 @@
         "label": "Conteúdo"
       },
       "continue": "Continuar",
+      "event": {
+        "all-day": "Todo o dia",
+        "end": "Termina",
+        "label": "Data e hora",
+        "start": "Começa"
+      },
       "geo": {
         "hint": "Latitude e longitude, por exemplo %s",
         "label": "Coordenadas de localização"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "Como de"
+      },
+      "location": {
+        "country-name": "País",
+        "label": "Localização",
+        "locality": "Cidade ou vila",
+        "name": "Local",
+        "postal-code": "Código postal",
+        "street-address": "Endereço"
       },
       "media": {
         "label": "Caminho do arquivo ou URL"

--- a/packages/endpoint-posts/locales/sr.json
+++ b/packages/endpoint-posts/locales/sr.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "Unesite naslov"
       },
+      "start": {
+        "empty": "Unesite datum početka"
+      },
       "url": {
         "empty": "Unesite veb adresu kao što je %s"
       }
@@ -50,6 +53,12 @@
         "label": "Sadržaj"
       },
       "continue": "Nastavi",
+      "event": {
+        "all-day": "Ceo dan",
+        "end": "Krajevi",
+        "label": "Datum i vreme",
+        "start": "Počinje"
+      },
       "geo": {
         "hint": "Geografska širina i dužina, na primer %s",
         "label": "Koordinate lokacije"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "Kao od"
+      },
+      "location": {
+        "country-name": "Zemlja",
+        "label": "Lokacija",
+        "locality": "Grad",
+        "name": "Mesto održavanja",
+        "postal-code": "Poštanski kod",
+        "street-address": "Ulica i broj"
       },
       "media": {
         "label": "Putanja ili URL datoteke"

--- a/packages/endpoint-posts/locales/zh-Hans-CN.json
+++ b/packages/endpoint-posts/locales/zh-Hans-CN.json
@@ -26,6 +26,9 @@
       "name": {
         "empty": "输入标题"
       },
+      "start": {
+        "empty": "输入开始日期"
+      },
       "url": {
         "empty": "输入像 %s 这样的网址"
       }
@@ -50,6 +53,12 @@
         "label": "内容"
       },
       "continue": "继续",
+      "event": {
+        "all-day": "全天",
+        "end": "结束",
+        "label": "日期和时间",
+        "start": "开始"
+      },
       "geo": {
         "hint": "纬度和经度，例如 %s",
         "label": "位置坐标"
@@ -59,6 +68,14 @@
       },
       "like-of": {
         "label": "像这样"
+      },
+      "location": {
+        "country-name": "国家",
+        "label": "地点",
+        "locality": "城市",
+        "name": "举办地点",
+        "postal-code": "邮政编码",
+        "street-address": "街道地址"
       },
       "media": {
         "label": "文件路径或 URL"

--- a/packages/endpoint-posts/test/unit/utils.js
+++ b/packages/endpoint-posts/test/unit/utils.js
@@ -2,6 +2,8 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { mockResponse } from "mock-req-res";
 import {
+  getGeoProperty,
+  getGeoValue,
   getLocationProperty,
   getPostName,
   getPostStatusBadges,
@@ -33,12 +35,123 @@ const publication = {
 };
 
 describe("endpoint-posts/lib/utils", () => {
-  it("Gets location property", () => {
-    assert.deepEqual(getLocationProperty("12.3456, -65.4321"), {
+  it("Gets geographic coordinates property", () => {
+    assert.deepEqual(getGeoProperty("50.8252, -0.1383"), {
       type: "geo",
-      latitude: "12.3456",
-      longitude: "-65.4321",
-      name: "12° 20′ 44.16″ N 65° 25′ 55.56″ W",
+      name: "50° 49′ 30.72″ N 0° 8′ 17.88″ W",
+      latitude: 50.8252,
+      longitude: -0.1383,
+    });
+  });
+
+  it("Gets comma separated geographic coordinates", () => {
+    assert.equal(
+      getGeoValue({
+        type: "geo",
+        name: "50° 49′ 30.72″ N 0° 8′ 17.88″ W",
+        latitude: 50.8252,
+        longitude: -0.1383,
+      }),
+      "50.8252,-0.1383",
+    );
+  });
+
+  it("Gets location property", async (t) => {
+    await t.test("with address", () => {
+      assert.deepEqual(
+        getLocationProperty({
+          location: {
+            "street-address": "Jubilee Street",
+            locality: "Brighton",
+            "postal-code": "BN1 1GE",
+          },
+        }),
+        {
+          type: "adr",
+          "street-address": "Jubilee Street",
+          locality: "Brighton",
+          "postal-code": "BN1 1GE",
+        },
+      );
+    });
+
+    await t.test("without empty values", () => {
+      assert.deepEqual(
+        getLocationProperty({
+          location: {
+            name: "Brighton Jubilee Library",
+            "street-address": "",
+            locality: "Brighton",
+            "postal-code": "",
+          },
+        }),
+        {
+          type: "card",
+          name: "Brighton Jubilee Library",
+          locality: "Brighton",
+        },
+      );
+    });
+
+    await t.test("with venue", () => {
+      assert.deepEqual(
+        getLocationProperty({
+          location: {
+            name: "Brighton Jubilee Library",
+            "street-address": "Jubilee Street",
+            locality: "Brighton",
+            "postal-code": "BN1 1GE",
+          },
+        }),
+        {
+          type: "card",
+          name: "Brighton Jubilee Library",
+          "street-address": "Jubilee Street",
+          locality: "Brighton",
+          "postal-code": "BN1 1GE",
+        },
+      );
+    });
+
+    await t.test("with geographic coordinates", () => {
+      assert.deepEqual(
+        getLocationProperty({
+          geo: "50.8252, -0.1383",
+        }),
+        {
+          type: "geo",
+          name: "50° 49′ 30.72″ N 0° 8′ 17.88″ W",
+          latitude: 50.8252,
+          longitude: -0.1383,
+        },
+      );
+    });
+
+    await t.test("with venue and geographic coordinates", () => {
+      assert.deepEqual(
+        getLocationProperty({
+          geo: "50.8252, -0.1383",
+          location: {
+            name: "Brighton Jubilee Library",
+            "street-address": "Jubilee Street",
+            locality: "Brighton",
+            "postal-code": "BN1 1GE",
+          },
+        }),
+        {
+          type: "card",
+          name: "Brighton Jubilee Library",
+          "street-address": "Jubilee Street",
+          locality: "Brighton",
+          "postal-code": "BN1 1GE",
+          geo: {
+            type: "geo",
+            name: "50° 49′ 30.72″ N 0° 8′ 17.88″ W",
+            latitude: 50.8252,
+            longitude: -0.1383,
+          },
+        },
+      );
     });
   });
 

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -9,7 +9,8 @@
 %}
 {% set nameOptional =
   postType !== "article" and
-  postType !== "bookmark" %}
+  postType !== "bookmark" and
+  postType !== "event" %}
 {% set nameIgnored =
   postType === "note" or
   postType === "like" or
@@ -154,6 +155,84 @@
     optional: nameOptional,
     errorMessage: fieldData("name").errorMessage
   }) | indent(2) if not nameIgnored }}
+
+{% if postType === "event" %}
+{% call fieldset({
+  classes: "fieldset--group",
+  legend: __("posts.form.location.label"),
+  optional: true
+}) %}
+  {{ input({
+    name: "location[name]",
+    value: fieldData("location.name").value,
+    label: __("posts.form.location.name")
+  }) | indent(2) if not nameIgnored }}
+
+  {{ input({
+    name: "location[street-address]",
+    value: fieldData("location.street-address").value,
+    label: __("posts.form.location.street-address"),
+    autocomplete: "address-line1"
+  }) | indent(2) }}
+
+  {{ input({
+    classes: "input--width-25",
+    name: "location[locality]",
+    value: fieldData("location.locality").value,
+    label: __("posts.form.location.locality"),
+    autocomplete: "address-level2"
+  }) | indent(2) }}
+
+  {{ input({
+    classes: "input--width-25",
+    name: "location[country-name]",
+    value: fieldData("location.country-name").value,
+    label: __("posts.form.location.country-name"),
+    autocomplete: "country-name"
+  }) | indent(2) }}
+
+  {{ input({
+    classes: "input--width-10",
+    name: "location[postal-code]",
+    value: fieldData("location.postal-code").value,
+    label: __("posts.form.location.postal-code"),
+    autocomplete: "postal-code"
+  }) | indent(2) }}
+{% endcall %}
+
+{% call fieldset({
+  classes: "fieldset--group fieldset--inline",
+  legend: __("posts.form.event.label")
+}) %}
+  <event-duration>
+    {{ input({
+      name: "start",
+      type: "datetime-local",
+      value: fieldData("start").value,
+      label: __("posts.form.event.start"),
+      errorMessage: fieldData("start").errorMessage
+    }) | indent(2) }}
+
+    {{ input({
+      name: "end",
+      type: "datetime-local",
+      value: fieldData("end").value,
+      label: __("posts.form.event.end"),
+      optional: true,
+      errorMessage: fieldData("end").errorMessage
+    }) | indent(2) }}
+
+    {{ checkboxes({
+      name: "all-day",
+      values: fieldData("all-day").value,
+      items: [{
+        label: __("posts.form.event.all-day"),
+        value: true
+      }]
+    }) | indent(2) }}
+  </event-duration>
+{% endcall %}
+{% endif %}
 
   {{ textarea({
     name: "content",

--- a/packages/frontend/components/error-message/styles.css
+++ b/packages/frontend/components/error-message/styles.css
@@ -2,5 +2,4 @@
   color: var(--color-error);
   font: var(--font-caption);
   font-weight: 600;
-  margin-block-end: var(--space-xs);
 }

--- a/packages/frontend/components/event-duration/index.js
+++ b/packages/frontend/components/event-duration/index.js
@@ -1,0 +1,29 @@
+export const EventDurationComponent = class extends HTMLElement {
+  constructor() {
+    super();
+
+    this.allDayToggle = this.querySelector(`input[type="checkbox"]`);
+    this.dateTimeInputs = this.querySelectorAll(`input[type="datetime-local"]`);
+  }
+
+  connectedCallback() {
+    this.updateDateTimeInputs();
+  }
+
+  updateDateTimeInputs() {
+    for (const $dateInput of this.dateTimeInputs) {
+      $dateInput.type = this.allDayToggle.checked ? "date" : "datetime-local";
+
+      this.allDayToggle.addEventListener("click", () => {
+        const initialValue = $dateInput.value;
+        if (this.allDayToggle.checked) {
+          $dateInput.type = "date";
+          $dateInput.value = initialValue.split("T")[0];
+        } else {
+          $dateInput.type = "datetime-local";
+          $dateInput.value = `${initialValue}T12:30`;
+        }
+      });
+    }
+  }
+};

--- a/packages/frontend/components/event-duration/styles.css
+++ b/packages/frontend/components/event-duration/styles.css
@@ -1,0 +1,11 @@
+event-duration {
+  align-items: end;
+  column-gap: var(--space-xl);
+  display: flex;
+  flex-wrap: wrap;
+  margin-block-start: 0 !important;
+
+  & .field {
+    min-inline-size: 20ch;
+  }
+}

--- a/packages/frontend/scripts/app.js
+++ b/packages/frontend/scripts/app.js
@@ -1,6 +1,7 @@
 import { AddAnotherComponent } from "../components/add-another/index.js";
 import { CheckboxesFieldComponent } from "../components/checkboxes/index.js";
 import { ErrorSummaryComponent } from "../components/error-summary/index.js";
+import { EventDurationComponent } from "../components/event-duration/index.js";
 import { GeoInputFieldComponent } from "../components/geo-input/index.js";
 import { NotificationBannerComponent } from "../components/notification-banner/index.js";
 import { RadiosFieldComponent } from "../components/radios/index.js";
@@ -11,6 +12,7 @@ import { TextareaFieldComponent } from "../components/textarea/index.js";
 customElements.define("add-another", AddAnotherComponent);
 customElements.define("checkboxes-field", CheckboxesFieldComponent);
 customElements.define("error-summary", ErrorSummaryComponent);
+customElements.define("event-duration", EventDurationComponent);
 customElements.define("geo-input-field", GeoInputFieldComponent);
 customElements.define("notification-banner", NotificationBannerComponent);
 customElements.define("radios-field", RadiosFieldComponent);

--- a/packages/frontend/styles/app.css
+++ b/packages/frontend/styles/app.css
@@ -29,6 +29,7 @@
 @import url("../components/details/styles.css");
 @import url("../components/error-message/styles.css");
 @import url("../components/error-summary/styles.css");
+@import url("../components/event-duration/styles.css");
 @import url("../components/field/styles.css");
 @import url("../components/fieldset/styles.css");
 @import url("../components/footer/styles.css");


### PR DESCRIPTION
- Add (optional) location fields with localised strings
- Add start and (optional) end datetime fields with localised strings
- Show location and start/end datetime fields for event post type
- Add validation for name and start date for event post type
- Add event post type to list of supported post types
- Add `<event-duration>` element that allows toggling between `input[type=datetime-local]` and `input[date]` depending on whether times are needed for the event 
- Update deriving location property so location can contain a venue (`h-card`) or address (`h-adr`) and/or geographic coordinates (`h-geo`)

In future iterations we can use geolocation to find an address and geographic coordinates from a fuzzy free-text search, but this simpler implementation means Indiekit can support creating this post type sooner.

Fixes #541