### PR TITLE
Media file upload component

### DIFF
--- a/helpers/frontend/views/frontend-components.njk
+++ b/helpers/frontend/views/frontend-components.njk
@@ -5,6 +5,7 @@
 {%- from "card/macro.njk" import card with context -%}
 {%- from "logo/macro.njk" import logo with context -%}
 {%- from "navigation/macro.njk" import navigation with context -%}
+{%- from "progress/macro.njk" import progress with context -%}
 {%- from "share-preview/macro.njk" import sharePreview with context -%}
 
 {% block content %}
@@ -402,6 +403,13 @@
     text: "Next text",
     label: "Next label"
   }
+}) }}
+
+<h2><code>progress</code></h2>
+
+{{ progress({
+  label: "Uploading file",
+  id: "progress"
 }) }}
 
 <h2><code>section</code></h2>

--- a/helpers/frontend/views/frontend-form.njk
+++ b/helpers/frontend/views/frontend-form.njk
@@ -82,6 +82,14 @@
   hint: "Character count hint text"
 }) }}
 
+{{ fileInput({
+  errorMessage: { text: "File upload input error" } if errors,
+  name: "file-input",
+  label: "File upload input",
+  hint: "File upload input hint text",
+  uploadEndpoint: application.mediaEndpoint
+}) }}
+
 {{ geoInput({
   errorMessage: { text: "Geo input error" } if errors,
   name: "geo-input",

--- a/packages/endpoint-files/locales/nl.json
+++ b/packages/endpoint-files/locales/nl.json
@@ -29,7 +29,7 @@
     },
     "title": "Bestanden",
     "upload": {
-      "action": "Uploaden bestand",
+      "action": "Upload bestand",
       "title": "Upload een nieuw bestand"
     }
   }

--- a/packages/endpoint-files/locales/pt.json
+++ b/packages/endpoint-files/locales/pt.json
@@ -25,11 +25,11 @@
       "file": {
         "label": "Arquivo"
       },
-      "submit": "Upload"
+      "submit": "Fazer upload"
     },
     "title": "Arquivos",
     "upload": {
-      "action": "Carregar ficheiro",
+      "action": "Subir arquivo",
       "title": "Carregar um novo arquivo"
     }
   }

--- a/packages/frontend/components/file-input/index.js
+++ b/packages/frontend/components/file-input/index.js
@@ -1,0 +1,113 @@
+/* eslint-disable jsdoc/no-undefined-types */
+import { wrapElement } from "../../lib/utils/wrap-element.js";
+
+export const FileInputFieldController = class extends HTMLElement {
+  constructor() {
+    super();
+
+    this.endpoint = this.getAttribute("endpoint");
+
+    /** @type {HTMLElement} */
+    this.$uploadProgress = this.querySelector(".file-input__progress");
+    this.$pathInput = this.querySelector("input");
+
+    this.$filePickerTemplate = this.querySelector("#file-input-picker");
+    this.$errorMessageTemplate = this.querySelector("#error-message");
+  }
+
+  connectedCallback() {
+    // Create group to hold input and button
+    const $inputButtonGroup = document.createElement("div");
+    $inputButtonGroup.classList.add("input-button-group");
+
+    // Create and display upload button
+    const $filePicker = this.$filePickerTemplate.content.cloneNode(true);
+
+    // Wrap input within `input-button-group` container
+    wrapElement(this.$pathInput, $inputButtonGroup);
+
+    // Add button to `input-button-group` container
+    $inputButtonGroup.append($filePicker);
+
+    // Make label behave like a button
+    const $pickerLabel = this.querySelector(`label[role="button"]`);
+    $pickerLabel.addEventListener("keydown", (event) => {
+      // Prevent default behaviour, including scrolling using spacebar
+      if (["Spacebar", " ", "Enter"].includes(event.key)) {
+        event.preventDefault();
+      }
+
+      if (event.key === "Enter") {
+        event.target.click();
+      }
+    });
+
+    $pickerLabel.addEventListener("keyup", (event) => {
+      if (["Spacebar", " "].includes(event.key)) {
+        event.preventDefault();
+        event.target.click();
+      }
+    });
+
+    // Add event to file input
+    const $pickerInput = this.querySelector(`input[type="file"]`);
+    $pickerInput.addEventListener("change", (event) => this.fetch(event));
+  }
+
+  /**
+   * Fetch file
+   * @param {Event} event - File input event
+   */
+  async fetch(event) {
+    this.$uploadProgress.hidden = false;
+
+    const formData = new FormData();
+    formData.append("file", event.target.files[0]);
+
+    try {
+      this.$pathInput.readOnly = true;
+
+      const endpointResponse = await fetch(this.endpoint, {
+        method: "POST",
+        body: formData,
+      });
+
+      if (endpointResponse.ok) {
+        this.$pathInput.value = await endpointResponse.headers.get("location");
+      } else {
+        this.showErrorMessage(endpointResponse.statusText);
+      }
+
+      this.$pathInput.readOnly = false;
+      this.$uploadProgress.hidden = true;
+    } catch (error) {
+      this.showErrorMessage(error);
+      this.$pathInput.readOnly = false;
+      this.$uploadProgress.hidden = true;
+    }
+  }
+
+  showErrorMessage(message) {
+    const $input = this.querySelector(".input");
+    const $inputButtonGroup = this.querySelector(".input-button-group");
+
+    // Create error message
+    let $errorMessage = this.$errorMessageTemplate.content.cloneNode(true);
+    $inputButtonGroup.before($errorMessage);
+    $errorMessage = this.querySelector(".error-message");
+    const $errorMessageText = this.querySelector(".error-message__text");
+
+    // Add error class to field
+    this.classList.add("field--error");
+
+    // Add error message text
+    $errorMessageText.textContent = message;
+
+    // Update `aria-describedby` on input element to reference error message
+    const inputAttributes = $input.getAttribute("aria-describedby") || "";
+    $input.setAttribute(
+      "aria-describedby",
+      [inputAttributes, $errorMessage.id].join(" "),
+    );
+  }
+};

--- a/packages/frontend/components/file-input/macro.njk
+++ b/packages/frontend/components/file-input/macro.njk
@@ -1,0 +1,3 @@
+{% macro fileInput(opts) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/frontend/components/file-input/styles.css
+++ b/packages/frontend/components/file-input/styles.css
@@ -1,0 +1,3 @@
+file-input-field {
+  display: block;
+}

--- a/packages/frontend/components/file-input/template.njk
+++ b/packages/frontend/components/file-input/template.njk
@@ -1,0 +1,43 @@
+{% from "../button/macro.njk" import button with context %}
+{% from "../error-message/macro.njk" import errorMessage with context %}
+{% from "../input/macro.njk" import input with context %}
+{% from "../progress/macro.njk" import progress with context %}
+{% set id = opts.id or opts.name | slugify({ decamelize: true }) %}
+{% call input({
+  field: {
+    element: "file-input-field",
+    attributes: {
+      "endpoint": opts.uploadEndpoint
+    }
+  },
+  classes: opts.classes,
+  id: id,
+  name: opts.name,
+  value: opts.value,
+  label: opts.label,
+  hint: opts.hint,
+  optional: opts.optional,
+  attributes: {
+    "aria-describedby": id + "-progress",
+    placeholder: opts.attributes.placeholder
+  },
+  errorMessage: opts.errorMessage
+}) %}
+  {{ progress({
+    classes: "file-input__progress",
+    id: id + "-progress",
+    label: __("fileInput.uploadingFile"),
+    attributes: {
+      hidden: true
+    }
+  }) }}
+  <template id="file-input-picker">
+    <label class="button button--secondary" for="{{ id }}-file" role="button" tabindex="0">{{ __("fileInput.uploadFile") }}</label>
+    <input hidden id="{{ id }}-file" type="file"{% if opts.accept %} accept="{{ opts.accept }}"{% endif %}>
+  </template>
+  <template id="error-message">
+    {{ errorMessage({
+      id: id + "-error"
+    }) | indent(4) }}
+  </template>
+{% endcall %}

--- a/packages/frontend/components/input/styles.css
+++ b/packages/frontend/components/input/styles.css
@@ -86,7 +86,7 @@
   flex-wrap: wrap;
   gap: var(--space-2xs);
 
-  & .input {
+  & *:first-child {
     flex: 999 1 auto;
     inline-size: auto;
     max-inline-size: 100%;
@@ -96,7 +96,7 @@
     margin-inline-end: calc(var(--input-border-width-focus) * -1);
   }
 
-  & .button {
+  & *:last-child {
     flex: 1 1 auto;
     margin-block-start: 0;
   }

--- a/packages/frontend/components/progress/macro.njk
+++ b/packages/frontend/components/progress/macro.njk
@@ -1,0 +1,3 @@
+{% macro progress(opts) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/frontend/components/progress/styles.css
+++ b/packages/frontend/components/progress/styles.css
@@ -1,0 +1,38 @@
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.progress {
+  --label-font: var(--font-body);
+  align-items: center;
+  flex-direction: row-reverse;
+  gap: var(--space-s);
+
+  &:not([hidden]) {
+    display: inline-flex;
+  }
+
+  & .label {
+    color: var(--color-on-offset);
+  }
+
+  & progress {
+    animation: spin 1s linear infinite;
+    appearance: none;
+    block-size: 1.5em;
+    border: var(--border-width-thickest) solid var(--color-offset-variant);
+    border-inline-end-color: var(--color-on-offset);
+    border-radius: 100%;
+    inline-size: 1.5em;
+    margin: 0;
+
+    &::-webkit-progress-inner-element {
+      display: none;
+    }
+  }
+}

--- a/packages/frontend/components/progress/template.njk
+++ b/packages/frontend/components/progress/template.njk
@@ -1,0 +1,10 @@
+{% from "../label/macro.njk" import label with context %}
+<div class="{{ classes("progress", opts) }}" {{- attributes(opts.attributes) }}>
+  {{- label({
+    for: opts.id,
+    text: opts.label
+  }) if opts.label }}
+  <progress id="{{ opts.id }}">
+    {{- caller() if caller -}}
+  </progress>
+</div>

--- a/packages/frontend/layouts/default.njk
+++ b/packages/frontend/layouts/default.njk
@@ -10,6 +10,7 @@
 {% from "details/macro.njk" import details with context %}
 {% from "error-summary/macro.njk" import errorSummary with context %}
 {% from "fieldset/macro.njk" import fieldset with context %}
+{% from "file-input/macro.njk" import fileInput with context %}
 {% from "footer/macro.njk" import footer with context %}
 {% from "geo-input/macro.njk" import geoInput with context %}
 {% from "header/macro.njk" import header with context %}

--- a/packages/frontend/locales/de.json
+++ b/packages/frontend/locales/de.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Es gibt ein Problem"
   },
+  "fileInput": {
+    "uploadFile": "Datei hochladen…",
+    "uploadingFile": "Datei wird hochgeladen"
+  },
   "geoInput": {
     "denied": "Erlaubnis zur Nutzung des aktuellen Standorts konnte nicht eingeholt werden",
     "failed": "Der aktuelle Standort kann nicht abgerufen werden",

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "There is a problem"
   },
+  "fileInput": {
+    "uploadFile": "Upload file…",
+    "uploadingFile": "Uploading file"
+  },
   "geoInput": {
     "denied": "Unable to get permission to use current location",
     "failed": "Unable to get current location",

--- a/packages/frontend/locales/es-419.json
+++ b/packages/frontend/locales/es-419.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Hay un problema"
   },
+  "fileInput": {
+    "uploadFile": "Cargar archivo…",
+    "uploadingFile": "Subiendo archivo"
+  },
   "geoInput": {
     "denied": "No se puede obtener el permiso para usar la ubicación actual",
     "failed": "No se puede obtener la ubicación actual",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Hay un problema"
   },
+  "fileInput": {
+    "uploadFile": "Cargar archivo…",
+    "uploadingFile": "Subiendo archivo"
+  },
   "geoInput": {
     "denied": "No se puede obtener el permiso para usar la ubicación actual",
     "failed": "No se puede obtener la ubicación actual",

--- a/packages/frontend/locales/fr.json
+++ b/packages/frontend/locales/fr.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Il y a un problème"
   },
+  "fileInput": {
+    "uploadFile": "Téléverser un fichier…",
+    "uploadingFile": "Téléchargement de fichiers"
+  },
   "geoInput": {
     "denied": "Impossible d’obtenir l’autorisation d’utiliser la position actuelle",
     "failed": "Impossible d’obtenir la position actuelle",

--- a/packages/frontend/locales/id.json
+++ b/packages/frontend/locales/id.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Ada masalah"
   },
+  "fileInput": {
+    "uploadFile": "Unggah berkas…",
+    "uploadingFile": "Mengunggah berkas"
+  },
   "geoInput": {
     "denied": "Tidak dapat memperoleh izin untuk menggunakan lokasi saat ini",
     "failed": "Tidak bisa mendapatkan lokasi saat ini",

--- a/packages/frontend/locales/nl.json
+++ b/packages/frontend/locales/nl.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Er is een Probleem"
   },
+  "fileInput": {
+    "uploadFile": "Upload bestand…",
+    "uploadingFile": "Uploaden van bestanden"
+  },
   "geoInput": {
     "denied": "Kan geen toestemming krijgen om de huidige locatie te gebruiken",
     "failed": "Kan de huidige locatie niet ophalen",

--- a/packages/frontend/locales/pl.json
+++ b/packages/frontend/locales/pl.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Wystąpił problem"
   },
+  "fileInput": {
+    "uploadFile": "Prześlij plik…",
+    "uploadingFile": "Wysyłanie pliku"
+  },
   "geoInput": {
     "denied": "Nie można uzyskać uprawnień do korzystania z bieżącej lokalizacji",
     "failed": "Nie można uzyskać bieżącej lokalizacji",

--- a/packages/frontend/locales/pt.json
+++ b/packages/frontend/locales/pt.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Há um problema"
   },
+  "fileInput": {
+    "uploadFile": "Subir arquivo…",
+    "uploadingFile": "Carregando arquivo"
+  },
   "geoInput": {
     "denied": "Não foi possível obter permissão para usar a localização atual",
     "failed": "Não é possível obter a localização atual",

--- a/packages/frontend/locales/sr.json
+++ b/packages/frontend/locales/sr.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Postoji problem"
   },
+  "fileInput": {
+    "uploadFile": "Otpremi datoteku…",
+    "uploadingFile": "Otpremanje datoteke"
+  },
   "geoInput": {
     "denied": "Nije moguće dobiti dozvolu za korišćenje trenutne lokacije",
     "failed": "Nije moguće dobiti trenutnu lokaciju",

--- a/packages/frontend/locales/sv.json
+++ b/packages/frontend/locales/sv.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "Det finns ett problem"
   },
+  "fileInput": {
+    "uploadFile": "Ladda upp fil…",
+    "uploadingFile": "Laddar upp fil"
+  },
   "geoInput": {
     "denied": "Det gick inte att få behörighet att använda aktuell plats",
     "failed": "Det gick inte att hämta aktuell plats",

--- a/packages/frontend/locales/zh-Hans-CN.json
+++ b/packages/frontend/locales/zh-Hans-CN.json
@@ -20,6 +20,10 @@
   "errorSummary": {
     "title": "有一个问题"
   },
+  "fileInput": {
+    "uploadFile": "上传文件…",
+    "uploadingFile": "正在上传文件"
+  },
   "geoInput": {
     "denied": "无法获得使用当前位置的权限",
     "failed": "无法获取当前位置",

--- a/packages/frontend/scripts/app.js
+++ b/packages/frontend/scripts/app.js
@@ -3,6 +3,7 @@ import { CharacterCountComponent } from "../components/character-count/index.js"
 import { CheckboxesFieldComponent } from "../components/checkboxes/index.js";
 import { ErrorSummaryComponent } from "../components/error-summary/index.js";
 import { EventDurationComponent } from "../components/event-duration/index.js";
+import { FileInputFieldController } from "../components/file-input/index.js";
 import { GeoInputFieldComponent } from "../components/geo-input/index.js";
 import { NotificationBannerComponent } from "../components/notification-banner/index.js";
 import { RadiosFieldComponent } from "../components/radios/index.js";
@@ -14,6 +15,7 @@ customElements.define("add-another", AddAnotherComponent);
 customElements.define("character-count", CharacterCountComponent);
 customElements.define("checkboxes-field", CheckboxesFieldComponent);
 customElements.define("error-summary", ErrorSummaryComponent);
+customElements.define("file-input-field", FileInputFieldController);
 customElements.define("event-duration", EventDurationComponent);
 customElements.define("geo-input-field", GeoInputFieldComponent);
 customElements.define("notification-banner", NotificationBannerComponent);

--- a/packages/frontend/styles/app.css
+++ b/packages/frontend/styles/app.css
@@ -45,6 +45,7 @@
 @import url("../components/navigation/styles.css");
 @import url("../components/notification-banner/styles.css");
 @import url("../components/pagination/styles.css");
+@import url("../components/progress/styles.css");
 @import url("../components/prose/styles.css");
 @import url("../components/radios/styles.css");
 @import url("../components/section/styles.css");

--- a/packages/frontend/styles/app.css
+++ b/packages/frontend/styles/app.css
@@ -32,6 +32,7 @@
 @import url("../components/event-duration/styles.css");
 @import url("../components/field/styles.css");
 @import url("../components/fieldset/styles.css");
+@import url("../components/file-input/styles.css");
 @import url("../components/footer/styles.css");
 @import url("../components/geo-input/styles.css");
 @import url("../components/header/styles.css");

--- a/packages/post-type-audio/includes/post-types/audio-field.njk
+++ b/packages/post-type-audio/includes/post-types/audio-field.njk
@@ -1,9 +1,11 @@
 {% macro audioFieldset(index) %}
-  {{ input({
+  {{ fileInput({
     name: "audio[" + index + "]",
     type: "url",
     value: fieldData("audio[" + index + "]").value,
     label: __("posts.form.media.label"),
+    accept: "audio/*",
+    uploadEndpoint: application.mediaEndpoint,
     attributes: {
       placeholder: "https://"
     },

--- a/packages/post-type-photo/includes/post-types/photo-field.njk
+++ b/packages/post-type-photo/includes/post-types/photo-field.njk
@@ -2,11 +2,13 @@
 {% call fieldset({
   classes: "fieldset--group"
 }) %}
-  {{ input({
+  {{ fileInput({
     name: "photo[" + index + "][url]",
     type: "url",
     value: fieldData("photo[" + index + "].url").value,
     label: __("posts.form.media.label"),
+    accept: "image/*",
+    uploadEndpoint: application.mediaEndpoint,
     attributes: {
       placeholder: "https://"
     },

--- a/packages/post-type-video/includes/post-types/video-field.njk
+++ b/packages/post-type-video/includes/post-types/video-field.njk
@@ -1,9 +1,11 @@
 {% macro videoFieldset(index) %}
-  {{ input({
+  {{ fileInput({
     name: "video[" + index + "]",
     type: "url",
     value: fieldData("video[" + index + "]").value,
     label: __("posts.form.media.label"),
+    accept: "video/*",
+    uploadEndpoint: application.mediaEndpoint,
     attributes: {
       placeholder: "https://"
     },


### PR DESCRIPTION
Partially fixes #538, #539 and #540.

Adds a `fileInput` component, that progressively enhances an `<input type="text">` to be populated from the upload from an injected `<input type="file">`. After clicking the file selector and choosing a file, a fetch request is initiated that uploads the chosen file and returns the URL from the media endpoint.

<img width="680" alt="Screenshot of file upload component." src="https://github.com/getindiekit/indiekit/assets/813383/0625f267-f9af-43dc-b68a-2b8e6ee564b8">

Possibly a number of ways this could be improved, but I think this is a good first pass at making uploading images inline easier, certainly easier than going to the separate file upload page and copy and pasting an uploaded file URL.

## Accessibility

Given restrictions around initiating a file picker programmatically, and without universal support for `window.showOpenFilePicker()`, am using a `<label>` styled as a `<button>` which is used to trigger the hidden `<input type="file">`. The label has been given a `button` role, added to the `tabindex`, and given the behaviours of a button so that it can be triggered using a keyboard.

Have tested using VoiceOver, but doubtless there are untold issues in other user agents. However, this seems like the most reasonable means of creating a button like control that can initiate the file picker. Open to other ideas on how this can be achieved.   