### PR TITLE
Ignore empty name property in post type discovery

### DIFF
--- a/packages/endpoint-micropub/lib/post-type-discovery.js
+++ b/packages/endpoint-micropub/lib/post-type-discovery.js
@@ -59,7 +59,7 @@ export const getPostType = (postTypes, properties) => {
   // If post has `name` and content, it’s an article
   // This is a deviation from the Post Type Algorithm, which identifies a post
   // as a note if the content is prefixed with the `name` value.
-  if (propertiesMap.has("name") && content) {
+  if (properties.name && content) {
     return "article";
   }
 

--- a/packages/endpoint-micropub/test/unit/post-type-discovery.js
+++ b/packages/endpoint-micropub/test/unit/post-type-discovery.js
@@ -17,6 +17,16 @@ describe("endpoint-media/lib/post-type-discovery", () => {
     assert.equal(result, "note");
   });
 
+  it("Discovers note post type (with an empty title)", () => {
+    const result = getPostType(postTypes, {
+      type: "entry",
+      name: "",
+      content: "Note content",
+    });
+
+    assert.equal(result, "note");
+  });
+
   it("Discovers article post type", () => {
     const result = getPostType(postTypes, {
       type: "entry",
@@ -82,6 +92,20 @@ describe("endpoint-media/lib/post-type-discovery", () => {
       content: {
         html: "<p>Article content in <em>HTML</em> format.</p>",
         text: "Article content in plaintext format.",
+      },
+    });
+
+    assert.equal(result, "article");
+  });
+
+  it("Discovers article post type (content begins with name)", () => {
+    // Indiekit deviates from the Post Type Algorithm, which identifies a post
+    // as a note if the content is prefixed with the `name` value.
+    const result = getPostType(postTypes, {
+      type: "entry",
+      name: "Article about something",
+      content: {
+        text: "Article about something fishy.",
       },
     });
 


### PR DESCRIPTION
Fixes #756.

Rather than check for the presence of the `name` property, check for the presence of a value assigned to `name`.