### PR TITLE
Simplify login screen

### DIFF
--- a/packages/frontend/lib/filters/url.js
+++ b/packages/frontend/lib/filters/url.js
@@ -10,7 +10,8 @@ export const friendlyUrl = (string) => {
 
   try {
     const { host, pathname } = new URL(string);
-    return host + pathname;
+
+    return pathname === "/" ? host : host + pathname;
   } catch {
     return string;
   }

--- a/packages/frontend/test/unit/filters/url.js
+++ b/packages/frontend/test/unit/filters/url.js
@@ -5,6 +5,7 @@ import { friendlyUrl, imageUrl } from "../../../lib/filters/index.js";
 describe("frontend/lib/filters/url", () => {
   it("Gets friendly URL", () => {
     assert.equal(friendlyUrl("https://foo.example/bar"), "foo.example/bar");
+    assert.equal(friendlyUrl("https://foo.example"), "foo.example");
     assert.equal(friendlyUrl("foo.example/bar"), "foo.example/bar");
   });
 

--- a/packages/indiekit/locales/de.json
+++ b/packages/indiekit/locales/de.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Melde dich mit IndieAuth an, um zu verifizieren, dass du %s besitzt",
+      "description": "Melden Sie sich an, um zu überprüfen, ob Sie Eigentümer sind %s",
       "me": "Webadresse",
-      "submit": "Mit IndieAuth anmelden",
+      "submit": "Fortsetzen",
       "title": "Anmelden"
     },
     "logout": {

--- a/packages/indiekit/locales/en.json
+++ b/packages/indiekit/locales/en.json
@@ -11,9 +11,9 @@
   "session": {
     "login": {
       "title": "Sign in",
-      "description": "Sign in with IndieAuth to verify that you own %s",
+      "description": "Sign in to verify that you own %s",
       "me": "Web address",
-      "submit": "Sign in with IndieAuth"
+      "submit": "Continue"
     },
     "logout": {
       "title": "Sign out"

--- a/packages/indiekit/locales/es-419.json
+++ b/packages/indiekit/locales/es-419.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Inicie sesión con IndieAuth para verificar que es propietario de %s",
+      "description": "Inicia sesión para verificar que eres dueño de %s",
       "me": "Dirección web",
-      "submit": "Iniciar sesión con IndieAuth",
+      "submit": "Continuar",
       "title": "Iniciar sesión"
     },
     "logout": {

--- a/packages/indiekit/locales/es.json
+++ b/packages/indiekit/locales/es.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Inicia sesión con IndieAuth para verificar que eres propietario de %s",
+      "description": "Inicia sesión para verificar que eres dueño de %s",
       "me": "Dirección web",
-      "submit": "Iniciar sesión con IndieAuth",
+      "submit": "Continuar",
       "title": "Iniciar sesión"
     },
     "logout": {

--- a/packages/indiekit/locales/fr.json
+++ b/packages/indiekit/locales/fr.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Connectez-vous avec IndieAuth pour vérifier que vous possédez %s",
+      "description": "Connectez-vous pour vérifier que vous possédez %s",
       "me": "Adresse Web",
-      "submit": "Connectez-vous avec IndieAuth",
+      "submit": "Continuer",
       "title": "Se connecter"
     },
     "logout": {

--- a/packages/indiekit/locales/id.json
+++ b/packages/indiekit/locales/id.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Masuk dengan IndieAuth untuk memverifikasi bahwa Anda memiliki %s",
+      "description": "Masuk untuk memverifikasi bahwa Anda memiliki %s",
       "me": "Alamat web",
-      "submit": "Masuk dengan IndieAuth",
+      "submit": "Lanjutkan",
       "title": "Masuk"
     },
     "logout": {

--- a/packages/indiekit/locales/nl.json
+++ b/packages/indiekit/locales/nl.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Meld u aan met IndieAuth om te controleren of u eigenaar bent van %s",
+      "description": "Meld je aan om te verifiëren dat je de eigenaar bent %s",
       "me": "Webadres",
-      "submit": "Log in met IndieAuth",
+      "submit": "Doorgaan",
       "title": "Inloggen"
     },
     "logout": {

--- a/packages/indiekit/locales/pl.json
+++ b/packages/indiekit/locales/pl.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Zaloguj się za pomocą IndieAuth, aby sprawdzić, czy posiadasz %s",
+      "description": "Zaloguj się, aby sprawdzić, czy jesteś właścicielem %s",
       "me": "Adres sieci Web",
-      "submit": "Zaloguj się za pomocą IndieAuth",
+      "submit": "Kontynuuj",
       "title": "Zaloguj się"
     },
     "logout": {

--- a/packages/indiekit/locales/pt.json
+++ b/packages/indiekit/locales/pt.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Faça login com IndieAuth para verificar se você possui %s",
+      "description": "Faça login para verificar se você possui %s",
       "me": "Endereço Web",
-      "submit": "Faça login com IndieAuth",
+      "submit": "Continuar",
       "title": "Fazer login"
     },
     "logout": {

--- a/packages/indiekit/locales/sr.json
+++ b/packages/indiekit/locales/sr.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "Prijavi se pomoću IndieAuth da potvrdiš da poseduješ %s",
+      "description": "Prijavite se da biste potvrdili da ste vlasnik %s",
       "me": "Veb adresa\n",
-      "submit": "Prijavi se pomoću IndieAuth",
+      "submit": "Nastavi",
       "title": "Prijavi se"
     },
     "logout": {

--- a/packages/indiekit/locales/zh-Hans-CN.json
+++ b/packages/indiekit/locales/zh-Hans-CN.json
@@ -55,9 +55,9 @@
   },
   "session": {
     "login": {
-      "description": "使用 IndieAuth 登录以验证你是否拥有 %s",
+      "description": "登录以验证您是否拥有 %s",
       "me": "网址",
-      "submit": "使用 IndieAuth 登录",
+      "submit": "继续",
       "title": "登录"
     },
     "logout": {


### PR DESCRIPTION
- Remove trailing slash from domains without a path component
- Remove mention of IndieAuth (implementation detail doesn’t need to be exposed to user)

| Before | After |
| - | - |
| ![Login screen before.](https://github.com/getindiekit/indiekit/assets/813383/e0eaa0c0-5d95-408b-a884-094937410dee) | ![Login screen after.](https://github.com/getindiekit/indiekit/assets/813383/cb4ae1b9-3b7e-4310-bfc7-be33bd2db1fe) |
