### PR TITLE
Remove need for plugins to supply `import.meta`

### DIFF
--- a/docs/plugins/api/.plugin-constructor.md
+++ b/docs/plugins/api/.plugin-constructor.md
@@ -1,8 +1,5 @@
 | Property | Type | Description |
 | :------- | :--- | :---------- |
 | `id` | `String` | Kebab-cased plug-in ID. _Required_. |
-| `meta` | [`import.meta`][] | _Required_. |
 | `name` | `String` | Human readable plug-in name. _Required_. |
 | `options` | `Object` | Plug-in options. _Optional_. |
-
-[`import.meta`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta

--- a/docs/plugins/api/add-endpoint.md
+++ b/docs/plugins/api/add-endpoint.md
@@ -127,7 +127,6 @@ const router = express.Router();
 export default class ExampleEndpoint {
   constructor() {
     this.id = "example-endpoint";
-    this.meta = import.meta;
     this.name = "Example endpoint";
     this.mountPath = "/example";
   }

--- a/docs/plugins/api/add-preset.md
+++ b/docs/plugins/api/add-preset.md
@@ -124,7 +124,6 @@ Text: I ate a cheese sandwich, which was nice.
 export default class ExamplePreset {
   constructor() {
     this.id = "example-preset";
-    this.meta = import.meta;
     this.name = "Example preset";
   }
 

--- a/docs/plugins/api/add-store.md
+++ b/docs/plugins/api/add-store.md
@@ -134,7 +134,6 @@ import exampleClient from 'example-client';
 export default class ExampleStore {
   constructor() {
     this.id = "example-store";
-    this.meta = import.meta;
     this.name = "Example store";
   }
 

--- a/docs/plugins/api/add-syndicator.md
+++ b/docs/plugins/api/add-syndicator.md
@@ -90,7 +90,6 @@ import exampleClient from 'example-client';
 export default class ExampleStore {
   constructor(options) {
     this.id = "example-syndicator";
-    this.meta = import.meta;
     this.name = "Example syndicator";
     this.options = options;
   }

--- a/docs/plugins/api/index.md
+++ b/docs/plugins/api/index.md
@@ -17,7 +17,6 @@ A plug-in is a `Class` with an `init()` function that is used to register endpoi
 export default class PluginName {
   constructor() {
     this.id = "plugin-name";
-    this.meta = import.meta;
     this.name = "Plugin name";
   }
 

--- a/helpers/frontend/index.js
+++ b/helpers/frontend/index.js
@@ -10,7 +10,6 @@ const router = express.Router({ caseSensitive: true, mergeParams: true });
 export default class FrontendEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-frontend";
-    this.meta = import.meta;
     this.name = "Frontend endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/helpers/store/index.js
+++ b/helpers/store/index.js
@@ -11,7 +11,6 @@ const defaults = {
 export default class TestStore {
   constructor(options = {}) {
     this.id = "test-store";
-    this.meta = import.meta;
     this.name = "Test store";
     this.options = { ...defaults, ...options };
   }

--- a/packages/endpoint-auth/index.js
+++ b/packages/endpoint-auth/index.js
@@ -23,7 +23,6 @@ const router = express.Router({ caseSensitive: true, mergeParams: true });
 export default class AuthorizationEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-auth";
-    this.meta = import.meta;
     this.name = "IndieAuth endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/packages/endpoint-files/index.js
+++ b/packages/endpoint-files/index.js
@@ -12,7 +12,6 @@ const router = express.Router(); // eslint-disable-line new-cap
 export default class FilesEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-files";
-    this.meta = import.meta;
     this.name = "File management endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/packages/endpoint-image/index.js
+++ b/packages/endpoint-image/index.js
@@ -9,7 +9,6 @@ const router = express.Router(); // eslint-disable-line new-cap
 export default class ImageEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-image";
-    this.meta = import.meta;
     this.name = "Image resizing endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/packages/endpoint-json-feed/index.js
+++ b/packages/endpoint-json-feed/index.js
@@ -11,7 +11,6 @@ const router = express.Router(); // eslint-disable-line new-cap
 export default class jsonFeedEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-json-feed";
-    this.meta = import.meta;
     this.name = "JSON Feed";
     this.options = { ...defaults, ...options };
     this.feedName = this.options.feedName;

--- a/packages/endpoint-media/index.js
+++ b/packages/endpoint-media/index.js
@@ -8,7 +8,6 @@ const router = express.Router(); // eslint-disable-line new-cap
 export default class MediaEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-media";
-    this.meta = import.meta;
     this.name = "Micropub media endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/packages/endpoint-micropub/index.js
+++ b/packages/endpoint-micropub/index.js
@@ -8,7 +8,6 @@ const router = express.Router(); // eslint-disable-line new-cap
 export default class MicropubEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-micropub";
-    this.meta = import.meta;
     this.name = "Micropub endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -13,7 +13,6 @@ const router = express.Router(); // eslint-disable-line new-cap
 export default class PostsEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-posts";
-    this.meta = import.meta;
     this.name = "Post management endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/packages/endpoint-share/index.js
+++ b/packages/endpoint-share/index.js
@@ -8,7 +8,6 @@ const router = express.Router(); // eslint-disable-line new-cap
 export default class ShareEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-share";
-    this.meta = import.meta;
     this.name = "Share endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/packages/endpoint-syndicate/index.js
+++ b/packages/endpoint-syndicate/index.js
@@ -7,7 +7,6 @@ const router = express.Router(); // eslint-disable-line new-cap
 export default class SyndicateEndpoint {
   constructor(options = {}) {
     this.id = "endpoint-syndicate";
-    this.meta = import.meta;
     this.name = "Syndication endpoint";
     this.options = { ...defaults, ...options };
     this.mountPath = this.options.mountPath;

--- a/packages/indiekit/lib/controllers/plugin.js
+++ b/packages/indiekit/lib/controllers/plugin.js
@@ -5,7 +5,7 @@ export const list = (request, response) => {
   const { application } = response.app.locals;
 
   const plugins = application.installedPlugins.map((plugin) => {
-    const _package = plugin.meta ? getPackageData(plugin.meta.url) : {};
+    const _package = getPackageData(plugin.filePath);
     plugin.photo = {
       srcOnError: "/assets/plug-in.svg",
       attributes: { height: 96, width: 96 },
@@ -35,7 +35,7 @@ export const view = (request, response) => {
   const plugin = application.installedPlugins.find(
     (plugin) => plugin.id === pluginId,
   );
-  plugin.package = getPackageData(plugin.meta.url);
+  plugin.package = getPackageData(plugin.filePath);
 
   response.render("plugins/view", {
     parent: {

--- a/packages/indiekit/lib/installed-plugins.js
+++ b/packages/indiekit/lib/installed-plugins.js
@@ -1,3 +1,7 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+const require = createRequire(import.meta.url);
+
 /**
  * Add plug-ins to application configuration
  * @param {object} Indiekit - Indiekit instance
@@ -9,6 +13,9 @@ export const getInstalledPlugins = async (Indiekit) => {
   for await (const pluginName of Indiekit.config.plugins) {
     const { default: IndiekitPlugin } = await import(pluginName);
     const plugin = new IndiekitPlugin(Indiekit.config[pluginName]);
+
+    // Add plug-in file path
+    plugin.filePath = path.dirname(require.resolve(pluginName));
 
     // Register plug-in functions
     if (plugin.init) {

--- a/packages/indiekit/lib/locale-catalog.js
+++ b/packages/indiekit/lib/locale-catalog.js
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
+import path from "node:path";
 import deepmerge from "deepmerge";
 
 const require = createRequire(import.meta.url);
@@ -24,10 +24,9 @@ export const getLocaleCatalog = (application) => {
 
     // Plug-in translations
     for (const plugin of application.installedPlugins) {
-      const translationUrl = new URL(`locales/${locale}.json`, plugin.meta.url);
-      const translationPath = fileURLToPath(translationUrl);
+      const localePath = path.join(plugin.filePath, `locales/${locale}.json`);
       try {
-        translations.push(require(translationPath));
+        translations.push(require(localePath));
       } catch {} // eslint-disable-line no-empty
     }
 

--- a/packages/indiekit/lib/routes.js
+++ b/packages/indiekit/lib/routes.js
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "node:url";
+import path from "node:path";
 import express from "express";
 import { assetsPath } from "@indiekit/frontend";
 import rateLimit from "express-rate-limit";
@@ -44,8 +44,8 @@ export const routes = (indiekitConfig) => {
 
   // Plug-in assets
   for (const plugin of application.installedPlugins) {
-    if (plugin.meta?.url) {
-      const assetsPath = fileURLToPath(new URL("assets", plugin.meta.url));
+    if (plugin.filePath) {
+      const assetsPath = path.join(plugin.filePath, "assets");
       router.use(`/assets/${plugin.id}`, express.static(assetsPath));
     }
   }

--- a/packages/indiekit/lib/utils.js
+++ b/packages/indiekit/lib/utils.js
@@ -2,7 +2,6 @@ import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 import { Buffer } from "node:buffer";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 const algorithm = "aes-256-ctr";
@@ -52,14 +51,13 @@ export const getUrl = (request) => {
 
 /**
  * Get package JSON object
- * @param {URL} fileUrl - File URL
+ * @param {string} filePath - File path
  * @returns {object} package.json
  */
-export const getPackageData = (fileUrl) => {
+export const getPackageData = (filePath) => {
+  console.log(filePath);
   try {
-    const filePath = fileURLToPath(fileUrl);
-    const packageDirectory = path.dirname(filePath);
-    return require(path.join(packageDirectory, "package.json"));
+    return require(path.join(filePath, "package.json"));
   } catch {
     return {};
   }

--- a/packages/indiekit/lib/views.js
+++ b/packages/indiekit/lib/views.js
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
@@ -13,10 +14,10 @@ export const views = (indiekitConfig) => {
 
   // Plug-in views
   for (const plugin of application.installedPlugins) {
-    if (plugin.meta?.url) {
+    if (plugin.filePath) {
       views.push(
-        fileURLToPath(new URL("includes", plugin.meta.url)),
-        fileURLToPath(new URL("views", plugin.meta.url)),
+        path.join(plugin.filePath, "includes"),
+        path.join(plugin.filePath, "views"),
       );
     }
   }

--- a/packages/indiekit/test/unit/utils.js
+++ b/packages/indiekit/test/unit/utils.js
@@ -1,8 +1,7 @@
 import { strict as assert } from "node:assert";
 import { randomBytes } from "node:crypto";
-import path from "node:path";
 import { describe, it } from "node:test";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { decrypt, encrypt, getPackageData } from "../../lib/utils.js";
 
 const iv = randomBytes(16);
@@ -15,14 +14,18 @@ describe("indiekit/lib/utils", () => {
   });
 
   it("Gets package JSON object", () => {
-    const url = pathToFileURL(path.resolve("packages/preset-hugo/index.js"));
-    const result = getPackageData(url);
+    const filePath = fileURLToPath(
+      new URL("../../../../packages/preset-hugo", import.meta.url),
+    );
+    const result = getPackageData(filePath);
     assert.equal(result.description, "Hugo publication preset for Indiekit");
   });
 
   it("Returns empty object getting unknown package JSON", () => {
-    const url = pathToFileURL(path.resolve("packages/foobar/index.js"));
-    const result = getPackageData(url);
+    const filePath = fileURLToPath(
+      new URL("../../../../packages/foobar", import.meta.url),
+    );
+    const result = getPackageData(filePath);
     assert.deepEqual(result, {});
   });
 });

--- a/packages/preset-hugo/index.js
+++ b/packages/preset-hugo/index.js
@@ -8,7 +8,6 @@ const defaults = {
 export default class HugoPreset {
   constructor(options = {}) {
     this.id = "hugo";
-    this.meta = import.meta;
     this.name = "Hugo preset";
     this.options = { ...defaults, ...options };
   }

--- a/packages/preset-jekyll/index.js
+++ b/packages/preset-jekyll/index.js
@@ -4,7 +4,6 @@ import { getPostTypes } from "./lib/post-types.js";
 export default class JekyllPreset {
   constructor() {
     this.id = "jekyll";
-    this.meta = import.meta;
     this.name = "Jekyll preset";
   }
 

--- a/packages/store-bitbucket/index.js
+++ b/packages/store-bitbucket/index.js
@@ -21,7 +21,6 @@ export default class BitbucketStore {
    */
   constructor(options = {}) {
     this.id = "bitbucket";
-    this.meta = import.meta;
     this.name = "Bitbucket store";
     this.options = { ...defaults, ...options };
   }

--- a/packages/store-file-system/index.js
+++ b/packages/store-file-system/index.js
@@ -15,7 +15,6 @@ const defaults = {
 export default class FileSystemStore {
   constructor(options = {}) {
     this.id = "file-system";
-    this.meta = import.meta;
     this.name = "File system store";
     this.options = { ...defaults, ...options };
   }

--- a/packages/store-ftp/index.js
+++ b/packages/store-ftp/index.js
@@ -22,7 +22,6 @@ export default class FtpStore {
    */
   constructor(options = {}) {
     this.id = "ftp";
-    this.meta = import.meta;
     this.name = "FTP store";
     this.options = { ...defaults, ...options };
   }

--- a/packages/store-gitea/index.js
+++ b/packages/store-gitea/index.js
@@ -19,7 +19,6 @@ export default class GiteaStore {
    */
   constructor(options = {}) {
     this.id = "gitea";
-    this.meta = import.meta;
     this.name = "Gitea store";
     this.options = { ...defaults, ...options };
   }

--- a/packages/store-github/index.js
+++ b/packages/store-github/index.js
@@ -18,7 +18,6 @@ export default class GithubStore {
    */
   constructor(options = {}) {
     this.id = "github";
-    this.meta = import.meta;
     this.name = "GitHub store";
     this.options = { ...defaults, ...options };
   }

--- a/packages/store-gitlab/index.js
+++ b/packages/store-gitlab/index.js
@@ -25,7 +25,6 @@ export default class GitlabStore {
    */
   constructor(options = {}) {
     this.id = "gitlab";
-    this.meta = import.meta;
     this.name = "GitLab store";
     this.options = { ...defaults, ...options };
     this.projectId = options.projectId || `${options.user}/${options.repo}`;

--- a/packages/syndicator-internet-archive/index.js
+++ b/packages/syndicator-internet-archive/index.js
@@ -19,7 +19,6 @@ export default class InternetArchiveSyndicator {
    */
   constructor(options = {}) {
     this.id = "internet-archive";
-    this.meta = import.meta;
     this.name = "Internet Archive syndicator";
     this.options = { ...defaults, ...options };
   }

--- a/packages/syndicator-mastodon/index.js
+++ b/packages/syndicator-mastodon/index.js
@@ -22,7 +22,6 @@ export default class MastodonSyndicator {
    */
   constructor(options = {}) {
     this.id = "mastodon";
-    this.meta = import.meta;
     this.name = "Mastodon syndicator";
     this.options = { ...defaults, ...options };
   }


### PR DESCRIPTION
Currently, we document the plugin API as needing plug-ins to provide a `meta` value which provides `import.meta`. For example:

```js
export default class ExampleEndpoint {
  constructor() {
    this.id = "example-endpoint";
    this.meta = import.meta;
    this.name = "Example endpoint";
    this.mountPath = "/example";
  }

  ...
}
```

This shouldn’t be the responsibility of plugin authors, it should be up to the consuming application to derive this information, which we can using Node’s [`require.resolve`](https://nodejs.org/api/modules.html#requireresolverequest-options) method.