### PR TITLE
Don’t decode date parameter values in Micropub form-encoded query strings

### DIFF
--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -30,12 +30,8 @@ export const formEncodedToJf2 = async (body, requestReferences) => {
         continue;
       }
 
-      // Decode string values
-      const isStringValue = typeof body[key] === "string";
-      const value = isStringValue ? decodeQueryParameter(body[key]) : body[key];
-
-      // Adds values to JF2 object
-      jf2[key] = value;
+      // Add decoded string value to JF2 object
+      jf2[key] = decodeQueryParameter(body[key]);
     }
   }
 

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -1,17 +1,26 @@
-import { getTimeZoneDesignator, supplant } from "@indiekit/util";
+import { getTimeZoneDesignator, isDate, supplant } from "@indiekit/util";
 import { format } from "date-fns-tz";
 import newbase60 from "newbase60";
 import { postTypeCount } from "./post-type-count.js";
 
 /**
  * Decode form-encoded query parameter
- * @param {string} string - String to decode
- * @returns {string} Decoded string
- * @example decodeQueryParameter('foo+bar') => 'foo bar'
+ * @param {*} value - Parameter value to decode
+ * @returns {*} Decoded string, else original parameter value
+ * @example decodeQueryParameter(['foo', 'bar']) => ['foo', 'bar']
+ * @example decodeQueryParameter('2024-02-14T13:24:00+0100') => '2024-02-14T13:24:00+0100'
  * @example decodeQueryParameter('https%3A%2F%2Ffoo.bar') => 'https://foo.bar'
+ * @example decodeQueryParameter('foo+bar') => 'foo bar'
  */
-export const decodeQueryParameter = (string) =>
-  decodeURIComponent(string.replaceAll("+", " "));
+export const decodeQueryParameter = (value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  return isDate(value)
+    ? decodeURIComponent(value)
+    : decodeURIComponent(value.replaceAll("+", " "));
+};
 
 /**
  * Excerpt the first n words from a string

--- a/packages/endpoint-micropub/test/unit/utils.js
+++ b/packages/endpoint-micropub/test/unit/utils.js
@@ -16,9 +16,16 @@ describe("endpoint-media/lib/utils", () => {
   });
 
   it("Decodes form-encoded query parameter", () => {
-    const result = decodeQueryParameter("https%3A%2F%2Ffoo.bar");
-
-    assert.equal(result, "https://foo.bar");
+    assert.deepEqual(decodeQueryParameter(["foo", "bar"]), ["foo", "bar"]);
+    assert.equal(
+      decodeQueryParameter("2024-02-14T13%3A24%3A00%2B0100"),
+      "2024-02-14T13:24:00+0100",
+    );
+    assert.equal(
+      decodeQueryParameter("https%3A%2F%2Ffoo.bar"),
+      "https://foo.bar",
+    );
+    assert.equal(decodeQueryParameter("foo+bar"), "foo bar");
   });
 
   it("Excerpts the first n words from a string", () => {

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -5,6 +5,7 @@ export {
   getDate,
   getTimeZoneDesignator,
   getTimeZoneOffset,
+  isDate,
 } from "./lib/date.js";
 export { sanitise } from "./lib/object.js";
 export { ISO_6709_RE } from "./lib/regex.js";

--- a/packages/util/lib/date.js
+++ b/packages/util/lib/date.js
@@ -126,3 +126,18 @@ export const getTimeZoneOffset = (timeZone, date) => {
   const offset = minutes === 0 ? 0 : minutes * -1;
   return offset;
 };
+
+/**
+ * Check if a string can be parsed as a date
+ * @param {string} string - String
+ * @returns {boolean} String is a date
+ */
+export const isDate = (string) => {
+  try {
+    const date = new Date(string);
+    date.toISOString();
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/packages/util/test/unit/date.js
+++ b/packages/util/test/unit/date.js
@@ -7,6 +7,7 @@ import {
   getDate,
   getTimeZoneDesignator,
   getTimeZoneOffset,
+  isDate,
 } from "../../lib/date.js";
 
 const { isValid, parseISO } = dateFns;
@@ -203,5 +204,11 @@ describe("util/lib/date", () => {
     assert.equal(getTimeZoneOffset("Asia/Taipei", date), -480);
     assert.equal(getTimeZoneOffset("America/Panama", date), 300);
     assert.equal(getTimeZoneOffset("UTC", date), 0);
+  });
+
+  it("Check if a string can be parsed as a date", () => {
+    assert.equal(isDate("2024-02-14T13:24:00+0100"), true);
+    assert.equal(isDate("Wed Feb 14 2024 13:24:00 GMT+0100"), true);
+    assert.equal(isDate("valentines+day"), false);
   });
 });


### PR DESCRIPTION
Form-encoded query strings are passed to the `decodeQueryParameter` method, where the URL is decoded and `+`s get replaced with spaces. However, given the following query:

```
h=entry&content=Testing+indiepass&post-status=published&category%5B%5D=Indiepass%2C+testing&published=2024-02-14T13%3A24%3A00%2B0100&post-status=published`
```

While `Testing+indiepass` is correctly converted to `Testing indiepass`, `2024-02-14T13%3A24%3A00%2B0100` is converted to `2024-02-14T13:24:00 0100` – the `+` gets replaced with a space. However, in date strings, `+` is used for time zone offsets, and so removing it causes parsing and conversion issues further along the pipeline.

This PR adds a new `isDate` utility method, that checks if a value can be converted to a `Date` and successful be parsed `toISOString()`. This check is then used in the Micropub endpoint when parsing form-encoded strings; if a string can be parsed as a date, we don’t replace the `+`.

Fixes #691.