### PR TITLE
More detailed error messages for GitHub store CRUD operations

### DIFF
--- a/packages/store-github/index.js
+++ b/packages/store-github/index.js
@@ -1,11 +1,29 @@
 import process from "node:process";
 import { Buffer } from "node:buffer";
+import makeDebug from "debug";
 import { IndiekitError } from "@indiekit/error";
+
+const debug = makeDebug(`indiekit-store:github`);
 
 const defaults = {
   baseUrl: "https://api.github.com",
   branch: "main",
   token: process.env.GITHUB_TOKEN,
+};
+
+const crudErrorMessage = ({ error, operation, filePath, branch, repo }) => {
+  const summary = `could not ${operation} file ${filePath} in repo ${repo}, branch ${branch}`;
+
+  const details = [
+    `Original error message: ${error.message}`,
+    `Ensure the GitHub token is not expired and has the necessary permissions`,
+    `You can check your tokens here: https://github.com/settings/tokens`,
+  ];
+  if (operation !== "create") {
+    details.push(`Ensure the file exists`);
+  }
+
+  return `${summary}. ${details.join(". ")}`;
 };
 
 export default class GithubStore {
@@ -100,11 +118,29 @@ export default class GithubStore {
    * @see {@link https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents}
    */
   async createFile(filePath, content, { message }) {
-    const createResponse = await this.#client(filePath, "PUT", {
-      branch: this.options.branch,
-      content: Buffer.from(content).toString("base64"),
-      message,
-    });
+    const repo = this.options.repo;
+    const branch = this.options.branch;
+
+    let createResponse;
+    try {
+      debug(`try creating file ${filePath} in repo ${repo}, branch ${branch}`);
+      createResponse = await this.#client(filePath, "PUT", {
+        branch,
+        content: Buffer.from(content).toString("base64"),
+        message,
+      });
+      debug(`created file ${filePath}`);
+    } catch (error) {
+      const message = crudErrorMessage({
+        error,
+        operation: "create",
+        filePath,
+        repo,
+        branch,
+      });
+      debug(message);
+      throw new Error(message);
+    }
 
     const file = await createResponse.json();
 
@@ -118,9 +154,25 @@ export default class GithubStore {
    * @see {@link https://docs.github.com/en/rest/repos/contents#get-repository-content}
    */
   async readFile(filePath) {
-    const readResponse = await this.#client(
-      `${filePath}?ref=${this.options.branch}`,
-    );
+    const repo = this.options.repo;
+    const branch = this.options.branch;
+
+    let readResponse;
+    try {
+      debug(`try reading file ${filePath} in repo ${repo}, branch ${branch}`);
+      readResponse = await this.#client(`${filePath}?ref=${branch}`);
+    } catch (error) {
+      const message = crudErrorMessage({
+        error,
+        operation: "read",
+        filePath,
+        repo,
+        branch,
+      });
+      debug(message);
+      throw new Error(message);
+    }
+
     const { content } = await readResponse.json();
 
     return Buffer.from(content, "base64").toString("utf8");
@@ -137,22 +189,56 @@ export default class GithubStore {
    * @see {@link https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents}
    */
   async updateFile(filePath, content, { message, newPath }) {
-    const readResponse = await this.#client(
-      `${filePath}?ref=${this.options.branch}`,
-    );
+    const repo = this.options.repo;
+    const branch = this.options.branch;
+
+    let readResponse;
+    try {
+      debug(`try reading file ${filePath} in repo ${repo}, branch ${branch}`);
+      readResponse = await this.#client(`${filePath}?ref=${branch}`);
+    } catch (error) {
+      const message = crudErrorMessage({
+        error,
+        operation: "read",
+        filePath,
+        repo,
+        branch,
+      });
+      debug(message);
+      throw new Error(message);
+    }
+
     const { sha } = await readResponse.json();
     const updateFilePath = newPath || filePath;
-    const updateResponse = await this.#client(updateFilePath, "PUT", {
-      branch: this.options.branch,
-      content: Buffer.from(content).toString("base64"),
-      message,
-      sha: sha || false,
-    });
+
+    let updateResponse;
+    try {
+      debug(`try updating file ${filePath} in repo ${repo}, branch ${branch}`);
+      updateResponse = await this.#client(updateFilePath, "PUT", {
+        branch,
+        content: Buffer.from(content).toString("base64"),
+        message,
+        sha: sha || false,
+      });
+      debug(`updated file ${filePath}`);
+    } catch (error) {
+      const message = crudErrorMessage({
+        error,
+        operation: "update",
+        filePath,
+        repo,
+        branch,
+      });
+      debug(message);
+      throw new Error(message);
+    }
 
     const file = await updateResponse.json();
 
     if (newPath) {
+      debug(`try deleting file ${filePath} in repo ${repo}, branch ${branch}`);
       await this.deleteFile(filePath, { message });
+      debug(`deleted file ${filePath}`);
     }
 
     return file.content.html_url;
@@ -167,21 +253,60 @@ export default class GithubStore {
    * @see {@link https://docs.github.com/en/rest/repos/contents#delete-a-file}
    */
   async deleteFile(filePath, { message }) {
-    const readResponse = await this.#client(
-      `${filePath}?ref=${this.options.branch}`,
-    );
+    const repo = this.options.repo;
+    const branch = this.options.branch;
+
+    let readResponse;
+    try {
+      debug(`try reading file ${filePath} in repo ${repo}, branch ${branch}`);
+      readResponse = await this.#client(`${filePath}?ref=${branch}`);
+    } catch (error) {
+      const message = crudErrorMessage({
+        error,
+        operation: "read",
+        filePath,
+        repo,
+        branch,
+      });
+      debug(message);
+      throw new Error(message);
+    }
+
     const { sha } = await readResponse.json();
 
-    await this.#client(filePath, "DELETE", {
-      branch: this.options.branch,
-      message,
-      sha,
-    });
+    try {
+      debug(`try deleting file ${filePath} in repo ${repo}, branch ${branch}`);
+      await this.#client(filePath, "DELETE", {
+        branch,
+        message,
+        sha,
+      });
+      debug(`deleted file ${filePath}`);
+    } catch (error) {
+      const message = crudErrorMessage({
+        error,
+        operation: "delete",
+        filePath,
+        repo,
+        branch,
+      });
+      debug(message);
+      throw new Error(message);
+    }
 
     return true;
   }
 
   init(Indiekit) {
+    const required_configs = ["baseUrl", "branch", "repo", "token", "user"];
+    for (const required of required_configs) {
+      if (!this.options[required]) {
+        const message = `could not initialize ${this.name}: ${required} not set. See https://www.npmjs.com/package/@indiekit/store-github for details.`;
+        debug(message);
+        console.error(message);
+        throw new Error(message);
+      }
+    }
     Indiekit.addStore(this);
   }
 }


### PR DESCRIPTION
This PR tries to improve the error messages a user can encounter when performing CRUD operations on the GitHub content store. It also adds a few debug logs useful when troubleshooting such operations.

The debug logs of this PR can be selectively enabled by setting the DEBUG environment variable:

```txt
DEBUG="indiekit-store:github"
```