### PR TITLE
Refactor slugs

### DIFF
--- a/docs/configuration/tokens.md
+++ b/docs/configuration/tokens.md
@@ -51,8 +51,6 @@ Tokens are available for a number of file properties, with many allowing you to 
 | `ss` | Second (zero-padded), for example `01` |
 | `t` | UNIX epoch seconds, for example `512969520` |
 | `T` | UNIX epoch milliseconds, for example `51296952000` |
-| `random` | A random 5-character string, for example `w9gwi` |
-| `uuid` | A [random UUID][uuid] |
 | `n` | Incremental count of posts (for type) in the same day, for example `1`. This token requires a [database to be configured](https://getindiekit.com/configuration/#application-mongodburl-url). |
 
 ### Post file tokens
@@ -72,5 +70,3 @@ The following tokens are only available for media files:
 | `ext` | File extension of uploaded file, for example `jpg` |
 | `filename` | Slugified name of uploaded file, for example `flower_1.jpg` for a file with the original name `Flower 1.jpg`. |
 | `md5` | MD5 checksum of the uploaded file, for example `be7d321488de26f2eb38834af7162164` |
-
-[uuid]: https://www.rfc-editor.org/rfc/rfc4122.html#section-4.4

--- a/helpers/fixtures/jf2/article-content-provided.jf2
+++ b/helpers/fixtures/jf2/article-content-provided.jf2
@@ -1,6 +1,5 @@
 {
   "type": "entry",
   "name": "What I had for lunch",
-  "content": "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",
-  "mp-slug": "lunch"
+  "content": "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then."
 }

--- a/helpers/fixtures/jf2/article-slug-provided-empty.jf2
+++ b/helpers/fixtures/jf2/article-slug-provided-empty.jf2
@@ -1,0 +1,6 @@
+{
+  "type": "entry",
+  "name": "What I had for lunch",
+  "content": "I ate a *cheese* sandwich, which was nice.",
+  "mp-slug": ""
+}

--- a/helpers/fixtures/jf2/note-slug-missing-no-name.jf2
+++ b/helpers/fixtures/jf2/note-slug-missing-no-name.jf2
@@ -1,0 +1,4 @@
+{
+  "type": "entry",
+  "content": "I ate a cheese sandwich, which was nice."
+}

--- a/helpers/fixtures/jf2/note-slug-provided-unslugified.jf2
+++ b/helpers/fixtures/jf2/note-slug-provided-unslugified.jf2
@@ -1,0 +1,5 @@
+{
+  "type": "entry",
+  "content": "I ate a cheese sandwich, which was nice.",
+  "mp-slug": "Cheese sandwich"
+}

--- a/helpers/fixtures/jf2/note-slug-provided.jf2
+++ b/helpers/fixtures/jf2/note-slug-provided.jf2
@@ -1,0 +1,5 @@
+{
+  "type": "entry",
+  "content": "I ate a cheese sandwich, which was nice.",
+  "mp-slug": "cheese-sandwich"
+}

--- a/packages/endpoint-media/lib/file.js
+++ b/packages/endpoint-media/lib/file.js
@@ -1,26 +1,31 @@
-import { getDate } from "@indiekit/util";
+import path from "node:path";
+import { getDate, slugify } from "@indiekit/util";
 import { fileTypeFromBuffer } from "file-type";
 
 /**
  * Derive properties from file data
- * @param {object} timeZone - Application time zone
+ * @param {object} publication - Publication configuration
  * @param {object} file - Original file object
+ * @param {object} timeZone - Application time zone
  * @returns {Promise<object>} File properties
- * @example fileData('brighton-pier.jpg') => {
+ * @example fileData('Brighton Pier.jpg') => {
  *   ext: '.jpg'
  *   filename: 'brighton-pier.jpg',
  *   'content-type': image/jpeg,
  *   published: '2020-07-19T22:59:23.497Z',
  * }
  */
-export const getFileProperties = async (timeZone, file) => {
+export const getFileProperties = async (publication, file, timeZone) => {
   const { ext } = await fileTypeFromBuffer(file.data);
   const published = getPublishedProperty(timeZone);
+
+  let basename = path.basename(file.name, ext);
+  basename = slugify(basename, publication.slugSeparator);
 
   return {
     "content-type": file.mimetype,
     ext,
-    filename: file.name,
+    filename: `${basename}.${ext}`,
     md5: file.md5,
     published,
   };

--- a/packages/endpoint-media/lib/media-data.js
+++ b/packages/endpoint-media/lib/media-data.js
@@ -18,10 +18,10 @@ export const mediaData = {
     debug(`create %O`, { file });
 
     const { hasDatabase, media, timeZone } = application;
-    const { me, postTypes, slugSeparator } = publication;
+    const { me, postTypes } = publication;
 
     // Media properties
-    const properties = await getFileProperties(timeZone, file);
+    const properties = await getFileProperties(publication, file, timeZone);
 
     // Get post type configuration
     const type = await getMediaType(file);
@@ -44,13 +44,11 @@ export const mediaData = {
       typeConfig.media.path,
       properties,
       application,
-      slugSeparator,
     );
     const url = await renderPath(
       typeConfig.media.url || typeConfig.media.path,
       properties,
       application,
-      slugSeparator,
     );
     properties.url = getCanonicalUrl(url, me);
 

--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -3,7 +3,6 @@ import {
   dateTokens,
   formatDate,
   getTimeZoneDesignator,
-  randomString,
   slugify,
   supplant,
 } from "@indiekit/util";
@@ -55,11 +54,6 @@ export const renderPath = async (path, properties, application, separator) => {
   // Add count of media type for the day
   const count = await mediaTypeCount.get(application, properties);
   tokens.n = count + 1;
-
-  // Add random token
-  tokens.random = randomString(5)
-    .replace(separator, "0") // Don’t use slug separator character
-    .toLowerCase();
 
   // Add UUID token
   tokens.uuid = crypto.randomUUID();

--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -1,9 +1,7 @@
-import { basename as getBasename } from "node:path";
 import {
   dateTokens,
   formatDate,
   getTimeZoneDesignator,
-  slugify,
   supplant,
 } from "@indiekit/util";
 import newbase60 from "newbase60";
@@ -29,10 +27,9 @@ export const getMediaProperties = (mediaData) => {
  * @param {string} path - URI template path
  * @param {object} properties - Media properties
  * @param {object} application - Application configuration
- * @param {string} separator - Slug separator
  * @returns {Promise<string>} Path
  */
-export const renderPath = async (path, properties, application, separator) => {
+export const renderPath = async (path, properties, application) => {
   const dateObject = new Date(properties.published);
   const serverTimeZone = getTimeZoneDesignator();
   const { locale, timeZone } = application;
@@ -58,10 +55,8 @@ export const renderPath = async (path, properties, application, separator) => {
   // Add file extension token
   tokens.ext = properties.ext;
 
-  // Add slugified file name token
-  let basename = getBasename(properties.filename, properties.ext);
-  basename = slugify(basename, separator);
-  tokens.filename = `${basename}.${properties.ext}`;
+  // Add file name token
+  tokens.filename = properties.filename;
 
   // Add md5 token
   tokens.md5 = properties.md5;

--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -55,9 +55,6 @@ export const renderPath = async (path, properties, application, separator) => {
   const count = await mediaTypeCount.get(application, properties);
   tokens.n = count + 1;
 
-  // Add UUID token
-  tokens.uuid = crypto.randomUUID();
-
   // Add file extension token
   tokens.ext = properties.ext;
 

--- a/packages/endpoint-media/test/unit/file.js
+++ b/packages/endpoint-media/test/unit/file.js
@@ -18,15 +18,18 @@ describe("endpoint-media/lib/file", () => {
   });
 
   it("Derives properties from file data", async () => {
+    const publication = {
+      slugSeparator: "-",
+    };
     const file = {
       data: getFixture("file-types/photo.jpg", false),
-      name: "photo.jpg",
+      name: "Photo 1.jpg",
       md5: "be7d321488de26f2eb38834af7162164",
     };
-    const result = await getFileProperties("UTC", file);
+    const result = await getFileProperties(publication, file, "UTC");
 
     assert.equal(result.ext, "jpg");
-    assert.equal(result.filename, "photo.jpg");
+    assert.equal(result.filename, "photo-1.jpg");
     assert.equal(result.md5, "be7d321488de26f2eb38834af7162164");
     assert.equal(isValid(parseISO(result.published)), true);
   });

--- a/packages/endpoint-media/test/unit/utils.js
+++ b/packages/endpoint-media/test/unit/utils.js
@@ -18,12 +18,10 @@ describe("endpoint-media/lib/util", () => {
   it("Renders path from URI template and properties", async () => {
     const dateToken = await renderPath("{yyyy}/{MM}", properties, {}, "-");
     const fileToken = await renderPath("{filename}", properties, {}, "-");
-    const uuidToken = await renderPath("{uuid}", properties, {}, "-");
     const md5Token = await renderPath("{md5}", properties, {}, "-");
 
     assert.match(dateToken, /^\d{4}\/\d{2}/);
     assert.match(fileToken, /^foo-1\.jpg/);
-    assert.match(uuidToken, /^[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}/);
     assert.match(md5Token, /^([\da-f]{32}|[\dA-F]{32})$/);
   });
 });

--- a/packages/endpoint-media/test/unit/utils.js
+++ b/packages/endpoint-media/test/unit/utils.js
@@ -5,7 +5,7 @@ import { renderPath } from "../../lib/utils.js";
 describe("endpoint-media/lib/util", () => {
   const properties = {
     ext: "jpg",
-    filename: "Foo 1.jpg",
+    filename: "foo-1.jpg",
     md5: "be7d321488de26f2eb38834af7162164",
     published: "2020-01-01",
   };
@@ -16,9 +16,9 @@ describe("endpoint-media/lib/util", () => {
   });
 
   it("Renders path from URI template and properties", async () => {
-    const dateToken = await renderPath("{yyyy}/{MM}", properties, {}, "-");
-    const fileToken = await renderPath("{filename}", properties, {}, "-");
-    const md5Token = await renderPath("{md5}", properties, {}, "-");
+    const dateToken = await renderPath("{yyyy}/{MM}", properties, {});
+    const fileToken = await renderPath("{filename}", properties, {});
+    const md5Token = await renderPath("{md5}", properties, {});
 
     assert.match(dateToken, /^\d{4}\/\d{2}/);
     assert.match(fileToken, /^foo-1\.jpg/);

--- a/packages/endpoint-media/test/unit/utils.js
+++ b/packages/endpoint-media/test/unit/utils.js
@@ -19,13 +19,11 @@ describe("endpoint-media/lib/util", () => {
     const dateToken = await renderPath("{yyyy}/{MM}", properties, {}, "-");
     const fileToken = await renderPath("{filename}", properties, {}, "-");
     const uuidToken = await renderPath("{uuid}", properties, {}, "-");
-    const randomToken = await renderPath("{random}", properties, {}, "-");
     const md5Token = await renderPath("{md5}", properties, {}, "-");
 
     assert.match(dateToken, /^\d{4}\/\d{2}/);
     assert.match(fileToken, /^foo-1\.jpg/);
     assert.match(uuidToken, /^[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}/);
-    assert.match(randomToken, /^\w{5}/);
     assert.match(md5Token, /^([\da-f]{32}|[\dA-F]{32})$/);
   });
 });

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -22,7 +22,7 @@ export const postData = {
     debug(`create %O`, { draftMode, properties });
 
     const { hasDatabase, posts, timeZone } = application;
-    const { me, postTypes, slugSeparator, syndicationTargets } = publication;
+    const { me, postTypes, syndicationTargets } = publication;
 
     // Add syndication targets
     const syndicateTo = getSyndicateToProperty(properties, syndicationTargets);
@@ -48,14 +48,8 @@ export const postData = {
       typeConfig.post.path,
       properties,
       application,
-      slugSeparator,
     );
-    const url = await renderPath(
-      typeConfig.post.url,
-      properties,
-      application,
-      slugSeparator,
-    );
+    const url = await renderPath(typeConfig.post.url, properties, application);
     properties.url = getCanonicalUrl(url, me);
 
     // Post status
@@ -108,7 +102,7 @@ export const postData = {
     debug(`update ${url} %O`, { operation });
 
     const { posts, timeZone } = application;
-    const { me, postTypes, slugSeparator } = publication;
+    const { me, postTypes } = publication;
 
     // Read properties
     let { path: _originalPath, properties } = await this.read(application, url);
@@ -149,13 +143,11 @@ export const postData = {
       typeConfig.post.path,
       properties,
       application,
-      slugSeparator,
     );
     const updatedUrl = await renderPath(
       typeConfig.post.url,
       properties,
       application,
-      slugSeparator,
     );
     properties.url = getCanonicalUrl(updatedUrl, me);
 
@@ -188,7 +180,7 @@ export const postData = {
     debug(`delete ${url}`);
 
     const { posts, timeZone } = application;
-    const { postTypes, slugSeparator } = publication;
+    const { postTypes } = publication;
 
     // Read properties
     const { properties } = await this.read(application, url);
@@ -215,7 +207,6 @@ export const postData = {
       typeConfig.post.path,
       properties,
       application,
-      slugSeparator,
     );
 
     // Update data in posts collection
@@ -240,7 +231,7 @@ export const postData = {
     debug(`undelete ${url} %O`, { draftMode });
 
     const { posts } = application;
-    const { postTypes, slugSeparator } = publication;
+    const { postTypes } = publication;
 
     // Read deleted properties
     const { _deletedProperties } = await this.read(application, url);
@@ -257,7 +248,6 @@ export const postData = {
       typeConfig.post.path,
       properties,
       application,
-      slugSeparator,
     );
 
     // Post status

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -198,7 +198,7 @@ export const postData = {
 
     // Delete all properties, except those required for path creation
     for (const key in _deletedProperties) {
-      if (!["mp-slug", "post-type", "published", "type", "url"].includes(key)) {
+      if (!["post-type", "published", "slug", "type", "url"].includes(key)) {
         delete properties[key];
       }
     }

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -106,9 +106,6 @@ export const renderPath = async (path, properties, application) => {
   // Add slug token
   tokens.slug = properties.slug;
 
-  // Add UUID token
-  tokens.uuid = crypto.randomUUID();
-
   // Populate URI template path with properties
   path = supplant(path, tokens);
 

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -4,7 +4,6 @@ import {
   getTimeZoneDesignator,
   isDate,
   randomString,
-  slugify,
   supplant,
 } from "@indiekit/util";
 import newbase60 from "newbase60";
@@ -41,29 +40,6 @@ export const excerptString = (string, n) => {
     const excerpt = string.split(/\s+/).slice(0, n).join(" ");
     return excerpt;
   }
-};
-
-/**
- * Get slug
- * @param {object} properties - JF2 properties
- * @param {string} separator - Slug separator
- * @returns {string} Slug
- */
-export const getSlug = (properties, separator) => {
-  const { name, slug } = properties;
-
-  let string;
-  if (slug) {
-    string = slug;
-  } else if (name) {
-    string = excerptString(name, 5);
-  } else {
-    string = randomString(5)
-      .replace("_", "0") // Slugify function strips any leading underscore
-      .replace(separator, "0"); // Don’t use slug separator character
-  }
-
-  return slugify(string, { separator });
 };
 
 /**
@@ -134,11 +110,11 @@ export const renderPath = async (path, properties, application, separator) => {
     .replace(separator, "0") // Don’t use slug separator character
     .toLowerCase();
 
+  // Add slug token
+  tokens.slug = properties.slug;
+
   // Add UUID token
   tokens.uuid = crypto.randomUUID();
-
-  // Add slug token (falls back to name or random if no `mp-slug`)
-  tokens.slug = getSlug(properties, separator);
 
   // Populate URI template path with properties
   path = supplant(path, tokens);

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -3,7 +3,6 @@ import {
   formatDate,
   getTimeZoneDesignator,
   isDate,
-  randomString,
   supplant,
 } from "@indiekit/util";
 import newbase60 from "newbase60";
@@ -79,10 +78,9 @@ export const relativeMediaPath = (url, me) =>
  * @param {string} path - URI template path
  * @param {object} properties - JF2 properties
  * @param {object} application - Application configuration
- * @param {string} separator - Slug separator
  * @returns {Promise<string>} Path
  */
-export const renderPath = async (path, properties, application, separator) => {
+export const renderPath = async (path, properties, application) => {
   const dateObject = new Date(properties.published);
   const serverTimeZone = getTimeZoneDesignator();
   const { locale, timeZone } = application;
@@ -104,11 +102,6 @@ export const renderPath = async (path, properties, application, separator) => {
   // Add count of post-type for the day
   const count = await postTypeCount.get(application, properties);
   tokens.n = count + 1;
-
-  // Add random token
-  tokens.random = randomString(5)
-    .replace(separator, "0") // Don’t use slug separator character
-    .toLowerCase();
 
   // Add slug token
   tokens.slug = properties.slug;

--- a/packages/endpoint-micropub/test/unit/jf2.js
+++ b/packages/endpoint-micropub/test/unit/jf2.js
@@ -10,6 +10,7 @@ import {
   getLocationProperty,
   getPhotoProperty,
   getVideoProperty,
+  getSlugProperty,
   getSyndicateToProperty,
   normaliseProperties,
 } from "../../lib/jf2.js";
@@ -286,6 +287,49 @@ describe("endpoint-micropub/lib/jf2", () => {
     ]);
   });
 
+  it("Derives slug from `mp-slug` property", () => {
+    const properties = JSON.parse(getFixture("jf2/note-slug-provided.jf2"));
+    const result = getSlugProperty(properties, "-");
+
+    assert.equal(result, "cheese-sandwich");
+  });
+
+  it("Derives slug from unslugified `mp-slug` property", () => {
+    const properties = JSON.parse(
+      getFixture("jf2/note-slug-provided-unslugified.jf2"),
+    );
+    const result = getSlugProperty(properties, "-");
+
+    assert.equal(result, "cheese-sandwich");
+  });
+
+  it("Derives slug, ignoring empty `mp-slug` property", () => {
+    const properties = JSON.parse(
+      getFixture("jf2/article-slug-provided-empty.jf2"),
+    );
+    const result = getSlugProperty(properties, "-");
+
+    assert.equal(result, "what-i-had-for-lunch");
+  });
+
+  it("Derives slug from `name` property", () => {
+    const properties = JSON.parse(
+      getFixture("jf2/article-content-provided-text.jf2"),
+    );
+    const result = getSlugProperty(properties, "-");
+
+    assert.equal(result, "what-i-had-for-lunch");
+  });
+
+  it("Derives slug by generating random string", () => {
+    const properties = JSON.parse(
+      getFixture("jf2/note-slug-missing-no-name.jf2"),
+    );
+    const result = getSlugProperty(properties, "-");
+
+    assert.match(result, /\w{5}/g);
+  });
+
   it("Does not add syndication target if no syndicators", () => {
     const properties = JSON.parse(
       getFixture("jf2/article-syndicate-to-provided.jf2"),
@@ -358,7 +402,7 @@ describe("endpoint-micropub/lib/jf2", () => {
 
     assert.equal(result.type, "entry");
     assert.equal(result.name, "What I had for lunch");
-    assert.equal(result.slug, "lunch");
+    assert.equal(result.slug, "what-i-had-for-lunch");
     assert.deepEqual(result.content, {
       html: `<blockquote>\n<p>I <del>ate</del><ins>had</ins> a <cite><a href="https://en.wikipedia.org/wiki/Cheese">cheese</a></cite> sandwich from https://cafe.example, which was &gt; 10.</p>\n</blockquote>\n<p>– Me, then.</p>`,
       text: "> I <del>ate</del><ins>had</ins> a <cite>[cheese](https://en.wikipedia.org/wiki/Cheese)</cite> sandwich from https://cafe.example, which was > 10.\n\n-- Me, then.",

--- a/packages/endpoint-micropub/test/unit/post-data.js
+++ b/packages/endpoint-micropub/test/unit/post-data.js
@@ -52,7 +52,7 @@ describe("endpoint-micropub/lib/post-data", async () => {
     const result = await postData.create(application, publication, properties);
 
     assert.equal(result.properties["post-type"], "note");
-    assert.equal(result.properties["mp-slug"], "foo");
+    assert.equal(result.properties.slug, "foo");
     assert.equal(result.properties.type, "entry");
     assert.equal(result.properties.url, "https://website.example/notes/foo/");
   });

--- a/packages/endpoint-micropub/test/unit/utils.js
+++ b/packages/endpoint-micropub/test/unit/utils.js
@@ -3,7 +3,6 @@ import { before, describe, it, mock } from "node:test";
 import {
   decodeQueryParameter,
   excerptString,
-  getSlug,
   getPostTemplateProperties,
   relativeMediaPath,
   renderPath,
@@ -33,37 +32,6 @@ describe("endpoint-media/lib/utils", () => {
     const result = excerptString("The quick fox jumped over the lazy fox", 5);
 
     assert.equal(result, "The quick fox jumped over");
-  });
-
-  it("Derives slug from `slug` property", () => {
-    const properties = { slug: "cheese-sandwich" };
-    const result = getSlug(properties, "-");
-
-    assert.equal(result, "cheese-sandwich");
-  });
-
-  it("Derives slug from `name` property", () => {
-    const properties = { name: "Cheese sandwich" };
-    const result = getSlug(properties, "-");
-
-    assert.equal(result, "cheese-sandwich");
-  });
-
-  it("Derives slug, ignoring empty `slug` property", () => {
-    const properties = {
-      name: "What I had for lunch",
-      slug: "",
-    };
-    const result = getSlug(properties, "-");
-
-    assert.equal(result, "what-i-had-for-lunch");
-  });
-
-  it("Derives slug by generating random string", () => {
-    const properties = { content: "I ate a cheese sandwich, which was nice." };
-    const result = getSlug(properties, "-");
-
-    assert.match(result, /\w{5}/g);
   });
 
   it("Gets post template properties", () => {

--- a/packages/endpoint-micropub/test/unit/utils.js
+++ b/packages/endpoint-micropub/test/unit/utils.js
@@ -62,7 +62,7 @@ describe("endpoint-media/lib/utils", () => {
   });
 
   it("Renders path from URI template and properties", async () => {
-    const template = "{yyyy}/{MM}/{uuid}/{slug}";
+    const template = "{yyyy}/{MM}/{slug}";
     const properties = {
       published: "2020-01-01",
       slug: "foo",
@@ -85,10 +85,7 @@ describe("endpoint-media/lib/utils", () => {
     };
     const result = await renderPath(template, properties, application);
 
-    assert.match(
-      result,
-      /\d{4}\/\d{2}\/[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}\/foo/,
-    );
+    assert.match(result, /\d{4}\/\d{2}\/foo/);
   });
 
   it("Convert string to array if not already an array", () => {

--- a/packages/endpoint-micropub/test/unit/utils.js
+++ b/packages/endpoint-micropub/test/unit/utils.js
@@ -62,7 +62,7 @@ describe("endpoint-media/lib/utils", () => {
   });
 
   it("Renders path from URI template and properties", async () => {
-    const template = "{yyyy}/{MM}/{uuid}/{random}/{slug}";
+    const template = "{yyyy}/{MM}/{uuid}/{slug}";
     const properties = {
       published: "2020-01-01",
       slug: "foo",
@@ -83,11 +83,11 @@ describe("endpoint-media/lib/utils", () => {
         },
       },
     };
-    const result = await renderPath(template, properties, application, "-");
+    const result = await renderPath(template, properties, application);
 
     assert.match(
       result,
-      /\d{4}\/\d{2}\/[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}\/\w{5}\/foo/,
+      /\d{4}\/\d{2}\/[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}\/foo/,
     );
   });
 

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -81,7 +81,7 @@
     {{ input({
       classes: "input--width-25",
       name: "mp-slug",
-      value: fieldData("mp-slug").value,
+      value: fieldData("slug").value,
       label: __("posts.form.mp-slug.label"),
       optional: true
     }) | indent(4) }}

--- a/packages/preset-eleventy/lib/post-template.js
+++ b/packages/preset-eleventy/lib/post-template.js
@@ -53,6 +53,7 @@ const getFrontMatter = (properties) => {
   delete properties.name; // Use `title`
   delete properties.postStatus; // Use `draft`
   delete properties.published; // Use `date`
+  delete properties.slug; // use `page.fileSlug`
   delete properties.type; // Not required
   delete properties.url; // Not required
 

--- a/packages/preset-hugo/lib/post-template.js
+++ b/packages/preset-hugo/lib/post-template.js
@@ -58,6 +58,7 @@ const getFrontMatter = (properties, frontMatterFormat) => {
   delete properties.name; // Use `title`
   delete properties.postStatus; // Use `draft`
   delete properties.published; // Use `date`
+  delete properties.slug; // File path dictates slug
   delete properties.type; // Not required
   delete properties.updated; // Use `lastmod`
   delete properties.url; // Not required

--- a/packages/preset-jekyll/lib/post-template.js
+++ b/packages/preset-jekyll/lib/post-template.js
@@ -54,6 +54,7 @@ const getFrontMatter = (properties) => {
   delete properties.content; // Shown below front matter
   delete properties.name; // Use `title`
   delete properties.post_status; // Use `published`
+  delete properties.slug; // File path dictates slug
   delete properties.summary; // Use `excerpt`
   delete properties.type; // Not required
   delete properties.url; // Not required


### PR DESCRIPTION
Argh. Slugs are a pain. They’re an essential component of the Micropub endpoint and need to be stable and predictable as they can affect generated paths (if a path don’t exist in a content store, things quickly fall apart).

This PR:

- [x] reverts aspects of #719, such that a `slug` property is always created and provided to the `postTemplate`; either from the value provided in `mp-slug`, a slugified `name` property, else a random 5-character string.
- [x] fixes the `slug` property not being remembered when a post is deleted
- [x] updates the post form to read from an existing `slug` property when editing a post
- [x] removes the `{random}` path token, as this token gets regenerated each time the `renderPath` function is called
- [x] removes the `{uuid}` path token for the same reasons
- [x] removes `slug` property from front matter when using the Eleventy present (Eleventy supplies `page.fileSlug`)
- [x] removes `slug` property from front matter when using the Jekyll present
- [x] removes `slug` property from front matter when using the Hugo present (with Hugo `slug` is a significant property that affects the published URL, which may lead to unintended URLs if the slug not being used in the post file path)

Need more use cases for it makes sense to supply `slug` property to front matter properties for different static site generators, however if using `postTemplate`, the `slug` property will be provided.

/cc @aciccarello