### PR TITLE
Update plug-in API docs to follow MDN format

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,4 +1,5 @@
 import markdownAnchor from "markdown-it-anchor";
+import markdownDefList from "markdown-it-deflist";
 import markdownFootnote from "markdown-it-footnote";
 import markdownTaskLists from "markdown-it-task-lists";
 import _package from "../../packages/indiekit/package.json" assert { type: "json" };
@@ -108,6 +109,7 @@ export default {
       }),
     },
     config: (md) => {
+      md.use(markdownDefList);
       md.use(markdownFootnote);
       md.use(markdownTaskLists);
     },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -37,8 +37,36 @@
   line-height: 1.6;
 }
 
-.vp-doc a {
-  font-weight: normal;
+/* Headings */
+.vp-doc h3 {
+  margin-top: 48px;
+}
+
+.vp-doc h3 code {
+  background: none;
+  font-size: inherit;
+  padding: 0;
+}
+
+.vp-doc h4 {
+  font-size: inherit;
+  margin-top: 24px;
+}
+
+/* Definition lists */
+.vp-doc dl dl {
+  border-left: 1px solid var(--vp-c-divider);
+  padding-left: 16px;
+}
+
+.vp-doc dd {
+  margin-left: 16px;
+  margin-top: 8px;
+}
+
+.vp-doc dt {
+  font-weight: 500;
+  margin-top: 16px;
 }
 
 /* Markdown footnotes */

--- a/docs/plugins/api/.plugin-constructor.md
+++ b/docs/plugins/api/.plugin-constructor.md
@@ -1,4 +1,0 @@
-| Property | Type | Description |
-| :------- | :--- | :---------- |
-| `name` | `String` | Human readable plug-in name. _Required_. |
-| `options` | `Object` | Plug-in options. _Optional_. |

--- a/docs/plugins/api/add-store.md
+++ b/docs/plugins/api/add-store.md
@@ -1,129 +1,108 @@
+---
+outline: deep
+---
+
 # `Indiekit.addStore`
 
-A [content store](../../concepts.md#content-store) plug-in interfaces with CRUD (create, read, update, delete) methods provided by a file system, server, database or API.
+A [content store](../../concepts.md#content-store) interfaces with CRUD (create, read, update, delete) methods provided by a file system, version control system, server, database or API.
 
-[[toc]]
+## Syntax
+
+```js
+new Indiekit.addStore(options);
+```
 
 ## Constructor
 
-<!--@include: .plugin-constructor.md-->
+`options`
+: An object used to customise the behaviour of the plug-in.
 
 ## Properties
 
-| Property | Type | Description |
-| :------- | :--- | :---------- |
-| `info` | `Object` | Information about the content store. _Required_. |
+`info` <Badge type="info" text="Required" />
+: An object representing information about the content store. The `info` property should return the following values:
 
-### `info`
+  `name` <Badge type="info" text="Required" />
+  : The name of the content store the plug-in supports.
 
-Indiekit’s web interface expects a content store plugin to provide some information about the content store it supports. This is provided by the `info` property:
-
-```js
-get info() {
-  return {
-    name: "Example content store",
-    uid: "https://store.example"
-  };
-}
-```
-
-The `info` property returns the following values:
-
-| Property | Type | Description |
-| :------- | :--- | :---------- |
-| `name` | `String` | The name of the content store the preset supports. _Required_. |
-| `uid` | `String` | URL or path to content store. _Required_. |
+  `uid` <Badge type="info" text="Required" />
+  : URL or path to content store.
 
 ## Methods
 
-| Method | Type | Description |
-| :----- | :--- | :---------- |
-| `createFile()` | `AsyncFunction` | Create a file on the content store. |
-| `readFile()` | `AsyncFunction` | Read a file from the content store. |
-| `updateFile()` | `AsyncFunction` | Update a file on the content store. |
-| `deleteFile()` | `AsyncFunction` | Delete a file on the content store. |
-
 ### `createFile()`
 
-| Parameters | Type | Description |
-| :--------- | :--- | :---------- |
-| `filePath` | `String` | Path to file. _Required_. |
-| `content` | `String` | File content. _Required_. |
-| `options.message` | `String` | Commit message. _Optional_. |
+An async function that creates a file on the content store.
 
-Returns a `String` containing the file’s URL if successful, else returns [`IndiekitError`][]. For example:
+#### Parameters
 
-```js
-async createFile(filePath, content, { message }) {
-  try {
-    await exampleClient.create(filePath, content, message);
-    return true;
-  } catch (error) {
-    throw new IndiekitError(error.message);
-  }
-}
-```
+`filePath` <Badge type="info" text="Required" />
+: A string representing the path to a file.
+
+`content` <Badge type="info" text="Required" />
+: A string representing the file content.
+
+`options.message`
+: A string representing the commit message.
+
+#### Return value
+
+A string containing the file’s URL if successful, else [`IndiekitError`][].
 
 ### `readFile()`
 
-| Parameters | Type | Description |
-| :--------- | :--- | :---------- |
-| `filePath` | `String` | Path to file. _Required_. |
+An async function that reads a file from the content store.
 
-Returns content as a `String` containing the file’s content if successful, else returns [`IndiekitError`][]. For example:
+#### Parameters
 
-```js
-async readFile(filePath) {
-  try {
-    await exampleClient.read(filePath);
-    return true;
-  } catch (error) {
-    throw new IndiekitError(error.message);
-  }
-}
-```
+`filePath` <Badge type="info" text="Required" />
+: A string representing the path to a file.
+
+#### Return value
+
+A string containing the file’s content if successful, else [`IndiekitError`][].
 
 ### `updateFile()`
 
-| Parameters | Type | Description |
-| :--------- | :--- | :---------- |
-| `filePath` | `String` | Path to file. _Required_. |
-| `content` | `String` | File content. _Required_. |
-| `options.message` | `String` | Commit message. _Optional_. |
-| `options.newPath` | `String` | New path to file. _Optional_. |
+An async function that updates a file on the content store.
 
-Returns a `String` containing the file’s updated URL if successful, else returns [`IndiekitError`][]. For example:
+#### Parameters
 
-```js
-async updateFile(filePath, content, { message, newPath }) {
-  try {
-    await exampleClient.update(filePath, content, message, newPath);
-    return true;
-  } catch (error) {
-    throw new IndiekitError(error.message);
-  }
-}
-```
+`filePath` <Badge type="info" text="Required" />
+: A string representing the path to a file.
+
+`content` <Badge type="info" text="Required" />
+: A string representing the updated file content.
+
+`options.message`
+: A string representing the commit message.
+
+`options.newPath`
+: A string representing the new path to file, if changed.
+
+#### Return value
+
+A string containing the file’s updated URL if successful, else [`IndiekitError`][].
 
 ### `deleteFile()`
 
-| Parameters | Type | Description |
-| :--------- | :--- | :---------- |
-| `filePath` | `String` | Path to file. _Required_. |
-| `options.message` | `String` | Commit message. _Optional_. |
+An async function that deletes a file on the content store.
 
-Returns a `Boolean` `true` if successful, else returns [`IndiekitError`][]. For example:
+#### Parameters
 
-```js
-async deleteFile(filePath, { message }) {
-  try {
-    await exampleClient.delete(filePath, message);
-    return true;
-  } catch (error) {
-    throw new IndiekitError(error.message);
-  }
-}
-```
+`filePath` <Badge type="info" text="Required" />
+: A string representing the path to a file.
+
+`options.message`
+: A string representing the commit message.
+
+#### Return value
+
+`true` if successful, else [`IndiekitError`][].
+
+### `init()`
+
+Used to register the plug-in. Accepts an `Indiekit` instance to allow its modification before returning.
 
 ## Example
 
@@ -184,6 +163,21 @@ export default class ExampleStore {
   }
 }
 ```
+
+### Add store information
+
+Indiekit’s web interface expects a content store plugin to provide some information about the content store it supports. This is provided by the `info` property:
+
+```js
+get info() {
+  return {
+    name: "Example content store",
+    uid: "https://store.example"
+  };
+}
+```
+
+## See also
 
 Example content store plug-ins:
 

--- a/docs/plugins/api/add-syndicator.md
+++ b/docs/plugins/api/add-syndicator.md
@@ -1,85 +1,78 @@
+---
+outline: deep
+---
+
 # `Indiekit.addSyndicator`
 
-A [syndicator](../../concepts.md#syndicator) plug-in syndicates content to a third-party service such as a social network via its API.
+A [syndicator](../../concepts.md#syndicator) shares content to a third-party service such as a social network, typically via its API.
 
-[[toc]]
+## Syntax
+
+```js
+new Indiekit.addSyndicator(options);
+```
 
 ## Constructor
 
-<!--@include: .plugin-constructor.md-->
+`options`
+: An object used to customise the behaviour of the plug-in.
 
 ## Properties
 
-| Property | Type | Description |
-| :------- | :--- | :---------- |
-| `info` | `Object`  | Information about the syndicator. |
+`info` <Badge type="info" text="Required" />
+: An object representing information about the third-party service. The `info` property should return the following values:
 
-### `info`
+  `name` <Badge type="info" text="Required" />
+  : A string representing the name of the third-party service the plug-in supports.
 
-Indiekit’s web interface expects a syndicator plug-in to provide some information about the third-party service it supports. In addition, some Micropub clients may also use this information in their publishing interface. This information is provided by the `info` property:
+  `uid` <Badge type="info" text="Required" />
+  : A string representing the URL to third-party service.
 
-```js
-get info() {
-  const { user } = this.options;
+  `checked`
+  : A boolean indicating whether this syndicator should be enabled by default in Micropub clients.
 
-  return {
-    name: `${user} on Example service`,
-    uid: `https://service.example/${user}`,
-    checked: true,
-    service: {
-      name: "Example service",
-      url: "https://service.example/",
-      photo: "/assets/example-syndicator/icon.svg",
-    },
-    user: {
-      name: user,
-      url: `https://service.example/${user}`,
-    },
-  };
-}
-```
+  `service`
+  : An object containing information about the third-party service.
 
-The `info` property returns the following values:
+    `name`
+    : A string representing the name of the third-party service.
 
-| Property | Type | Description |
-| :------- | :--- | :---------- |
-| `name` | `String` | The name of the third-party service the syndicator supports. _Required_. |
-| `uid` | `String` | URL or path to the syndication target. _Required_. |
-| `checked` | `Boolean` | Whether this syndicator should be enabled by default in Micropub clients. _Optional_. |
-| `service.name` | `String` | Name of the third-party service. _Optional_. |
-| `service.url` | `String` | URL of the third-party service. _Optional_. |
-| `service.photo` | `String` | Icon, logo or photo used to identify the third-party service in Micropub clients. _Optional_. |
-| `user.name` | `String` | Name of the user on the third-party service. _Optional_. |
-| `user.url` | `String` | URL for the user on the third-party service. _Optional_. |
+    `url`
+    : A string representing the URL of the third-party service.
+
+    `photo`
+    : A string providing a URL to an icon, logo or photo used to identify the third-party service in Micropub clients.
+
+  `user`
+  : An object containing information about the user account on the third-party service.
+
+    `name`
+    : A string representing the name of the user account.
+
+    `url`
+    : A string representing the URL for the user account.
 
 ## Methods
 
-| Method | Type | Description |
-| :----- | :--- | :---------- |
-| `syndicate()` | `AsyncFunction` | Syndicate a post to a third-party service. |
-
 ### `syndicate()`
 
-| Parameters | Type | Description |
-| :--------- | :--- | :---------- |
-| `properties` | `Object` | Path to file. _Required_. |
-| `publication` | `Object` | Path to file. _Required_. |
+An async function used to syndicate posts to the third-party service.
 
-Returns the URL for the syndicated content as a `String` if successful, else returns [`IndiekitError`][]. For example:
+### `init()`
 
-```js
-async syndicate(properties, publication) {
-  try {
-    return await exampleClient.post(properties, publication);
-  } catch (error) {
-    throw new IndiekitError(error.message, {
-      cause: error,
-      plugin: this.name,
-      status: error.status,
-    });
-  }
-}
-```
+Used to register the plug-in. Accepts an `Indiekit` instance to allow its modification before returning.
+
+#### Parameters
+
+`properties` <Badge type="info" text="Required" />
+: An object containing properties for a post. These conform to the [JF2 Post Serialisation Format](https://jf2.spec.indieweb.org).
+
+`publication` <Badge type="info" text="Required" />
+: An object containing the [publication’s configuration](/configuration/#publication).
+
+#### Return value
+
+A string representing the URL for the syndicated content if successful, else [`IndiekitError`][].
 
 ## Example
 
@@ -129,6 +122,33 @@ export default class ExampleStore {
   }
 }
 ```
+
+### Add target information
+
+Indiekit’s web interface expects a syndicator plug-in to provide some information about the third-party service it supports. In addition, some Micropub clients may also use this information in their publishing interface. This information is provided by the `info` property:
+
+```js
+get info() {
+  const { user } = this.options;
+
+  return {
+    name: `${user} on Example service`,
+    uid: `https://service.example/${user}`,
+    checked: true,
+    service: {
+      name: "Example service",
+      url: "https://service.example/",
+      photo: "/assets/example-syndicator/icon.svg",
+    },
+    user: {
+      name: user,
+      url: `https://service.example/${user}`,
+    },
+  };
+}
+```
+
+## See also
 
 Example syndicator plug-ins:
 

--- a/docs/plugins/api/error.md
+++ b/docs/plugins/api/error.md
@@ -2,21 +2,39 @@
 
 A custom error handler, [`IndiekitError`](https://github.com/getindiekit/indiekit/blob/main/packages/error/index.js), is available to plug-ins to return consistent and predictable error responses to Indiekit.
 
+## Syntax
+
 ```js
 import { IndiekitError } from "@indiekit/error";
 
 throw new IndiekitError(message, options);
 ```
 
-| Parameters | Type | Description |
-| :--------- | :--- | :---------- |
-| `message` | `String` | Human readable error message. _Required_. |
-| `options.cause` | `Error` | Original error. _Optional_. |
-| `options.code` | `String` | [Error code][]. _Optional_. |
-| `options.plugin` | `String` | Name of plug-in. This is used to prefix any error messages caused by a plug-in. _Optional_. |
-| `options.scope` | `String` | OAuth authentication scope. _Optional_. |
-| `options.status` | `Number` | [HTTP response status code][]. _Optional_. |
-| `options.uri` | `String` | URL to webpage providing information about the cause of the error and how to resolve it. _Optional_. |
+## Constructor
 
-[Error code]: https://github.com/getindiekit/indiekit/blob/main/packages/error/errors.js
+`message` <Badge type="info" text="Required" />
+: Human readable error message.
+
+`options`
+: An object used to customise the behaviour of the error.
+
+  `cause`
+  : An error object containing the original error.
+
+  `code`
+  : A string representing the internal [error code][].
+
+  `plugin`
+  : A string representing the name of plug-in. Used to prefix error messages caused by a plug-in.
+
+  `scope`
+  : A string representing an OAuth authentication scope.
+
+  `status`
+  : A number representing an [HTTP response status code][].
+
+  `uri`
+  : A string representing a URL to webpage providing information about the cause of the error and how to resolve it.
+
+[error code]: https://github.com/getindiekit/indiekit/blob/main/packages/error/errors.js
 [HTTP response status code]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "jsdom": "^24.0.0",
         "lint-staged": "^15.0.0",
         "markdown-it-anchor": "^8.6.6",
+        "markdown-it-deflist": "^3.0.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-task-lists": "^2.1.1",
         "mock-fs": "^5.1.2",
@@ -12260,6 +12261,12 @@
         "@types/markdown-it": "*",
         "markdown-it": "*"
       }
+    },
+    "node_modules/markdown-it-deflist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-3.0.0.tgz",
+      "integrity": "sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg==",
+      "dev": true
     },
     "node_modules/markdown-it-footnote": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "jsdom": "^24.0.0",
     "lint-staged": "^15.0.0",
     "markdown-it-anchor": "^8.6.6",
+    "markdown-it-deflist": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-task-lists": "^2.1.1",
     "mock-fs": "^5.1.2",


### PR DESCRIPTION
Updates the plug-in API docs to follow a structure similar to that used on MDN. Roughly speaking, that means showing the syntax, briefly outlining the different properties and methods, then expanding below with examples, finishing off with links to related content.

In part, this should help address #652. Further changes will be needed in other parts of the documentation, but this is a good start.

Plan is to:

- [x] update API docs for `Indiekit.addEndpoint`
- [x] update API docs for `Indiekit.addPreset`
- [x] update API docs for `Indiekit.addStore`
- [x] update API docs for `Indiekit.addSyndicator`
- [x] update API docs for `IndiekitError`
- [x] update references to use new post type concept
