### PR TITLE
Fix add another re-cloning elements in geo and file inputs 

### DIFF
--- a/packages/frontend/components/file-input/index.js
+++ b/packages/frontend/components/file-input/index.js
@@ -9,29 +9,37 @@ export const FileInputFieldController = class extends HTMLElement {
 
     /** @type {HTMLElement} */
     this.$uploadProgress = this.querySelector(".file-input__progress");
-    this.$pathInput = this.querySelector(".file-input__path");
-
-    this.$filePickerTemplate = this.querySelector("#file-input-picker");
+    this.$fileInputPath = this.querySelector(".file-input__path");
+    this.$fileInputPicker = this.querySelector(".file-input__picker");
+    this.$fileInputPickerTemplate = this.querySelector("#file-input-picker");
     this.$errorMessageTemplate = this.querySelector("#error-message");
   }
 
   connectedCallback() {
-    // Create group to hold input and button
-    const $inputButtonGroup = document.createElement("div");
-    $inputButtonGroup.classList.add("input-button-group");
+    if (!this.$fileInputPicker) {
+      // Create group to hold input and button
+      const $inputButtonGroup = document.createElement("div");
+      $inputButtonGroup.classList.add("input-button-group");
 
-    // Create and display upload button
-    const $filePicker = this.$filePickerTemplate.content.cloneNode(true);
+      // Create upload button
+      const $fileInputPicker =
+        this.$fileInputPickerTemplate.content.cloneNode(true);
 
-    // Wrap input within `input-button-group` container
-    wrapElement(this.$pathInput, $inputButtonGroup);
+      // Wrap input within `input-button-group` container
+      wrapElement(this.$fileInputPath, $inputButtonGroup);
 
-    // Add button to `input-button-group` container
-    $inputButtonGroup.append($filePicker);
+      // Add button to `input-button-group` container
+      $inputButtonGroup.append($fileInputPicker);
 
-    // Make label behave like a button
-    const $pickerLabel = this.querySelector(`label[role="button"]`);
-    $pickerLabel.addEventListener("keydown", (event) => {
+      // Update `this.$fileInputPicker`
+      this.$fileInputPicker = this.querySelector(".file-input__picker");
+    }
+
+    // Make file input label behave like a button to trigger file input
+    const $fileInputButton =
+      this.$fileInputPicker.querySelector(`.file-input__button`);
+
+    $fileInputButton.addEventListener("keydown", (event) => {
       // Prevent default behaviour, including scrolling using spacebar
       if (["Spacebar", " ", "Enter"].includes(event.key)) {
         event.preventDefault();
@@ -42,7 +50,7 @@ export const FileInputFieldController = class extends HTMLElement {
       }
     });
 
-    $pickerLabel.addEventListener("keyup", (event) => {
+    $fileInputButton.addEventListener("keyup", (event) => {
       if (["Spacebar", " "].includes(event.key)) {
         event.preventDefault();
         event.target.click();
@@ -50,8 +58,9 @@ export const FileInputFieldController = class extends HTMLElement {
     });
 
     // Add event to file input
-    const $pickerInput = this.querySelector(`input[type="file"]`);
-    $pickerInput.addEventListener("change", (event) => this.fetch(event));
+    const $fileInputFile =
+      this.$fileInputPicker.querySelector(`.file-input__file`);
+    $fileInputFile.addEventListener("change", (event) => this.fetch(event));
   }
 
   /**
@@ -65,7 +74,7 @@ export const FileInputFieldController = class extends HTMLElement {
     formData.append("file", event.target.files[0]);
 
     try {
-      this.$pathInput.readOnly = true;
+      this.$fileInputPath.readOnly = true;
 
       const endpointResponse = await fetch(this.endpoint, {
         method: "POST",
@@ -73,16 +82,17 @@ export const FileInputFieldController = class extends HTMLElement {
       });
 
       if (endpointResponse.ok) {
-        this.$pathInput.value = await endpointResponse.headers.get("location");
+        this.$fileInputPath.value =
+          await endpointResponse.headers.get("location");
       } else {
         this.showErrorMessage(endpointResponse.statusText);
       }
 
-      this.$pathInput.readOnly = false;
+      this.$fileInputPath.readOnly = false;
       this.$uploadProgress.hidden = true;
     } catch (error) {
       this.showErrorMessage(error);
-      this.$pathInput.readOnly = false;
+      this.$fileInputPath.readOnly = false;
       this.$uploadProgress.hidden = true;
     }
   }

--- a/packages/frontend/components/file-input/template.njk
+++ b/packages/frontend/components/file-input/template.njk
@@ -32,8 +32,10 @@
     }
   }) }}
   <template id="file-input-picker">
-    <label class="button button--secondary" for="{{ id }}-file" role="button" tabindex="0">{{ __("fileInput.uploadFile") }}</label>
-    <input hidden id="{{ id }}-file" type="file"{% if opts.accept %} accept="{{ opts.accept }}"{% endif %}>
+    <div class="file-input__picker">
+      <label class="file-input__button button button--secondary" for="{{ id }}-file" role="button" tabindex="0">{{ __("fileInput.uploadFile") }}</label>
+      <input class="file-input__file" hidden id="{{ id }}-file" type="file"{% if opts.accept %} accept="{{ opts.accept }}"{% endif %}>
+    </div>
   </template>
   <template id="error-message">
     {{ errorMessage({

--- a/packages/frontend/components/geo-input/index.js
+++ b/packages/frontend/components/geo-input/index.js
@@ -5,13 +5,13 @@ export const GeoInputFieldComponent = class extends HTMLElement {
   constructor() {
     super();
 
-    this.$geoInput = this.querySelector("input");
+    this.$geoInput = this.querySelector(".geo-input");
+    this.$geoInputButton = this.querySelector(".geo-input__button");
+    this.$geoInputButtonTemplate = this.querySelector("#geo-input-button");
+    this.$errorMessageTemplate = this.querySelector("#error-message");
 
     this.i18nDenied = this.getAttribute("i18n-denied");
     this.i18nFailed = this.getAttribute("i18n-failed");
-
-    this.$findButtonTemplate = this.querySelector("#find-button");
-    this.$errorMessageTemplate = this.querySelector("#error-message");
   }
 
   connectedCallback() {
@@ -19,22 +19,27 @@ export const GeoInputFieldComponent = class extends HTMLElement {
       return;
     }
 
-    // Create group to hold input and button
-    const $inputButtonGroup = document.createElement("div");
-    $inputButtonGroup.classList.add("input-button-group");
+    if (!this.$geoInputButton) {
+      // Create group to hold input and button
+      const $inputButtonGroup = document.createElement("div");
+      $inputButtonGroup.classList.add("input-button-group");
 
-    // Create and display find location button
-    let $findButton = this.$findButtonTemplate.content.cloneNode(true);
+      // Create find location button
+      const $geoInputButton =
+        this.$geoInputButtonTemplate.content.cloneNode(true);
 
-    // Wrap input within `input-button-group` container
-    wrapElement(this.$geoInput, $inputButtonGroup);
+      // Wrap input within `input-button-group` container
+      wrapElement(this.$geoInput, $inputButtonGroup);
 
-    // Add button to `input-button-group` container
-    $inputButtonGroup.append($findButton);
+      // Add find location button to `input-button-group` container
+      $inputButtonGroup.append($geoInputButton);
+
+      // Update `this.$geoInputButton`
+      this.$geoInputButton = this.querySelector(".geo-input__button");
+    }
 
     // Add event to cloned button
-    $findButton = this.querySelector("button");
-    $findButton.addEventListener("click", () => this.find());
+    this.$geoInputButton.addEventListener("click", () => this.find());
   }
 
   /**

--- a/packages/frontend/components/geo-input/template.njk
+++ b/packages/frontend/components/geo-input/template.njk
@@ -10,7 +10,7 @@
       "i18n-failed": __("geoInput.failed")
     }
   },
-  classes: opts.classes,
+  classes: classes("geo-input", opts),
   id: id,
   name: opts.name,
   value: opts.value,
@@ -19,9 +19,9 @@
   optional: opts.optional,
   errorMessage: opts.errorMessage
 }) %}
-  <template id="find-button">
+  <template id="geo-input-button">
     {{ button({
-      classes: "button--secondary",
+      classes: "geo-input__button button--secondary",
       type: "button",
       text: __("geoInput.getCurrentPosition")
     }) | indent(4) }}


### PR DESCRIPTION
Fixes #729.

Once we’ve instantiated new elements in the geo input and file input components (the find button for the geo input, the file picker ‘button’ for the file input), we don’t need to create them again when cloning (for example within the add another component).

Thanks to @tvararu for helping me debug this issue. :shipit: 