### PR TITLE
Immediately notify the user about connection issues with MongoDB

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -104,6 +104,9 @@ _Optional_, defaults to `process.env.MONGO_URL`. For example:
 }
 ```
 
+> [!TIP] Change in upcoming version <Badge type="info" text="1.0.0-beta.8" />
+> To use a specifically named database, include this in your path (the default database is `test`). For example, `mongodb://mongodb0.example.com:27017/indiekit`.
+
 <!--@include: .option-contains-secrets.md-->
 
 ### application.port `number`

--- a/helpers/database/index.js
+++ b/helpers/database/index.js
@@ -4,7 +4,7 @@ import { getMongodbClient } from "@indiekit/indiekit/lib/mongodb.js";
 export const testDatabase = async () => {
   const mongoServer = await MongoMemoryServer.create();
   const mongoUri = mongoServer.getUri();
-  const client = await getMongodbClient(mongoUri);
+  const { client } = await getMongodbClient(mongoUri);
   const database = await client.db();
 
   return { client, database, mongoServer, mongoUri };

--- a/packages/frontend/layouts/default.njk
+++ b/packages/frontend/layouts/default.njk
@@ -69,7 +69,7 @@
 <main class="{{ mainClasses }}" id="main">
 {{- notificationBanner({
   type: ("error" if error) or ("success" if success),
-  text: (error.message if error) or (success if success) or notice,
+  text: (error if error) or (success if success) or notice,
   details: error.stack if error
 }) if error or success or notice }}
 {{- backLink({

--- a/packages/indiekit/lib/middleware/locals.js
+++ b/packages/indiekit/lib/middleware/locals.js
@@ -15,6 +15,11 @@ export const locals = (indiekitConfig) =>
       // Application
       request.app.locals.application = application;
 
+      // Display any MongoDB client connection errors
+      if (application._mongodbClientError) {
+        request.app.locals.error = application._mongodbClientError;
+      }
+
       // Application locale
       application.localeUsed = response.locals.getLocale();
 

--- a/packages/indiekit/lib/mongodb.js
+++ b/packages/indiekit/lib/mongodb.js
@@ -3,18 +3,35 @@ import { MongoClient } from "mongodb";
 /**
  * Connect to MongoDB client
  * @param {string} mongodbUrl - MongoDB URL
- * @returns {import('mongodb').MongoClient|undefined} MongoDB client
+ * @returns {Promise<object>} MongoDB client
  */
-export const getMongodbClient = (mongodbUrl) => {
-  if (mongodbUrl) {
-    try {
-      const client = new MongoClient(mongodbUrl, {
-        connectTimeoutMS: 5000,
-      });
+export const getMongodbClient = async (mongodbUrl) => {
+  let client;
 
-      return client;
-    } catch (error) {
-      console.warn(error.message);
-    }
+  if (!mongodbUrl) {
+    return;
   }
+
+  // Create client
+  try {
+    client = new MongoClient(mongodbUrl, {
+      connectTimeoutMS: 5000,
+    });
+  } catch (error) {
+    console.error(error.message);
+
+    return { error };
+  }
+
+  // Connect to client
+  try {
+    await client.connect();
+  } catch (error) {
+    console.error(error.message);
+
+    await client.close();
+    return { error };
+  }
+
+  return { client };
 };


### PR DESCRIPTION
Fixes #690.

- `getMongodbClient` now provides either a `client` or `error` value. If `error` is provided (which contains an `Error` object), this is then passed on to application locals so that an error message can be displayed in the user interface (in addition to one being shown in the console)
- Errors are provided when **creating** a new MongoDB client, and when **connecting** to one that has been successfully created:

  ![Screenshot 2024-02-17 at 18 39 15](https://github.com/getindiekit/indiekit/assets/813383/d335541b-1622-4be0-8539-76eb220eedf3)
  ![Screenshot 2024-02-17 at 18 39 51](https://github.com/getindiekit/indiekit/assets/813383/e954ee4c-6dab-482e-bfb9-426471e1c08a)

I have tested this with the following connection strings:

- `https://localhost:27017` (not a MongoDB address)
- `mongodb+srv://localhost:27017` (`mongodb+srv` protocol with a disallowed port)
- `mongodb://foo:bar@localhost` (invalid credentials)

I can’t seem to produce an error however if the database URL can’t be resolved, for example `mongodb://mongo.example:12345`. In this case, the application just hangs.

I’ve also updated the implementation so that the database name is taken from the URL. So for example, given a connection URL of `https://localhost:27017/indiekit`, the database name would be `indiekit`. This then also addresses #681, for which the suggested help content on the correct database URL can be merged.

@jackdbd: Thank-you so much for your brilliant and detailed issue on this. Let me know if this PR would help prevent the issues you ran into. However, I’m not sure there’s a need to show errors for nonexistent databases, as I believe MongoDB create one if not found, though I may be wrong.