### PR TITLE
Update documentation for configuration, including post types

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -18,12 +18,15 @@ const sidebar = [
   {
     text: "Configuration",
     items: [
-      { text: "Options", link: "/configuration/" },
-      { text: "Post types", link: "/configuration/post-types" },
-      { text: "Post template", link: "/configuration/post-template" },
+      { text: "Introduction", link: "/configuration/" },
+      { text: "Application options", link: "/configuration/application" },
+      { text: "Publication options", link: "/configuration/publication" },
       { text: "Commit messages", link: "/configuration/commit-messages" },
       { text: "Localisation", link: "/configuration/localisation" },
+      { text: "Post types", link: "/configuration/post-types" },
+      { text: "Post template", link: "/configuration/post-template" },
       { text: "Time zone", link: "/configuration/time-zone" },
+      { text: "Tokens", link: "/configuration/tokens" },
     ],
   },
   {

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -54,7 +54,7 @@ By default Indiekit supports creating the following post types:
 | `like`       | Posts used to share likes of other people’s posts. |
 | `note`       | Posts containing short, unstructured thoughts. |
 | `photo`      | Posts whose primary content is a photograph or other image. |
-| `reply`      | posts are used to reply to other people’s posts. |
+| `reply`      | Posts used to reply to other people’s posts. |
 
 ## Publication
 

--- a/docs/configuration/.option-contains-secrets.md
+++ b/docs/configuration/.option-contains-secrets.md
@@ -1,2 +1,0 @@
-> [!WARNING]
-> This value may contain private information such as a username and password. It’s recommended that you store this value in an environment (or configuration) variable which can only be seen by you and the application.

--- a/docs/configuration/.plugin-secrets.md
+++ b/docs/configuration/.plugin-secrets.md
@@ -1,2 +1,0 @@
-> [!WARNING]
-> Plug-ins may include options that require private information such as passwords or API keys to be given. It’s recommended that you store these values in environment (or configuration) variables which can only be seen by you and the application.

--- a/docs/configuration/application.md
+++ b/docs/configuration/application.md
@@ -1,0 +1,96 @@
+# Application options
+
+The following properties in the `application` configuration option are used to configure Indiekit’s server and application interface.
+
+## `authorizationEndpoint`
+
+Indiekit uses its own authorization endpoint, but you can use a third-party service by setting a URL for this option.
+
+Defaults to `"[application.url]/auth"`.
+
+## `introspectionEndpoint`
+
+Indiekit uses its own token introspection endpoint, but you can use a third-party service by setting a URL for this option.
+
+Defaults to `"[application.url]/auth/introspect"`.
+
+## `locale`
+
+A [ISO 639-1 language code](https://en.wikipedia.org/wiki/ISO_639-1) representing the language to use in the application interface.
+
+Defaults to system language if Indiekit has that localisation, else `"en"` (English).
+
+See [Localisation →](localisation.md)
+
+## `mediaEndpoint`
+
+Indiekit uses its own [Micropub media endpoint](https://micropub.spec.indieweb.org/#media-endpoint), but you can use a third-party service by setting a URL for this option.
+
+Defaults to `"[application.url]/media"`.
+
+## `micropubEndpoint`
+
+Indiekit uses its own Micropub endpoint, but you can use a third-party service by setting a URL for this option.
+
+Defaults to `"[application.url]/micropub"`.
+
+## `mongodbUrl`
+
+A [MongoDB connection string](https://www.mongodb.com/docs/manual/reference/connection-string/). Used by features that require a database.
+
+> [!WARNING]
+> This value may contain private information such as a username and password. It’s recommended that you store this value in an environment (or configuration) variable which can only be seen by you and the application.
+
+To use a specifically named database, include this in your path (the default database name is `indiekit`). For example, `mongodb://mongodb0.example.com:27017/custom-name`.
+
+Defaults to connection string provided in `process.env.MONGO_URL`.
+
+## `port`
+
+A number representing the port the application server should listen on.
+
+Defaults to `3000`.
+
+## `name`
+
+A string representing the name of your server.
+
+Defaults to `"Indiekit"`.
+
+## `themeColor`
+
+A string containing a hexadecimal colour value representing the accent colour used in the application interface.
+
+Defaults to `"#0055ee"`.
+
+## `themeColorScheme`
+
+Color scheme used in the application interface: `"automatic"`, `"light"` or `"dark"`.
+
+Defaults to `"automatic"`.
+
+## `timeZone`
+
+The time zone for the application. By default this is set to `"UTC"`, however if you want to offset dates according to your time zone you can provide [a time zone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This option also accepts a number of other values.
+
+Defaults to `"UTC"`.
+
+See [customising the time zone →](time-zone.md)
+
+## `tokenEndpoint`
+
+Indiekit uses its own token endpoint, but you can use a third-party service by setting a URL for this option.
+
+Defaults to `"[application.url]/auth/token"`.
+
+## `ttl`
+
+A number representing the length of time to cache external data requests (in seconds).
+
+Defaults to `604800` (7 days).
+
+## `url`
+
+The URL of your server. Useful if Indiekit is running behind a reverse proxy.
+
+Defaults to the URL of your server (as provided by request headers).

--- a/docs/configuration/commit-messages.md
+++ b/docs/configuration/commit-messages.md
@@ -3,7 +3,7 @@
 Indiekit provides content store plug-ins with a `metaData` object. This contains the following meta data that can be used in commit messages:
 
 - `action`: Action to take i.e. ‘create’, ‘upload’.
-- `result`: Result of action, i.e. ‘created’, ’uploaded'.
+- `result`: Result of action, i.e. ‘created’, ’uploaded’.
 - `fileType`: File type, i.e. ’post’ or ‘file‘.
 - `postType`: IndieWeb post type, i.e. ‘note’, ‘photo’, ‘reply’.
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,4 +1,4 @@
-# Options
+# Configuration
 
 Indiekit uses [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) to find and load a configuration file.
 
@@ -16,393 +16,43 @@ The `.indiekitrc` file (without extension) can be in JSON or YAML format. You ca
 - `.indiekitrc.yaml` / `.indiekitrc.yml`
 - `.indiekitrc.js`
 
-## application
+## Options
 
-### application.authorizationEndpoint `URL`
+Indiekit’s configuration file uses the following top-level properties:
 
-Indiekit uses its own authorization endpoint, but you can use a third-party service by setting a value for this option.
+- [`application`](application.md), an object containing configuration for the server and application interface,
+- [`publication`](publication.md), an object containing information about a publication, and how Indiekit should interact with it,
+- `plugins`, an array used to register [plug-ins](../plugins/index.md),
+- and finally, each plug-in may accept its own configuration options, and these should be provided under a key with the plug-in’s name.
 
-_Optional_, defaults to `"[application.url]/auth"`. For example:
+  > [!WARNING]
+  > Plug-ins may include options that require private information such as passwords or API keys to be given. It’s recommended that you store these values in environment (or configuration) variables which can only be seen by you and the application.
 
-```json
-{
-  "application": {
-    "authorizationEndpoint": "https://server.example/auth"
-  }
-}
-```
-
-### application.introspectionEndpoint `URL`
-
-Indiekit uses its own token introspection endpoint, but you can use a third-party service by setting a value for this option.
-
-_Optional_, defaults to `"[application.url]/auth/introspect"`. For example:
+## Example
 
 ```json
 {
   "application": {
-    "authorizationEndpoint": "https://server.example/introspect"
-  }
-}
-```
-
-### application.locale `string`
-
-The language used in the application interface.
-
-_Optional_, defaults to system language if supported, else `"en"` (English). For example:
-
-```json
-{
-  "application": {
-    "locale": "de"
-  }
-}
-```
-
-See [Localisation →](localisation.md)
-
-### application.mediaEndpoint `URL`
-
-Indiekit uses its own [Micropub media endpoint](https://micropub.spec.indieweb.org/#media-endpoint), but you can use a third-party service by setting a value for this option.
-
-_Optional_, defaults to `"[application.url]/media"`. For example:
-
-```json
-{
-  "application": {
-    "mediaEndpoint": "https://server.example/media"
-  }
-}
-```
-
-### application.micropubEndpoint `URL`
-
-Indiekit uses its own Micropub endpoint, but you can use a third-party service by setting a value for this option.
-
-_Optional_, defaults to `"[application.url]/micropub"`. For example:
-
-```json
-{
-  "application": {
-    "micropubEndpoint": "https://server.example/micropub"
-  }
-}
-```
-
-### application.mongodbUrl `URL`
-
-A [MongoDB connection string](https://www.mongodb.com/docs/manual/reference/connection-string/). Used by features that require a database.
-
-_Optional_, defaults to `process.env.MONGO_URL`. For example:
-
-```json
-{
-  "application": {
-    "mongodbUrl": "mongodb://mongodb0.example.com:27017"
-  }
-}
-```
-
-> [!TIP] Change in upcoming version <Badge type="info" text="1.0.0-beta.8" />
-> To use a specifically named database, include this in your path (the default database name is `indiekit`). For example, `mongodb://mongodb0.example.com:27017/custom-name`.
-
-<!--@include: .option-contains-secrets.md-->
-
-### application.port `number`
-
-Port for application server to listen on.
-
-_Optional_, defaults to `3000`. For example:
-
-```json
-{
-  "application": {
-    "port": 1234
-  }
-}
-```
-
-### application.name `string`
-
-The name of your server.
-
-_Optional_, defaults to `"Indiekit"`. For example:
-
-```json
-{
-  "application": {
-    "name": "My IndieWeb Server"
-  }
-}
-```
-
-### application.themeColor `string`
-
-Accent colour used in the application interface.
-
-_Optional_, defaults to `"#0055ee"`. For example:
-
-```json
-{
-  "application": {
-    "themeColor": "#663399"
-  }
-}
-```
-
-### application.themeColorScheme `string`
-
-Color scheme used in the application interface, `"automatic"`, `"light"` or `"dark"`.
-
-_Optional_, defaults to `"automatic"`. For example:
-
-```json
-{
-  "application": {
-    "themeColorScheme": "dark"
-  }
-}
-```
-
-### application.timeZone `string`
-
-The time zone for the application. By default this is set to `"UTC"`, however if you want to offset dates according to your time zone you can provide [a time zone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This option also accepts a number of other values.
-
-_Optional_, defaults to `"UTC"`. For example:
-
-```json
-{
-  "application": {
-    "timeZone": "Europe/Berlin"
-  }
-}
-```
-
-See [customising the time zone →](time-zone.md)
-
-### application.tokenEndpoint `URL`
-
-Indiekit uses its own token endpoint, but you can use a third-party service by setting a value for this option.
-
-_Optional_, defaults to `"[application.url]/auth/token"`. For example:
-
-```json
-{
-  "application": {
-    "tokenEndpoint": "https://server.example/token"
-  }
-}
-```
-
-### application.ttl `number`
-
-Length of time to cache external data requests (in seconds).
-
-_Optional_, defaults to `604800` (7 days). For example:
-
-```json
-{
-  "application": {
-    "ttl": 3600
-  }
-}
-```
-
-### application.url `string`
-
-The URL of your server. Useful if Indiekit is running behind a reverse proxy.
-
-_Optional_, defaults to the URL of your server (as provided by request headers). For example:
-
-```json
-{
-  "application": {
-    "url": "https://server.website.example"
-  }
-}
-```
-
-## plugins
-
-An array of plug-ins you wish to use with Indiekit. For example:
-
-```json
-{
+    "locale": "de",
+    "name": "Unabhängigkeit"
+  },
+  "publication": {
+    "locale": "de",
+    "me": "https://website.example",
+    "postTypes": {
+      "event": {
+        "name": "Veranstaltungen"
+      }
+    }
+  },
   "plugins": [
-    "@indiekit/preset-jekyll",
-    "@indiekit/store-github",
-    "@indiekit/syndicator-mastodon",
+    "@indiekit/post-type-event",
+    "@indiekit/preset-hugo"
   ],
-}
-```
-
-Each plug-in may accept its own configuration options, and these should be provided under a key with the plug-in’s name. For example:
-
-```json
-{
   "@indiekit/preset-hugo": {
     "frontMatterFormat": "yaml"
   }
 }
 ```
 
-<!--@include: .plugin-secrets.md-->
-
-Learn more about Indiekit’s [plug-in API](../plugins/api/index.md).
-
-## publication
-
-### publication.categories `Array | URL`
-
-A list of categories or tags used on your website. Can be an array of values, or the location of a JSON file providing an array of values.
-
-_Optional_.
-
-Example, using an array:
-
-```json
-{
-  "publication": {
-    "categories": ["sport", "technology", "travel"]
-  }
-}
-```
-
-Example, using a URL:
-
-```json
-{
-  "publication": {
-    "categories": "https://website.example/categories.json"
-  }
-}
-```
-
-### publication.enrichPostData `boolean`
-
-Fetch and append data about URLs referenced in new posts.
-
-_Optional_, defaults to `false`. For example:
-
-```json
-{
-  "publication": {
-    "enrichPostData": true
-  }
-}
-```
-
-When enabled, Indiekit will try to fetch Microformats data for any URL in a new post (for example URLs for `bookmark-of`, `like-of`, `repost-of`, `in-reply-to`).
-
-If any data is found, a `references` property will be included in the resulting post data. For example, given the following Micropub request:
-
-```sh
-POST /micropub HTTP/1.1
-Host: indiekit.mywebsite.com
-Content-Type: application/x-www-form-urlencoded
-Authorization: Bearer XXXXXXX
-
-h=entry
-&content=This+made+me+very+hungry.
-&bookmark-of=https://website.example/notes/123
-```
-
-should the note post at `https://website.example/notes/123` include Microformats, the following post data would be generated:
-
-```js
-{
-  date: "2022-11-03T22:00:00",
-  "bookmark-of": "https://website.example/notes/123",
-  content: "This made me very hungry.",
-  references: {
-    "https://website.example/notes/123": {
-      type: "entry",
-      published: "2013-03-07",
-      content: "I ate a cheese sandwich, which was nice.",
-      url: "https://website.example/notes/123"
-    }
-  }
-}
-```
-
-This referenced Microformats data could then be used in the design of your website to provide extra information about the content you are linking to.
-
-### publication.locale `string`
-
-Your publication’s locale. Currently used to format dates.
-
-_Optional_, defaults to `"en"` (English). For example:
-
-```json
-{
-  "publication": {
-    "locale": "de"
-  }
-}
-```
-
-### publication.me `URL`
-
-Your website’s URL.
-
-_Required_. For example:
-
-```json
-{
-  "publication": {
-    "me": "https://website.example"
-  }
-}
-```
-
-### publication.postTemplate `Function`
-
-A post template is a function that takes post properties received and parsed by the Micropub endpoint and renders them in a given file format, for example, a Markdown file with YAML front matter.
-
-_Optional_, defaults to MF2 JSON.
-
-See [customising a post template →](post-template.md)
-
-### publication.postTypes `Array`
-
-A set of default paths and templates for different post types.
-
-_Optional if using a preset_. For example:
-
-```json
-"publication": {
-  "postTypes": [{
-    "type": "note",
-    "name": "Journal entry",
-    "post": {
-      "path": "_journal/{yyyy}-{MM}-{dd}-{slug}.md",
-      "url": "journal/{yyyy}/{MM}/{slug}"
-    }
-  }]
-}
-```
-
-See [customising post types →](post-types.md)
-
-### publication.slugSeparator `string`
-
-The character used to replace spaces when creating a slug.
-
-_Optional_, defaults to `"-"` (hyphen). For example:
-
-```json
-{
-  "publication": {
-    "slugSeparator": "_"
-  }
-}
-```
-
-### publication.storeMessageTemplate `Function`
-
-Function used to customise message format.
-
-_Optional_, defaults to `[action] [postType] [fileType]`.
-
-See [customising commit messages →](commit-messages.md)
+[This example configuration](https://github.com/getindiekit/example-config) can be used as a starting point for configuring your own Indiekit server.

--- a/docs/configuration/post-template.md
+++ b/docs/configuration/post-template.md
@@ -6,9 +6,9 @@ The `postTemplate()` method takes one argument, `properties`, which contains the
 
 ```js
 {
-  published: '2020-02-02',
-  name: 'What I had for lunch',
-  content: 'I ate a cheese sandwich, which was nice.',
+  published: "2020-02-02",
+  name: "What I had for lunch",
+  content: "I ate a cheese sandwich, which was nice.",
 }
 ```
 

--- a/docs/configuration/post-types.md
+++ b/docs/configuration/post-types.md
@@ -1,90 +1,46 @@
 # Post types
 
-The Micropub API lets you publish a variety of [post types](https://indieweb.org/posts#Types_of_Posts), and Indiekit lets you decide how these different types are handled. You can do this by using a publication preset, configuring values manually, or a combination of both.
+The Micropub API lets you publish a variety of [post types](../concepts#post-type), and Indiekit lets you decide how these different types are handled.
 
-For example, to use the Jekyll preset but override the `note` and `photo` post types, you would add the following to your configuration:
+Post types can be configured in a few different ways. In order of priority:
+
+1. [`publication.postTypes`](publication#posttypes) configuration
+2. a [publication preset plug-in](/plugins/presets)
+3. a [post type plug-in](/plugins/post-types)
+
+Publication preset plug-ins provide default values for where post and media files should be saved, as well as a post template that formats incoming properties according to the file format expected by that publication.
+
+Post type plug-ins define the fields used to created and edit posts in Indiekit’s interface.
+
+While both plug-in types set default values for post types, these can be changed by defining alternative values in `publication.postTypes`
+
+For example, to use the Jekyll preset but override the location `note` and `event` post files are saved to, you would add the following to your configuration:
 
 ```json
 {
-  "plugins": ["@indiekit/preset-jekyll"],
+  "plugins": [
+    "@indiekit/post-type-event",
+    "@indiekit/preset-jekyll"
+  ],
   "publication": {
-    "postTypes": [
-      {
-        "type": "note",
-        "name": "Journal entry",
+    "postTypes": {
+      "note": {
+        "name": "Journal",
         "post": {
           "path": "_journal/{yyyy}-{MM}-{dd}-{slug}.md",
           "url": "journal/{yyyy}/{MM}/{slug}"
         }
       },
-      {
-        "type": "photo",
-        "name": "Photograph",
+      "event": {
+        "name": "Calendar",
         "post": {
-          "path": "_photos/{yyyy}-{MM}-{dd}-{slug}.md",
-          "url": "photos/{yyyy}/{MM}/{slug}"
-        },
-        "media": {
-          "path": "media/photos/{yyyy}/{filename}"
+          "path": "_calendar/{yyyy}-{MM}-{dd}-{slug}.md",
+          "url": "calendar/{yyyy}/{MM}/{slug}"
         }
       }
-    ]
+    }
   }
 }
 ```
 
-Each post type can take the following values:
-
-| Property | Type | Description |
-| :--- | :---------- | :---------- |
-| `type` | `string` | The IndieWeb [post type](https://indieweb.org/Category:PostType). _Required_. |
-| `name` | `string` | The name you use for this post type on your own site. You needn’t specify this value, but some Micropub clients use this value in their publishing interfaces. |
-| `h` | `string` | Microformat vocabulary to use. _Optional_, defaults to `"entry"`. |
-| `discovery` | `string` | Property to use for [post type discovery](https://www.w3.org/TR/post-type-discovery/). _Optional_. |
-| `fields` | `Array[object]` | Which input fields to display in Indiekit’s publishing interface. Micropub clients may use these values in their publishing interfaces. |
-| `fields[].required` | `boolean` | Input field is required. Micropub clients may use this value in their publishing interfaces. |
-| `post.path` | `string` | Where posts should be saved in your content store. _Required_. |
-| `post.url` | `string` | Permalink (the URL path) for posts on your website. _Required_. |
-| `media.path` | `string` | Where media files should be saved in your content store. _Required_ |
-| `media.url` | `string` | Public accessible URL for media files. This can use the same template variables as `media.path`. _Optional_, defaults to `media.path`. |
-
-## Path and URL tokens
-
-Values for `*.path` and `*.url` can be customised using the following tokens:
-
-| Token | Path type | Description |
-| :---- | :-------- | :---------- |
-| `y` | `post` `media` | Calendar year, eg <samp>2020</samp> |
-| `yyyy` | `post` `media` | Calendar year (zero-padded), eg <samp>2020</samp> |
-| `M` | `post` `media` | Month number, eg <samp>9</samp> |
-| `MM` | `post` `media` | Month number (zero-padded), eg <samp>09</samp> |
-| `MMM` | `post` `media` | Month name (abbreviated), eg <samp>Sep</samp> |
-| `MMMM` | `post` `media` | Month name (wide), eg <samp>September</samp> |
-| `w` | `post` `media` | Week number, eg <samp>1</samp> |
-| `ww` | `post` `media` | Week number (zero-padded), eg <samp>01</samp> |
-| `D` | `post` `media` | Day of the year, eg <samp>1</samp> |
-| `DDD` | `post` `media` | Day of the year (zero-padded), eg <samp>001</samp> |
-| `D60` | `post` `media` | Day of the year (sexageismal), eg <samp>57h</samp> |
-| `d` | `post` `media` | Day of the month, eg <samp>1</samp> |
-| `dd` | `post` `media` | Day of the month (zero-padded), eg <samp>01</samp> |
-| `h` | `post` `media` | Hour (12-hour-cycle), eg <samp>1</samp> |
-| `hh` | `post` `media` | Hour (12-hour-cycle, zero-padded), eg <samp>01</samp> |
-| `H` | `post` `media` | Hour (24-hour-cycle), eg <samp>1</samp> |
-| `HH` | `post` `media` | Hour (24-hour-cycle, zero-padded), eg <samp>01</samp> |
-| `m` | `post` `media` | Minute, eg <samp>1</samp> |
-| `mm` | `post` `media` | Minute (zero-padded), eg <samp>01</samp> |
-| `s` | `post` `media` | Second, eg <samp>1</samp> |
-| `ss` | `post` `media` | Second (zero-padded), eg <samp>01</samp> |
-| `t` | `post` `media` | UNIX epoch seconds, eg <samp>512969520</samp> |
-| `T` | `post` `media` | UNIX epoch milliseconds, eg <samp>51296952000</samp> |
-| `uuid` | `post` `media` | A [random UUID][uuid] |
-| `slug` | `post` | Provided slug, slugified `name` or a 5 character string, eg <samp>ycf9o</samp> |
-| `n`[^1] | `post` `media` | Incremental count of posts (for type) in the same day, eg <samp>1</samp> |
-| `basename` | `media` | 5 character alpha-numeric string, eg <samp>w9gwi</samp> |
-| `ext` | `media` | File extension of uploaded file, eg <samp>jpg</samp> |
-| `filename` | `media` | `basename` plus `ext`, eg <samp>w9gwi.jpg</samp> |
-| `originalname` | `media` | Original name of uploaded file, eg <samp>flower.jpg</samp> |
-
-[^1]: Using the `n` token requires a [database to be configured](https://getindiekit.com/configuration/#application-mongodburl-url).
-
-[uuid]: https://www.rfc-editor.org/rfc/rfc4122.html#section-4.4
+In addition, by setting values for `name` property for each post type, this overrides the default value provided by the `@indiekit/post-type-note` plug-in (installed by default) and the `@indiekit/post-type-event` plug-in.

--- a/docs/configuration/publication.md
+++ b/docs/configuration/publication.md
@@ -1,0 +1,177 @@
+# Publication options
+
+The following properties in the `publication` configuration option are used to provide information to Indiekit about a publication and how to interact with it.
+
+## `categories`
+
+A list of categories or tags used on your website. Can be an array of values, or a URL pointing to the location of a JSON file that provides an array of values.
+
+Example, using an array:
+
+```json
+{
+  "publication": {
+    "categories": ["sport", "technology", "travel"]
+  }
+}
+```
+
+Example, using a URL:
+
+```json
+{
+  "publication": {
+    "categories": "https://website.example/categories.json"
+  }
+}
+```
+
+## `enrichPostData`
+
+A boolean to determine if data about URLs referenced in new posts is fetched and appended to a post’s properties.
+
+Defaults to `false`.
+
+When enabled, Indiekit will try to fetch Microformats data for any URL in a new post (for example URLs for `bookmark-of`, `like-of`, `repost-of`, `in-reply-to`).
+
+If any data is found, a `references` property will be included in the resulting post data. For example, given the following Micropub request:
+
+```sh
+POST /micropub HTTP/1.1
+Host: indiekit.mywebsite.com
+Content-Type: application/x-www-form-urlencoded
+Authorization: Bearer XXXXXXX
+
+h=entry
+&content=This+made+me+very+hungry.
+&bookmark-of=https://website.example/notes/123
+```
+
+should the note post at `https://website.example/notes/123` include Microformats, the following post data would be generated:
+
+```js
+{
+  date: "2022-11-03T22:00:00",
+  "bookmark-of": "https://website.example/notes/123",
+  content: "This made me very hungry.",
+  references: {
+    "https://website.example/notes/123": {
+      type: "entry",
+      published: "2013-03-07",
+      content: "I ate a cheese sandwich, which was nice.",
+      url: "https://website.example/notes/123"
+    }
+  }
+}
+```
+
+This referenced Microformats data could then be used in the design of your website to provide extra information about the content you are linking to.
+
+## `locale`
+
+A [ISO 639-1 language code](https://en.wikipedia.org/wiki/ISO_639-1) representing the language used by the publication. Currently used to format dates.
+
+Defaults to `"en"` (English).
+
+## `me`
+
+Your website’s URL.
+
+<Badge type="info" text="Required" />
+
+## `postTemplate`
+
+A post template is a function that takes post properties received and parsed by the Micropub endpoint and renders them in a given file format, for example, a Markdown file with YAML front matter.
+
+Defaults to MF2 JSON.
+
+See [customising a post template →](post-template.md)
+
+## `postTypes`
+
+A keyed collection of configuration properties for different post types. For example:
+
+````json
+{
+  "postTypes": {
+    "note": {
+      "name": "Journal entry",
+      "post": {
+        "path": "_journal/{yyyy}-{MM}-{dd}-{slug}.md",
+        "url": "journal/{yyyy}/{MM}/{slug}"
+      }
+    },
+    "photo": {
+      "name": "Photograph",
+      "post": {
+        "path": "_photos/{yyyy}-{MM}-{dd}-{slug}.md",
+        "url": "photos/{yyyy}/{MM}/{slug}"
+      },
+      "media": {
+        "path": "media/photos/{yyyy}/{filename}"
+      }
+    }
+  }
+}
+````
+
+Some of these values may already be set by a preset plugin or any post type plugins, but you can overwrite any configuration values they have set.
+
+See [customising post types →](post-types.md)
+
+### Properties
+
+`name`
+: A string representing the name you use for this post type on your own site. You needn’t specify this value, but some Micropub clients use this value in their publishing interfaces.
+
+`h`
+: A string representing the [Microformat vocabulary](http://microformats.org/wiki/microformats2#v2_vocabularies) to use. Defaults to `entry`.
+
+`discovery`
+: A string representing the field name to use when identifying incoming Micropub requests.
+
+`fields`
+: An object containing [FieldType](/plugins/api/add-post-type.md#fieldtype) objects, optionally with a `required` property, and keyed by field name. For example:
+
+  ```json
+  {
+    "name": "Journal entry",
+    "fields": {
+      "content": { "required": true },
+      "categories": { "required": true },
+      "location": {}
+    }
+  }
+  ```
+
+`post`
+: An object containing options for how post files should be stored.
+
+  `path`
+  : A string representing where posts should be saved in your content store.
+
+  `url`
+  : A string representing a permalink (or URL path) format for posts on your website.
+
+`media`
+: An object containing options for how media files should be stored.
+
+  `path`
+  : A string representing where media files should be saved in your content store.
+
+  `url`
+  : A string representing the public accessible URL for media files.
+
+## `slugSeparator`
+
+A string representing the character used to replace spaces when creating a slug.
+
+Defaults to `"-"` (hyphen).
+
+## `storeMessageTemplate`
+
+A function that can be used to customise messages used when saving files to content stores that save messages with each change, for example git repositories.
+
+Defaults to `[action] [postType] [fileType]`.
+
+See [customising commit messages →](commit-messages.md)

--- a/docs/configuration/tokens.md
+++ b/docs/configuration/tokens.md
@@ -1,0 +1,76 @@
+---
+outline: deep
+---
+
+# Tokens
+
+Values for post and media paths in post type configuration can be customised using placeholder tokens.
+
+For example, given the following properties for a note post:
+
+```js
+{
+  published: "2020-02-02",
+  name: "What I had for lunch",
+  content: "I ate a cheese sandwich, which was nice.",
+}
+```
+
+would, with the path `_journal/{yyyy}-{MM}-{dd}-{slug}.md`, output:
+
+```txt
+_journal/2020-02-02-what-i-had-for-lunch.md
+```
+
+## Path and URL tokens
+
+Tokens are available for a number of file properties, with many allowing you to use parts of the published or uploaded date in generated paths and URLs:
+
+| Token | Description |
+| :---- | :---------- |
+| `y` | Calendar year, for example `2020` |
+| `yyyy` | Calendar year (zero-padded), for example `2020` |
+| `M` | Month number, for example `9` |
+| `MM` | Month number (zero-padded), for example `09` |
+| `MMM` | Month name (abbreviated), for example `Sep` |
+| `MMMM` | Month name (wide), for example `September` |
+| `w` | Week number, for example `1` |
+| `ww` | Week number (zero-padded), for example `01` |
+| `D` | Day of the year, for example `1` |
+| `DDD` | Day of the year (zero-padded), for example `001` |
+| `D60` | Day of the year (sexageismal), for example `57h` |
+| `d` | Day of the month, for example `1` |
+| `dd` | Day of the month (zero-padded), for example `01` |
+| `h` | Hour (12-hour-cycle), for example `1` |
+| `hh` | Hour (12-hour-cycle, zero-padded), for example `01` |
+| `H` | Hour (24-hour-cycle), for example `1` |
+| `HH` | Hour (24-hour-cycle, zero-padded), for example `01` |
+| `m` | Minute, for example `1` |
+| `mm` | Minute (zero-padded), for example `01` |
+| `s` | Second, for example `1` |
+| `ss` | Second (zero-padded), for example `01` |
+| `t` | UNIX epoch seconds, for example `512969520` |
+| `T` | UNIX epoch milliseconds, for example `51296952000` |
+| `uuid` | A [random UUID][uuid] |
+| `n` | Incremental count of posts (for type) in the same day, for example `1`. This token requires a [database to be configured](https://getindiekit.com/configuration/#application-mongodburl-url). |
+
+### Post file tokens
+
+The following tokens are only available for post files:
+
+| Token | Description |
+| :---- | :---------- |
+| `slug` | Slug provided in `mp-slug` property, slugified `name` or a 5 character string, for example `ycf9o` |
+
+### Media file tokens
+
+The following tokens are only available for media files:
+
+| Token | Description |
+| :---- | :---------- |
+| `basename` | 5 character alpha-numeric string, for example `w9gwi` |
+| `ext` | File extension of uploaded file, for example `jpg` |
+| `filename` | `basename` plus `ext`, for example `w9gwi.jpg` |
+| `originalname` | Original name of uploaded file, for example `flower.jpg` |
+
+[uuid]: https://www.rfc-editor.org/rfc/rfc4122.html#section-4.4

--- a/docs/plugins/api/add-post-type.md
+++ b/docs/plugins/api/add-post-type.md
@@ -6,9 +6,6 @@ outline: deep
 
 A [post type](../../concepts.md#post-type) defines fields for creating and editing different post (or content) types, either using Indiekit or via third-party Micropub clients.
 
-> [!TIP] New feature
-> Post type plug-ins will be introduced in <Badge text="1.0.0-beta.8" />
-
 ## Syntax
 
 ```js

--- a/docs/plugins/api/add-post-type.md
+++ b/docs/plugins/api/add-post-type.md
@@ -35,7 +35,7 @@ new Indiekit.addPostType(type, options);
   : A string representing the [Microformat vocabulary](http://microformats.org/wiki/microformats2#v2_vocabularies) to use. Defaults to `entry`.
 
   `fields` <Badge type="info" text="Required" />
-  : A object containing [FieldType](#postfield) objects, keyed by field name.
+  : An object containing [FieldType](#postfield) objects, keyed by field name.
 
   `discovery`
   : A string representing the field name to use when identifying incoming Micropub requests.
@@ -45,7 +45,7 @@ new Indiekit.addPostType(type, options);
     In most cases this option is required. Only post types already defined in the [post type discovery][] algorithm (`article`, `event`, `like`, `note`, `photo`, `repost`, `rsvp`, `reply` and `video`) can ignore this option.
 
 `validationSchemas`
-: A object containing [Schema](#postfield) objects.
+: An object containing [Schema](#postfield) objects.
 
 ## Interfaces
 

--- a/docs/plugins/post-types.md
+++ b/docs/plugins/post-types.md
@@ -2,9 +2,6 @@
 
 A [post type](../concepts#post-type) provides an interface for creating and editing different content types.
 
-> [!TIP] New feature
-> Post type plug-ins will be introduced in <Badge text="1.0.0-beta.8" />
-
 Plug-ins are available for the following post types:
 
 ## [@indiekit/post-type-article](https://npmjs.org/package/@indiekit/post-type-article)

--- a/packages/endpoint-media/lib/media-type-count.js
+++ b/packages/endpoint-media/lib/media-type-count.js
@@ -9,7 +9,7 @@ export const mediaTypeCount = {
     if (!application.posts || !application.posts.count()) {
       console.warn("No database configuration provided");
       console.info(
-        "See https://getindiekit.com/configuration/#application-mongodburl-url",
+        "See https://getindiekit.com/configuration/application/#mongodburl",
       );
 
       return;

--- a/packages/endpoint-micropub/lib/post-type-count.js
+++ b/packages/endpoint-micropub/lib/post-type-count.js
@@ -11,7 +11,7 @@ export const postTypeCount = {
     if (!application.posts || !application.posts.count()) {
       console.warn("No database configuration provided");
       console.info(
-        "See https://getindiekit.com/configuration/#application-mongodburl-url",
+        "See https://getindiekit.com/configuration/application/#mongodburl",
       );
 
       return;

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -71,7 +71,7 @@ export const Indiekit = class {
     // Check for required configuration options
     if (!this.publication.me) {
       console.error("No publication URL in configuration");
-      console.info("https://getindiekit.com/configuration/#publication-me-url");
+      console.info("https://getindiekit.com/configuration/publication#me");
       process.exit();
     }
 


### PR DESCRIPTION
- Break configuration into separate pages for `application` and `publication`
- Update links in application to these new pages
- Update documentation around post type configuration
- Remove references to upcoming new post type plug-in feature
- Fix typos