### PR TITLE
Character count component, show character and word count for content field

### DIFF
--- a/helpers/frontend/views/frontend-form.njk
+++ b/helpers/frontend/views/frontend-form.njk
@@ -75,6 +75,13 @@
   }
 }) }}
 
+{{ characterCount({
+  errorMessage: { text: "Character count input error" } if errors,
+  name: "character-count",
+  label: "Character count",
+  hint: "Character count hint text"
+}) }}
+
 {{ geoInput({
   errorMessage: { text: "Geo input error" } if errors,
   name: "geo-input",

--- a/packages/endpoint-posts/includes/post-fields/content.njk
+++ b/packages/endpoint-posts/includes/post-fields/content.njk
@@ -1,4 +1,4 @@
-{{ textarea({
+{{ characterCount({
   name: "content",
   value: properties.content.text or fieldData("content").value,
   label: __("posts.form.content.label"),

--- a/packages/frontend/components/character-count/index.js
+++ b/packages/frontend/components/character-count/index.js
@@ -1,0 +1,185 @@
+/**
+ * Based on the Character count component from the GOV.UK Design System.
+ * Provides a visible, real-time character and word count, and visually
+ * hidden counter that announces updates to screen readers periodically.
+ *
+ * This component provides a character and word count, and doesn’t inform or
+ * enforce any arbitrary content limits.
+ * @see {@link https://design-system.service.gov.uk/components/character-count}
+ * @see {@link https://dav-idc.com/making-a-character-count-component-more-accessible}
+ */
+export const CharacterCountComponent = class extends HTMLElement {
+  constructor() {
+    super();
+
+    this.$textarea = this.querySelector("textarea");
+    this.$textareaDescription = this.querySelector(
+      `#${this.$textarea.id}-info`,
+    );
+    this.lastInputTimestamp = undefined;
+    this.lastInputValue = "";
+    this.valueChecker = undefined;
+
+    this.i18nChar = this.getAttribute("i18n-char") || `%s character`;
+    this.i18nChars = this.getAttribute("i18n-chars") || `%s characters`;
+    this.i18nWord = this.getAttribute("i18n-word") || `%s word`;
+    this.i18nWords = this.getAttribute("i18n-words") || `%s words`;
+
+    this.$screenReaderCountMessage = document.createElement("p");
+    this.$screenReaderCountMessage.className = "-!-visually-hidden";
+    this.$screenReaderCountMessage.setAttribute("aria-live", "polite");
+    this.$textareaDescription.insertAdjacentElement(
+      "afterend",
+      this.$screenReaderCountMessage,
+    );
+
+    this.$visibleCountMessage = document.createElement("p");
+    this.$visibleCountMessage.className = this.$textareaDescription.className;
+    this.$visibleCountMessage.setAttribute("aria-hidden", "true");
+    this.$textareaDescription.insertAdjacentElement(
+      "afterend",
+      this.$visibleCountMessage,
+    );
+  }
+
+  connectedCallback() {
+    this.$textareaDescription.classList.add("-!-visually-hidden");
+
+    this.$textarea.addEventListener("keyup", this.#handleKeyUp.bind(this));
+    this.$textarea.addEventListener("focus", this.#handleFocus.bind(this));
+    this.$textarea.addEventListener("blur", this.#handleBlur.bind(this));
+    window.addEventListener("pageshow", this.#updateCountMessages.bind(this));
+    this.#updateCountMessages();
+  }
+
+  /**
+   * Update visible character counter and keep track of when the last update
+   * happened for each keypress
+   * @access private
+   */
+  #handleKeyUp() {
+    this.#updateVisibleCountMessage();
+    this.lastInputTimestamp = Date.now();
+  }
+
+  /**
+   * Handle focus event
+   *
+   * Speech recognition software such as Dragon NaturallySpeaking will modify
+   * a field by directly changing its `value`. These changes don’t trigger
+   * events in JavaScript, so we need to poll to handle when and if they occur.
+   *
+   * Once the keyup event hasn’t been detected for at least 1000 ms (1s), check
+   * if textarea value has changed and update count message if it has.
+   *
+   * This is so that update triggered by manual comparison doesn’t conflict
+   * with debounced KeyboardEvent updates.
+   * @access private
+   */
+  #handleFocus() {
+    this.valueChecker = window.setInterval(() => {
+      if (
+        !this.lastInputTimestamp ||
+        Date.now() - 500 >= this.lastInputTimestamp
+      ) {
+        this.#updateIfValueChanged();
+      }
+    }, 1000);
+  }
+
+  /**
+   * Stop checking textarea value once it no longer has focus
+   * @access private
+   */
+  #handleBlur() {
+    if (this.valueChecker) {
+      window.clearInterval(this.valueChecker);
+    }
+  }
+
+  /**
+   * Update count message if textarea value has changed
+   * @access private
+   */
+  #updateIfValueChanged() {
+    if (this.$textarea.value !== this.lastInputValue) {
+      this.lastInputValue = this.$textarea.value;
+      this.#updateCountMessages();
+    }
+  }
+
+  /**
+   * Helper method to update both visible and screen reader-specific counters
+   * simultaneously (e.g. on init)
+   * @access private
+   */
+  #updateCountMessages() {
+    this.#updateVisibleCountMessage();
+    this.#updateScreenReaderCountMessage();
+  }
+
+  /**
+   * Update visible count message
+   * @access private
+   */
+  #updateVisibleCountMessage() {
+    this.$visibleCountMessage.textContent = this.#countMessage;
+  }
+
+  /**
+   * Update screen reader count message
+   * @access private
+   */
+  #updateScreenReaderCountMessage() {
+    this.$screenReaderCountMessage.textContent = this.#countMessage;
+  }
+
+  /**
+   * Count number of characters (or words) in given string
+   * @access private
+   * @param {string} string - The text to count the characters of
+   * @param {boolean} [countWords] - Count words instead of characters
+   * @returns {number} the number of characters (or words) in the text
+   */
+  #count(string, countWords = false) {
+    if (countWords) {
+      // Matches consecutive non-whitespace characters
+      const tokens = string.match(/\S+/g) ?? [];
+      return tokens.length;
+    }
+
+    return string.length;
+  }
+
+  /**
+   * Get count message
+   * @access private
+   * @returns {string} Status message
+   */
+  get #countMessage() {
+    return this.#formatCountMessage(this.$textarea.value);
+  }
+
+  /**
+   * Format and localise count shown to users
+   * @access private
+   * @param {string} string - Number of characters remaining
+   * @returns {string} Status message
+   */
+  #formatCountMessage(string) {
+    const characters = this.#count(string);
+    const words = this.#count(string, true);
+
+    let characterCount = this.i18nChars.replace("%s", String(characters));
+    if (characters === 1) {
+      characterCount = this.i18nChar.replace("%s", String(characters));
+    }
+
+    let wordCount = this.i18nWords.replace("%s", String(words));
+    if (words === 1) {
+      wordCount = this.i18nWord.replace("%s", String(words));
+    }
+
+    return `${characterCount}, ${wordCount}`;
+  }
+};

--- a/packages/frontend/components/character-count/macro.njk
+++ b/packages/frontend/components/character-count/macro.njk
@@ -1,0 +1,3 @@
+{% macro characterCount(opts) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/frontend/components/character-count/styles.css
+++ b/packages/frontend/components/character-count/styles.css
@@ -1,0 +1,3 @@
+character-count {
+  display: block;
+}

--- a/packages/frontend/components/character-count/template.njk
+++ b/packages/frontend/components/character-count/template.njk
@@ -1,0 +1,14 @@
+{% from "../hint/macro.njk" import hint with context %}
+{% from "../textarea/macro.njk" import textarea with context %}
+{%- set id = opts.id or opts.name | slugify({ decamelize: true }) -%}
+<character-count
+  i18n-char="{{ __("characterCount.char.one") }}"
+  i18n-chars="{{ __("characterCount.char.other") }}"
+  i18n-word="{{ __("characterCount.word.one") }}"
+  i18n-words="{{ __("characterCount.word.other") }}">
+  {{- textarea(opts) }}
+  {{ hint({
+    text: "&nbsp;",
+    id: id + "-info"
+  }) | trim | indent(2) }}
+</character-count>

--- a/packages/frontend/layouts/default.njk
+++ b/packages/frontend/layouts/default.njk
@@ -5,6 +5,7 @@
 {% from "button/macro.njk" import button with context %}
 {% from "card/macro.njk" import card with context %}
 {% from "card-grid/macro.njk" import cardGrid with context %}
+{% from "character-count/macro.njk" import characterCount with context %}
 {% from "checkboxes/macro.njk" import checkboxes with context %}
 {% from "details/macro.njk" import details with context %}
 {% from "error-summary/macro.njk" import errorSummary with context %}

--- a/packages/frontend/locales/de.json
+++ b/packages/frontend/locales/de.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Zurück"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s Charakter",
+      "other": "%s Charaktere"
+    },
+    "word": {
+      "one": "%s Wort",
+      "other": "%s Worte"
+    }
+  },
   "error": "Fehler",
   "errorSummary": {
     "title": "Es gibt ein Problem"

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Back"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s character",
+      "other": "%s characters"
+    },
+    "word": {
+      "one": "%s word",
+      "other": "%s words"
+    }
+  },
   "error": "Error",
   "errorSummary": {
     "title": "There is a problem"

--- a/packages/frontend/locales/es-419.json
+++ b/packages/frontend/locales/es-419.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Atrás"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s carácter",
+      "other": "%s caracteres"
+    },
+    "word": {
+      "one": "%s palabra",
+      "other": "%s palabras"
+    }
+  },
   "error": "Error",
   "errorSummary": {
     "title": "Hay un problema"

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Atrás"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s carácter",
+      "other": "%s caracteres"
+    },
+    "word": {
+      "one": "%s palabra",
+      "other": "%s palabras"
+    }
+  },
   "error": "Error",
   "errorSummary": {
     "title": "Hay un problema"

--- a/packages/frontend/locales/fr.json
+++ b/packages/frontend/locales/fr.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Retour"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s caractère",
+      "other": "%s caractères"
+    },
+    "word": {
+      "one": "%s mot",
+      "other": "%s mots"
+    }
+  },
   "error": "Erreur",
   "errorSummary": {
     "title": "Il y a un problème"

--- a/packages/frontend/locales/id.json
+++ b/packages/frontend/locales/id.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Kembali"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s huruf",
+      "other": "%s huruf"
+    },
+    "word": {
+      "one": "%s kata",
+      "other": "%s kata"
+    }
+  },
   "error": "Kesalahan",
   "errorSummary": {
     "title": "Ada masalah"

--- a/packages/frontend/locales/nl.json
+++ b/packages/frontend/locales/nl.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Terug"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s karakter",
+      "other": "%s karakters"
+    },
+    "word": {
+      "one": "%s woord",
+      "other": "%s woorden"
+    }
+  },
   "error": "Fout",
   "errorSummary": {
     "title": "Er is een Probleem"

--- a/packages/frontend/locales/pl.json
+++ b/packages/frontend/locales/pl.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Wstecz"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s znak",
+      "other": "%s znaki"
+    },
+    "word": {
+      "one": "%s słowo",
+      "other": "%s słowa"
+    }
+  },
   "error": "Błąd",
   "errorSummary": {
     "title": "Wystąpił problem"

--- a/packages/frontend/locales/pt.json
+++ b/packages/frontend/locales/pt.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Voltar"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s caracter",
+      "other": "%s caracteres"
+    },
+    "word": {
+      "one": "%s palavra",
+      "other": "%s palavras"
+    }
+  },
   "error": "Erro",
   "errorSummary": {
     "title": "Há um problema"

--- a/packages/frontend/locales/sr.json
+++ b/packages/frontend/locales/sr.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "Nazad"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s karaktera",
+      "other": "%s znakova"
+    },
+    "word": {
+      "one": "%s reč",
+      "other": "%s reči"
+    }
+  },
   "error": "Greška",
   "errorSummary": {
     "title": "Postoji problem"

--- a/packages/frontend/locales/zh-Hans-CN.json
+++ b/packages/frontend/locales/zh-Hans-CN.json
@@ -6,6 +6,16 @@
   "backLink": {
     "text": "返回"
   },
+  "characterCount": {
+    "char": {
+      "one": "%s字符",
+      "other": "%s字符"
+    },
+    "word": {
+      "one": "%s字",
+      "other": "%s字"
+    }
+  },
   "error": "错误",
   "errorSummary": {
     "title": "有一个问题"

--- a/packages/frontend/scripts/app.js
+++ b/packages/frontend/scripts/app.js
@@ -1,4 +1,5 @@
 import { AddAnotherComponent } from "../components/add-another/index.js";
+import { CharacterCountComponent } from "../components/character-count/index.js";
 import { CheckboxesFieldComponent } from "../components/checkboxes/index.js";
 import { ErrorSummaryComponent } from "../components/error-summary/index.js";
 import { EventDurationComponent } from "../components/event-duration/index.js";
@@ -10,6 +11,7 @@ import { TagInputFieldComponent } from "../components/tag-input/index.js";
 import { TextareaFieldComponent } from "../components/textarea/index.js";
 
 customElements.define("add-another", AddAnotherComponent);
+customElements.define("character-count", CharacterCountComponent);
 customElements.define("checkboxes-field", CheckboxesFieldComponent);
 customElements.define("error-summary", ErrorSummaryComponent);
 customElements.define("event-duration", EventDurationComponent);

--- a/packages/frontend/styles/app.css
+++ b/packages/frontend/styles/app.css
@@ -24,6 +24,7 @@
 @import url("../components/button/styles.css");
 @import url("../components/card/styles.css");
 @import url("../components/card-grid/styles.css");
+@import url("../components/character-count/styles.css");
 @import url("../components/checkboxes/styles.css");
 @import url("../components/details/styles.css");
 @import url("../components/error-message/styles.css");


### PR DESCRIPTION
Based on the [Character count component from the GOV.UK Design System](https://design-system.service.gov.uk/components/character-count/#options-character-count-example--count-message).

The `<character-count>` component provides a visible, real-time character and word count for a `<textarea>` as well as a visually hidden counter that announces updates to screen readers periodically. [Some more background surrounding this approach can be found in this blog post by David Cox](https://dav-idc.com/making-a-character-count-component-more-accessible/).

Unlike the GOV.UK example, this component provides only a character and word count, and doesn’t inform or enforce any limits. Different social networks will have different limits, so a character count only needs to be informative. This component is also currently shown when writing longer article posts, and whilst here there are no limits, it's nice to know how many words you’ve written.

The counter is translated, of course.

<img width="745" alt="Screenshot of the counter component." src="https://github.com/getindiekit/indiekit/assets/813383/363e9d7b-d327-493a-8f73-a3ca44a6fcb9">

<img width="745" alt="Screenshot of the counter component with a German translation." src="https://github.com/getindiekit/indiekit/assets/813383/952d3fe7-be10-4c00-90db-2fed3e5ed2ec">
