### PR TITLE
Log CRUD operations on post-data and post-content in micropub endpoint

### DIFF
--- a/packages/endpoint-micropub/lib/post-content.js
+++ b/packages/endpoint-micropub/lib/post-content.js
@@ -1,4 +1,7 @@
+import makeDebug from "debug";
 import { getPostTemplateProperties } from "./utils.js";
+
+const debug = makeDebug("indiekit:endpoint-micropub:post-content");
 
 export const postContent = {
   /**
@@ -8,6 +11,7 @@ export const postContent = {
    * @returns {Promise<object>} Response data
    */
   async create(publication, postData) {
+    debug(`create %O`, { postData });
     const { postTemplate, store, storeMessageTemplate } = publication;
     const { path, properties } = postData;
     const metaData = {
@@ -40,6 +44,7 @@ export const postContent = {
    * @returns {Promise<object>} Response data
    */
   async update(publication, postData, url) {
+    debug(`update ${url} %O`, { postData });
     const { postTemplate, store, storeMessageTemplate } = publication;
     const { _originalPath, path, properties } = postData;
     const metaData = {
@@ -81,6 +86,7 @@ export const postContent = {
    * @returns {Promise<object>} Response data
    */
   async delete(publication, postData) {
+    debug(`delete %O`, { postData });
     const { store, storeMessageTemplate } = publication;
     const { path, properties } = postData;
     const metaData = {
@@ -109,6 +115,7 @@ export const postContent = {
    * @returns {Promise<object>} Response data
    */
   async undelete(publication, postData) {
+    debug(`undelete %O`, { postData });
     const { postTemplate, store, storeMessageTemplate } = publication;
     const { path, properties } = postData;
     const metaData = {

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -1,10 +1,13 @@
 import util from "node:util";
+import makeDebug from "debug";
 import { IndiekitError } from "@indiekit/error";
 import { getCanonicalUrl, getDate } from "@indiekit/util";
 import { getPostType } from "./post-type-discovery.js";
 import { getSyndicateToProperty, normaliseProperties } from "./jf2.js";
 import * as updateMf2 from "./update.js";
 import { renderPath } from "./utils.js";
+
+const debug = makeDebug("indiekit:endpoint-micropub:post-data");
 
 export const postData = {
   /**
@@ -16,6 +19,7 @@ export const postData = {
    * @returns {Promise<object>} Post data
    */
   async create(application, publication, properties, draftMode = false) {
+    debug(`create %O`, { draftMode, properties });
     const { hasDatabase, posts, timeZone } = application;
     const { me, postTypes, syndicationTargets } = publication;
 
@@ -70,6 +74,7 @@ export const postData = {
    * @returns {Promise<object>} Post data
    */
   async read(application, url) {
+    debug(`read ${url}`);
     const { posts } = application;
     const query = { "properties.url": url };
 
@@ -92,6 +97,7 @@ export const postData = {
    * @returns {Promise<object>} Post data
    */
   async update(application, publication, url, operation) {
+    debug(`update ${url} %O`, { operation });
     const { posts, timeZone } = application;
     const { me, postTypes } = publication;
 
@@ -168,6 +174,7 @@ export const postData = {
    * @returns {Promise<object>} Post data
    */
   async delete(application, publication, url) {
+    debug(`delete ${url}`);
     const { posts, timeZone } = application;
     const { postTypes } = publication;
 
@@ -217,6 +224,7 @@ export const postData = {
    * @returns {Promise<object>} Post data
    */
   async undelete(application, publication, url, draftMode) {
+    debug(`undelete ${url} %O`, { draftMode });
     const { posts } = application;
     const { postTypes } = publication;
 


### PR DESCRIPTION
I think that adding even a single log statement for each CRUD operation would aid troubleshooting and improve debuggability.