### PR TITLE
Prevent duplicates being created with the same URL

### DIFF
--- a/helpers/fixtures/jf2/note-slug-missing-no-name.jf2
+++ b/helpers/fixtures/jf2/note-slug-missing-no-name.jf2
@@ -1,4 +1,0 @@
-{
-  "type": "entry",
-  "content": "I ate a cheese sandwich, which was nice."
-}

--- a/helpers/mock-agent/store-gitea.js
+++ b/helpers/mock-agent/store-gitea.js
@@ -9,28 +9,39 @@ export function mockClient() {
   agent.disableNetConnect();
 
   const origin = /https:\/\/gitea\..*/;
-  const path = /\/api\/v1\/repos\/username\/repo\/contents\/\D{3}.md/;
+  const path = /\/api\/v1\/repos\/username\/repo\/contents\/(foo|bar).txt/;
   const getResponse = {
-    content: "Zm9vYmFy", // ‘foobar’ Base64 encoded
-    path: "foo.md",
+    content: "Zm9v", // ‘foo’ Base64 encoded
+    path: "foo.txt",
     sha: "1234",
   };
 
-  // Create file
+  // Create new file
+  agent
+    .get(origin)
+    .intercept({ path: /.*new\.txt/, method: "POST" })
+    .reply(201, (options) => ({
+      branch: "main",
+      commit: { html_url: `${options.origin}/username/repo/new.txt` },
+      path: "foo.txt",
+    }))
+    .persist();
+
+  // Create/update file
   agent
     .get(origin)
     .intercept({ path, method: "POST" })
     .reply(201, (options) => ({
       branch: "main",
-      commit: { html_url: `${options.origin}/username/repo/foo.md` },
-      path: "foo.md",
+      commit: { html_url: `${options.origin}/username/repo/foo.txt` },
+      path: "foo.txt",
     }))
     .persist();
 
   // Create file (Unauthorized)
   agent
     .get(origin)
-    .intercept({ path: /.*401\.md/, method: "POST" })
+    .intercept({ path: /.*401\.txt/, method: "POST" })
     .reply(401, { message: "Unauthorized" });
 
   // Read file
@@ -43,24 +54,25 @@ export function mockClient() {
   // Read file (Unauthorized)
   agent
     .get(origin)
-    .intercept({ path: /.*401\.md/, method: "GET" })
+    .intercept({ path: /.*401\.txt/, method: "GET" })
     .reply(401, { message: "Unauthorized" })
     .persist();
 
   // Read file (Not Found)
   agent
     .get(origin)
-    .intercept({ path: /.*404\.md/, method: "GET" })
-    .reply(404, { message: "Not found" });
+    .intercept({ path: /.*404\.txt/, method: "GET" })
+    .reply(404, { message: "Not found" })
+    .persist();
 
   // Update and rename file
   agent
     .get(origin)
-    .intercept({ path: /.*bar\.md/, method: "PUT" })
+    .intercept({ path: /.*bar\.txt/, method: "PUT" })
     .reply(200, (options) => ({
       branch: "main",
-      commit: { html_url: `${options.origin}/username/repo/bar.md` },
-      path: "bar.md",
+      commit: { html_url: `${options.origin}/username/repo/bar.txt` },
+      path: "bar.txt",
     }))
     .persist();
 
@@ -70,8 +82,8 @@ export function mockClient() {
     .intercept({ path, method: "PUT" })
     .reply(200, (options) => ({
       branch: "main",
-      commit: { html_url: `${options.origin}/username/repo/foo.md` },
-      path: "foo.md",
+      commit: { html_url: `${options.origin}/username/repo/foo.txt` },
+      path: "foo.txt",
     }))
     .persist();
 

--- a/helpers/mock-agent/store-gitlab.js
+++ b/helpers/mock-agent/store-gitlab.js
@@ -9,70 +9,90 @@ export function mockClient() {
   agent.disableNetConnect();
 
   const origin = /https:\/\/gitlab\..*/;
-  const filePath = /\/api\/v4\/projects\/.*\/repository\/files\/\D{3}.md/;
+  const filePath = /\/api\/v4\/projects\/.*\/repository\/files\/\D{3}.txt/;
   const commitPath = /\/api\/v4\/projects\/.*\/repository\/commits/;
 
   // Create file
   agent
     .get(origin)
     .intercept({ path: filePath, method: "POST" })
-    .reply(201, { file_path: "foo.md", branch: "main" })
+    .reply(
+      201,
+      { file_path: "foo.txt", branch: "main" },
+      { headers: { "content-type": "application/json" } },
+    )
     .persist();
 
   // Create file (Unauthorized)
   agent
     .get(origin)
-    .intercept({ path: /.*401\.md/, method: "POST" })
+    .intercept({ path: /.*401\.txt/, method: "POST" })
     .reply(401);
 
   // Read raw file
   agent
     .get(origin)
-    .intercept({ path: /.*\D{3}.md\/raw\?ref=main/ })
+    .intercept({ path: /.*\D{3}.txt\/raw\?ref=main/ })
     .reply(200, "foobar");
 
   // Read raw file (Unauthorized)
   agent
     .get(origin)
-    .intercept({ path: /.*401\.md\/raw\?ref=main/ })
+    .intercept({ path: /.*401\.txt\/raw\?ref=main/ })
     .reply(401);
 
   // Update file
   agent
     .get(origin)
     .intercept({ path: filePath, method: "PUT" })
-    .reply(200, { file_path: "foo.md", branch: "main" });
+    .reply(
+      200,
+      { file_path: "foo.txt", branch: "main" },
+      { headers: { "content-type": "application/json" } },
+    );
 
   // Update and rename file
   agent
     .get(origin)
     .intercept({ path: commitPath, method: "POST", body: /previous_path/ })
-    .reply(200, { file_path: "bar.md", message: "message" })
+    .reply(
+      200,
+      { file_path: "bar.txt", message: "message" },
+      { headers: { "content-type": "application/json" } },
+    )
     .persist();
 
   // Update commit
   agent
     .get(origin)
-    .intercept({ path: commitPath, method: "POST", body: /.*\D{3}.md/ })
-    .reply(200, { file_path: "foo.md", message: "message" })
+    .intercept({ path: commitPath, method: "POST", body: /.*\D{3}.txt/ })
+    .reply(
+      200,
+      { file_path: "foo.txt", message: "message" },
+      { headers: { "content-type": "application/json" } },
+    )
     .persist();
 
   // Update commit (Unauthorized)
   agent
     .get(origin)
-    .intercept({ path: commitPath, method: "POST", body: /.*401\.md/ })
+    .intercept({ path: commitPath, method: "POST", body: /.*401\.txt/ })
     .reply(401);
 
   // Delete file
   agent
     .get(origin)
     .intercept({ path: filePath, method: "DELETE" })
-    .reply(200, { commit: { message: "Message" }, content: {} });
+    .reply(
+      200,
+      { commit: { message: "Message" }, content: {} },
+      { headers: { "content-type": "application/json" } },
+    );
 
   // Delete file (Unauthorized)
   agent
     .get(origin)
-    .intercept({ path: /.*401\.md/, method: "DELETE" })
+    .intercept({ path: /.*401\.txt/, method: "DELETE" })
     .reply(401);
 
   return agent;

--- a/helpers/mock-agent/store-gitlab.js
+++ b/helpers/mock-agent/store-gitlab.js
@@ -15,10 +15,10 @@ export function mockClient() {
   // Create file
   agent
     .get(origin)
-    .intercept({ path: filePath, method: "POST" })
+    .intercept({ path: /.*new\.txt/, method: "POST" })
     .reply(
       201,
-      { file_path: "foo.txt", branch: "main" },
+      { file_path: "new.txt", branch: "main" },
       { headers: { "content-type": "application/json" } },
     )
     .persist();
@@ -29,17 +29,36 @@ export function mockClient() {
     .intercept({ path: /.*401\.txt/, method: "POST" })
     .reply(401);
 
+  // Read file
+  agent
+    .get(origin)
+    .intercept({ path: /.*(foo|bar).txt\?ref=main/ })
+    .reply(
+      200,
+      { content: "Zm9v" }, // ‘foo’ Base64 encoded
+      { headers: { "content-type": "application/json" } },
+    )
+    .persist();
+
   // Read raw file
   agent
     .get(origin)
-    .intercept({ path: /.*\D{3}.txt\/raw\?ref=main/ })
-    .reply(200, "foobar");
+    .intercept({ path: /.*(foo|bar).txt\/raw\?ref=main/ })
+    .reply(200, "foo")
+    .persist();
 
   // Read raw file (Unauthorized)
   agent
     .get(origin)
     .intercept({ path: /.*401\.txt\/raw\?ref=main/ })
     .reply(401);
+
+  // Read raw file (Not Found)
+  agent
+    .get(origin)
+    .intercept({ path: /.*404\.txt/ })
+    .reply(404)
+    .persist();
 
   // Update file
   agent
@@ -65,7 +84,7 @@ export function mockClient() {
   // Update commit
   agent
     .get(origin)
-    .intercept({ path: commitPath, method: "POST", body: /.*\D{3}.txt/ })
+    .intercept({ path: commitPath, method: "POST", body: /.*(foo|bar).txt/ })
     .reply(
       200,
       { file_path: "foo.txt", message: "message" },

--- a/indiekit.config.js
+++ b/indiekit.config.js
@@ -50,12 +50,12 @@ const config = {
       },
       photo: {
         post: {
-          path: "_photos/{yyyy}-{MM}-{dd}-{n}.markdown",
-          url: "photos/{yyyy}/{DDD}/p{n}/",
+          path: "_photos/{yyyy}-{MM}-{dd}-{slug}.markdown",
+          url: "photos/{yyyy}/{DDD}/{slug}/",
         },
         media: {
-          path: "media/photos/{yyyy}/{DDD}/p{n}/{filename}",
-          url: "media/photos/{yyyy}/{DDD}/p{n}/{filename}",
+          path: "media/photos/{yyyy}/{DDD}/{slug}/{filename}",
+          url: "media/photos/{yyyy}/{DDD}/{slug}/{filename}",
         },
       },
     },

--- a/packages/endpoint-media/lib/media-data.js
+++ b/packages/endpoint-media/lib/media-data.js
@@ -58,9 +58,10 @@ export const mediaData = {
 
     const mediaData = { path, properties };
 
-    // Add data to media collection (if present)
+    // Add data to media collection (or replace existing if present)
     if (hasDatabase) {
-      await media.insertOne(mediaData);
+      const query = { "properties.url": properties.url };
+      await media.replaceOne(query, mediaData, { upsert: true });
     }
 
     return mediaData;

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -1,4 +1,4 @@
-import { getDate, randomString, slugify } from "@indiekit/util";
+import { getDate, md5, slugify } from "@indiekit/util";
 import {
   fetchReferences,
   mf2tojf2,
@@ -236,7 +236,7 @@ export const getVideoProperty = (properties, me) => {
  */
 export const getSlugProperty = (properties, separator) => {
   const suggested = properties["mp-slug"];
-  const { name } = properties;
+  const { name, published } = properties;
 
   let string;
   if (suggested) {
@@ -244,9 +244,7 @@ export const getSlugProperty = (properties, separator) => {
   } else if (name) {
     string = excerptString(name, 5);
   } else {
-    string = randomString(5)
-      .replace("_", "0") // Slugify function strips any leading underscore
-      .replace(separator, "0"); // Don’t include slug separator character
+    string = md5(published).slice(0, 5);
   }
 
   return slugify(string, { separator });

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -60,9 +60,13 @@ export const postData = {
 
     const postData = { path, properties };
 
-    // Add data to posts collection (if present)
+    // Add data to posts collection (or replace existing if present)
     if (hasDatabase) {
-      await posts.insertOne(postData, { checkKeys: false });
+      const query = { "properties.url": properties.url };
+      await posts.replaceOne(query, postData, {
+        checkKeys: false,
+        upsert: true,
+      });
     }
 
     return postData;

--- a/packages/endpoint-micropub/test/unit/jf2.js
+++ b/packages/endpoint-micropub/test/unit/jf2.js
@@ -323,7 +323,7 @@ describe("endpoint-micropub/lib/jf2", () => {
 
   it("Derives slug by generating random string", () => {
     const properties = JSON.parse(
-      getFixture("jf2/note-slug-missing-no-name.jf2"),
+      getFixture("jf2/note-published-provided.jf2"),
     );
     const result = getSlugProperty(properties, "-");
 

--- a/packages/store-bitbucket/index.js
+++ b/packages/store-bitbucket/index.js
@@ -76,6 +76,28 @@ export default class BitbucketStore {
   }
 
   /**
+   * Check if file exists
+   * @param {string} filePath - Path to file
+   * @returns {Promise<boolean>} File exists
+   * @see {@link https://bitbucketjs.netlify.app/#api-repositories-repositories_readSrc}
+   */
+  async fileExists(filePath) {
+    try {
+      await this.#client.repositories.readSrc({
+        format: "meta",
+        commit: this.options.branch,
+        path: filePath,
+        repo_slug: this.options.repo,
+        workspace: this.options.user,
+      });
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Create file
    * @param {string} filePath - Path to file
    * @param {string} content - File content
@@ -86,6 +108,11 @@ export default class BitbucketStore {
    */
   async createFile(filePath, content, { message }) {
     try {
+      const fileExists = await this.fileExists(filePath);
+      if (fileExists) {
+        return;
+      }
+
       await this.#client.repositories.createSrcFileCommit({
         [filePath]: content,
         branch: this.options.branch,

--- a/packages/store-file-system/index.js
+++ b/packages/store-file-system/index.js
@@ -58,6 +58,10 @@ export default class FileSystemStore {
       const absolutePath = this.#absolutePath(filePath);
       const dirname = path.dirname(absolutePath);
 
+      if (existsSync(absolutePath)) {
+        return;
+      }
+
       if (!existsSync(dirname)) {
         await fs.mkdir(dirname, { recursive: true });
       }

--- a/packages/store-file-system/test/index.js
+++ b/packages/store-file-system/test/index.js
@@ -50,6 +50,14 @@ describe("store-file-system", () => {
     assert.equal(await fs.readFile("directory/foo.txt", "utf8"), "foo");
   });
 
+  it("Doesn’t create file if already exists", async () => {
+    mockFs({ "directory/bar.txt": "foo" });
+
+    const result = await fileSystem.createFile("bar.txt", "foo");
+
+    assert.equal(result, undefined);
+  });
+
   it("Throws error creating file", async () => {
     mockFs();
 

--- a/packages/store-ftp/index.js
+++ b/packages/store-ftp/index.js
@@ -118,6 +118,12 @@ export default class FtpStore {
       const readableStream = this.#createReadableStream(content);
       const absolutePath = this.#absolutePath(filePath);
 
+      // Return if file already exists
+      const fileExists = await client.exists(absolutePath);
+      if (fileExists) {
+        return;
+      }
+
       // Create directory if doesn’t exist
       const directory = path.dirname(absolutePath);
       const directoryType = await client.exists(directory);

--- a/packages/store-ftp/test/index.js
+++ b/packages/store-ftp/test/index.js
@@ -75,6 +75,12 @@ describe("store-ftp", () => {
     );
   });
 
+  it("Doesn’t create file if already exists", async () => {
+    await ftp.createFile("foo.md", "foobar");
+
+    assert.equal(await ftp.createFile("foo.md", "foobar"), undefined);
+  });
+
   it("Throws error creating file", async () => {
     await assert.rejects(ftp.createFile(undefined, ""), {
       message: `FTP store: The "path" argument must be of type string. Received undefined`,

--- a/packages/store-gitea/index.js
+++ b/packages/store-gitea/index.js
@@ -105,6 +105,22 @@ export default class GiteaStore {
   }
 
   /**
+   * Check if file exists
+   * @param {string} filePath - Path to file
+   * @returns {Promise<boolean>} File exists
+   * @see {@link https://bitbucketjs.netlify.app/#api-repositories-repositories_readSrc}
+   */
+  async fileExists(filePath) {
+    try {
+      await this.#client(`${filePath}?ref=${this.options.branch}`);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Create file
    * @param {string} filePath - Path to file
    * @param {string} content - File content
@@ -114,6 +130,11 @@ export default class GiteaStore {
    * @see {@link https://gitea.com/api/swagger#/repository/repoCreateFile}
    */
   async createFile(filePath, content, { message }) {
+    const fileExists = await this.fileExists(filePath);
+    if (fileExists) {
+      return;
+    }
+
     const createResponse = await this.#client(filePath, "POST", {
       branch: this.options.branch,
       content: Buffer.from(content).toString("base64"),

--- a/packages/store-gitea/test/index.js
+++ b/packages/store-gitea/test/index.js
@@ -47,25 +47,38 @@ describe("store-github", async () => {
     assert.equal(indiekit.publication.store.info.name, "user/repo on Gitea");
   });
 
+  it("Checks if file exists", async () => {
+    assert.equal(await gitea.fileExists("foo.txt"), true);
+    assert.equal(await gitea.fileExists("404.txt"), false);
+  });
+
   it("Creates file", async () => {
-    const result = await gitea.createFile("foo.md", "foo", {
+    const result = await gitea.createFile("new.txt", "new", {
       message: "Message",
     });
 
-    assert.equal(result, "https://gitea.com/username/repo/foo.md");
+    assert.equal(result, "https://gitea.com/username/repo/new.txt");
+  });
+
+  it("Doesn’t create file if already exists", async () => {
+    const result = await gitea.createFile("foo.txt", "foo", {
+      message: "Message",
+    });
+
+    assert.equal(result, undefined);
   });
 
   it("Creates file at custom instance", async () => {
-    const result = await giteaInstance.createFile("foo.md", "foo", {
+    const result = await giteaInstance.createFile("new.txt", "foo", {
       message: "Message",
     });
 
-    assert.equal(result, "https://gitea.instance/username/repo/foo.md");
+    assert.equal(result, "https://gitea.instance/username/repo/new.txt");
   });
 
   it("Throws error creating file", async () => {
     await assert.rejects(
-      gitea.createFile("401.md", "foo", { message: "Message" }),
+      gitea.createFile("401.txt", "foo", { message: "Message" }),
       {
         message: "Gitea store: Unauthorized",
       },
@@ -73,37 +86,37 @@ describe("store-github", async () => {
   });
 
   it("Reads file", async () => {
-    const result = await gitea.readFile("foo.md");
+    const result = await gitea.readFile("foo.txt");
 
-    assert.equal(result, "foobar");
+    assert.equal(result, "foo");
   });
 
   it("Throws error reading file", async () => {
-    await assert.rejects(gitea.readFile("404.md"), {
+    await assert.rejects(gitea.readFile("404.txt"), {
       message: "Gitea store: Not found",
     });
   });
 
   it("Updates file", async () => {
-    const result = await gitea.updateFile("foo.md", "foo", {
+    const result = await gitea.updateFile("foo.txt", "foo", {
       message: "Message",
     });
 
-    assert.equal(result, "https://gitea.com/username/repo/foo.md");
+    assert.equal(result, "https://gitea.com/username/repo/foo.txt");
   });
 
   it("Updates and renames file", async () => {
-    const result = await gitea.updateFile("foo.md", "foo", {
+    const result = await gitea.updateFile("foo.txt", "foo", {
       message: "Message",
-      newPath: "bar.md",
+      newPath: "bar.txt",
     });
 
-    assert.equal(result, "https://gitea.com/username/repo/bar.md");
+    assert.equal(result, "https://gitea.com/username/repo/bar.txt");
   });
 
   it("Throws error updating file", async () => {
     await assert.rejects(
-      gitea.updateFile("401.md", "foo", { message: "Message" }),
+      gitea.updateFile("401.txt", "foo", { message: "Message" }),
       {
         message: "Gitea store: Unauthorized",
       },
@@ -111,13 +124,13 @@ describe("store-github", async () => {
   });
 
   it("Deletes a file", async () => {
-    const result = await gitea.deleteFile("foo.md", { message: "Message" });
+    const result = await gitea.deleteFile("foo.txt", { message: "Message" });
 
     assert.equal(result, true);
   });
 
   it("Throws error deleting a file", async () => {
-    await assert.rejects(gitea.deleteFile("401.md", { message: "Message" }), {
+    await assert.rejects(gitea.deleteFile("401.txt", { message: "Message" }), {
       message: "Gitea store: Unauthorized",
     });
   });

--- a/packages/store-github/test/index.js
+++ b/packages/store-github/test/index.js
@@ -41,37 +41,50 @@ describe("store-github", async () => {
     assert.equal(indiekit.publication.store.info.name, "user/repo on GitHub");
   });
 
+  it("Checks if file exists", async () => {
+    assert.equal(await github.fileExists("foo.txt"), true);
+    assert.equal(await github.fileExists("404.txt"), false);
+  });
+
   it("Creates file", async () => {
-    const result = await github.createFile("foo.md", "foobar", {
+    const result = await github.createFile("new.txt", "new", {
       message: "Message",
     });
 
-    assert.equal(result, "https://github.com/user/repo/blob/main/foo.txt");
+    assert.equal(result, "https://github.com/user/repo/blob/main/new.txt");
+  });
+
+  it("Doesn’t create file if already exists", async () => {
+    const result = await github.createFile("foo.txt", "foo", {
+      message: "Message",
+    });
+
+    assert.equal(result, undefined);
   });
 
   it("Throws error creating file", async () => {
     await assert.rejects(
-      github.createFile("401.md", "foobar", { message: "Message" }),
+      github.createFile("401.txt", "foo", { message: "Message" }),
       (error) => {
-        assert(error.message.includes("Could not create file 401.md"));
+        assert(error.message.includes("Could not create file 401.txt"));
         return true;
       },
     );
   });
 
   it("Reads file", async () => {
-    assert.equal(await github.readFile("foo.md"), "foobar");
+    assert.equal(await github.readFile("foo.txt"), "foo");
   });
 
   it("Throws error reading file", async () => {
-    await assert.rejects(github.readFile("404.md"), (error) => {
-      assert(error.message.includes("Could not read file 404.md"));
+    await assert.rejects(github.readFile("404.txt"), (error) => {
+      assert(error.message.includes("Could not read file 404.txt"));
       return true;
     });
   });
 
   it("Updates file", async () => {
-    const result = await github.updateFile("foo.md", "foobar", {
+    const result = await github.updateFile("foo.txt", "foo", {
       message: "Message",
     });
 
@@ -79,16 +92,16 @@ describe("store-github", async () => {
   });
 
   it("Updates and renames file", async () => {
-    const result = await github.updateFile("foo.md", "qux", {
+    const result = await github.updateFile("foo.txt", "qux", {
       message: "Message",
-      newPath: "bar.md",
+      newPath: "bar.txt",
     });
 
     assert.equal(result, "https://github.com/user/repo/blob/main/bar.txt");
   });
 
   it("Creates file if original Not Found in repository", async () => {
-    const result = await github.updateFile("bar.md", "foobar", {
+    const result = await github.updateFile("bar.txt", "foo", {
       message: "Message",
     });
 
@@ -97,23 +110,23 @@ describe("store-github", async () => {
 
   it("Throws error updating file", async () => {
     await assert.rejects(
-      github.updateFile("401.md", "foobar", { message: "Message" }),
+      github.updateFile("401.txt", "foo", { message: "Message" }),
       (error) => {
-        assert(error.message.includes("Could not read file 401.md"));
+        assert(error.message.includes("Could not read file 401.txt"));
         return true;
       },
     );
   });
 
   it("Deletes a file", async () => {
-    assert.ok(await github.deleteFile("foo.md", { message: "Message" }));
+    assert.ok(await github.deleteFile("foo.txt", { message: "Message" }));
   });
 
   it("Throws error file Not Found in repository", async () => {
     await assert.rejects(
-      github.deleteFile("404.md", { message: "Message" }),
+      github.deleteFile("404.txt", { message: "Message" }),
       (error) => {
-        assert(error.message.includes("Could not read file 404.md"));
+        assert(error.message.includes("Could not read file 404.txt"));
         return true;
       },
     );
@@ -121,9 +134,9 @@ describe("store-github", async () => {
 
   it.skip("Throws error deleting a file", async () => {
     await assert.rejects(
-      github.deleteFile("401.md", { message: "Message" }),
+      github.deleteFile("401.txt", { message: "Message" }),
       (error) => {
-        assert(error.message.includes("Could not delete file 401.md"));
+        assert(error.message.includes("Could not delete file 401.txt"));
         return true;
       },
     );

--- a/packages/store-gitlab/index.js
+++ b/packages/store-gitlab/index.js
@@ -86,6 +86,26 @@ export default class GitlabStore {
   }
 
   /**
+   * Check if file exists
+   * @param {string} filePath - Path to file
+   * @returns {Promise<boolean>} File exists
+   * @see {@link https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository}
+   */
+  async fileExists(filePath) {
+    try {
+      await this.#client.RepositoryFiles.show(
+        this.projectId,
+        filePath,
+        this.options.branch,
+      );
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Create file
    * @param {string} filePath - Path to file
    * @param {string} content - File content
@@ -96,6 +116,11 @@ export default class GitlabStore {
    */
   async createFile(filePath, content, { message }) {
     try {
+      const fileExists = await this.fileExists(filePath);
+      if (fileExists) {
+        return;
+      }
+
       const createResponse = await this.#client.RepositoryFiles.create(
         this.projectId,
         filePath,

--- a/packages/store-gitlab/test/index.js
+++ b/packages/store-gitlab/test/index.js
@@ -50,24 +50,24 @@ describe("store-gitlab", async () => {
   });
 
   it("Creates file", { timeout: 60 }, async () => {
-    const result = await gitlab.createFile("foo.md", "foo", {
+    const result = await gitlab.createFile("foo.txt", "foo", {
       message: "Message",
     });
 
-    assert.equal(result, "https://gitlab.com/username/repo/foo.md");
+    assert.equal(result, "https://gitlab.com/username/repo/foo.txt");
   });
 
   it("Creates file with projectId at custom instance", async () => {
-    const result = await gitlabInstance.createFile("foo.md", "foo", {
+    const result = await gitlabInstance.createFile("foo.txt", "foo", {
       message: "Message",
     });
 
-    assert.equal(result, "https://gitlab.instance/projects/1234/foo.md");
+    assert.equal(result, "https://gitlab.instance/projects/1234/foo.txt");
   });
 
   it("Throws error creating file", async () => {
     await assert.rejects(
-      gitlab.createFile("401.md", "foo", { message: "Message" }),
+      gitlab.createFile("401.txt", "foo", { message: "Message" }),
       {
         message: "GitLab store: Unauthorized",
       },
@@ -75,37 +75,37 @@ describe("store-gitlab", async () => {
   });
 
   it("Reads file", async () => {
-    const result = await gitlab.readFile("foo.md");
+    const result = await gitlab.readFile("foo.txt");
 
     assert.equal(result, "foobar");
   });
 
   it("Throws error reading file", async () => {
-    await assert.rejects(gitlab.readFile("401.md"), {
+    await assert.rejects(gitlab.readFile("401.txt"), {
       message: "GitLab store: Unauthorized",
     });
   });
 
   it("Updates file", async () => {
-    const result = await gitlab.updateFile("foo.md", "foo", {
+    const result = await gitlab.updateFile("foo.txt", "foo", {
       message: "Message",
     });
 
-    assert.equal(result, "https://gitlab.com/username/repo/foo.md");
+    assert.equal(result, "https://gitlab.com/username/repo/foo.txt");
   });
 
   it("Updates and renames file", async () => {
-    const result = await gitlab.updateFile("foo.md", "foo", {
+    const result = await gitlab.updateFile("foo.txt", "foo", {
       message: "Message",
-      newPath: "bar.md",
+      newPath: "bar.txt",
     });
 
-    assert.equal(result, "https://gitlab.com/username/repo/bar.md");
+    assert.equal(result, "https://gitlab.com/username/repo/bar.txt");
   });
 
   it("Throws error updating file", async () => {
     await assert.rejects(
-      gitlab.updateFile("401.md", "foo", { message: "Message" }),
+      gitlab.updateFile("401.txt", "foo", { message: "Message" }),
       {
         message: "GitLab store: Unauthorized",
       },
@@ -113,13 +113,13 @@ describe("store-gitlab", async () => {
   });
 
   it("Deletes a file", async () => {
-    const result = await gitlab.deleteFile("foo.md", { message: "Message" });
+    const result = await gitlab.deleteFile("foo.txt", { message: "Message" });
 
     assert.equal(result, true);
   });
 
   it("Throws error deleting a file", async () => {
-    await assert.rejects(gitlab.deleteFile("401.md", { message: "Message" }), {
+    await assert.rejects(gitlab.deleteFile("401.txt", { message: "Message" }), {
       message: "GitLab store: Unauthorized",
     });
   });

--- a/packages/store-gitlab/test/index.js
+++ b/packages/store-gitlab/test/index.js
@@ -49,20 +49,33 @@ describe("store-gitlab", async () => {
     );
   });
 
-  it("Creates file", { timeout: 60 }, async () => {
+  it("Checks if file exists", async () => {
+    assert.equal(await gitlab.fileExists("foo.txt"), true);
+    assert.equal(await gitlab.fileExists("404.txt"), false);
+  });
+
+  it("Creates file", async () => {
+    const result = await gitlab.createFile("new.txt", "new", {
+      message: "Message",
+    });
+
+    assert.equal(result, "https://gitlab.com/username/repo/new.txt");
+  });
+
+  it("Doesn’t create file if already exists", async () => {
     const result = await gitlab.createFile("foo.txt", "foo", {
       message: "Message",
     });
 
-    assert.equal(result, "https://gitlab.com/username/repo/foo.txt");
+    assert.equal(result, undefined);
   });
 
   it("Creates file with projectId at custom instance", async () => {
-    const result = await gitlabInstance.createFile("foo.txt", "foo", {
+    const result = await gitlabInstance.createFile("new.txt", "new", {
       message: "Message",
     });
 
-    assert.equal(result, "https://gitlab.instance/projects/1234/foo.txt");
+    assert.equal(result, "https://gitlab.instance/projects/1234/new.txt");
   });
 
   it("Throws error creating file", async () => {
@@ -77,7 +90,7 @@ describe("store-gitlab", async () => {
   it("Reads file", async () => {
     const result = await gitlab.readFile("foo.txt");
 
-    assert.equal(result, "foobar");
+    assert.equal(result, "foo");
   });
 
   it("Throws error reading file", async () => {

--- a/packages/store-s3/index.js
+++ b/packages/store-s3/index.js
@@ -62,6 +62,26 @@ export default class S3Store {
   }
 
   /**
+   * Check if file exists
+   * @param {string} filePath - Path to file
+   * @returns {Promise<boolean>} File exists
+   */
+  async fileExists(filePath) {
+    try {
+      const getCommand = new GetObjectCommand({
+        Bucket: this.options.bucket,
+        Key: filePath,
+      });
+
+      await this.client().send(getCommand);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Create file
    * @param {string} filePath - Path to file
    * @param {string} content - File content
@@ -75,6 +95,11 @@ export default class S3Store {
     });
 
     try {
+      const fileExists = await this.fileExists(filePath);
+      if (fileExists) {
+        return;
+      }
+
       const { ETag } = await this.client().send(putCommand);
 
       if (ETag) {

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -10,6 +10,6 @@ export {
 } from "./lib/date.js";
 export { sanitise } from "./lib/object.js";
 export { ISO_6709_RE } from "./lib/regex.js";
-export { randomString, slugify, supplant } from "./lib/string.js";
+export { md5, randomString, slugify, supplant } from "./lib/string.js";
 export { getCanonicalUrl, isSameOrigin } from "./lib/url.js";
 export { isRequired } from "./lib/validation-schema.js";

--- a/packages/util/lib/string.js
+++ b/packages/util/lib/string.js
@@ -1,5 +1,12 @@
-import { randomBytes } from "node:crypto";
+import { randomBytes, createHash } from "node:crypto";
 import slugifyString from "@sindresorhus/slugify";
+
+/**
+ * Generate MD5 hashed string
+ * @param {string} string - String
+ * @returns {string} MD5 hashed string
+ */
+export const md5 = (string) => createHash("md5").update(string).digest("hex");
 
 /**
  * Generate cryptographically random string

--- a/packages/util/test/unit/string.js
+++ b/packages/util/test/unit/string.js
@@ -1,9 +1,15 @@
 import { strict as assert } from "node:assert";
 import { Buffer } from "node:buffer";
 import { describe, it } from "node:test";
-import { randomString, slugify, supplant } from "../../lib/string.js";
+import { md5, randomString, slugify, supplant } from "../../lib/string.js";
 
 describe("util/lib/string", () => {
+  it("Generates MD5 hashed string", () => {
+    const result = md5("foo");
+
+    assert.equal(result, "acbd18db4cc2f85cedef654fccc4a4d8");
+  });
+
   it("Generates cryptographically random string", () => {
     const result = randomString(8);
 


### PR DESCRIPTION
Fixes #731.

- [x] Use md5 hash of published date to create `slug` token; this means the slug remains a constant value, and therefore so does the URL (including those that include a `slug` token)
- [x] Use `replaceOne` with `upsert` when creating new posts
- [x] Use `replaceOne` with `upsert` when creating new files
- [x] Update Bitbucket store to not attempt to create a new file if already exists
- [x] Update file system store to not create a new file if already exists
- [x] Update FTP store to not create a new file if already exists
- [x] Update GitHub store to not create a new file if already exists
- [x] Update Gitea store to not create a new file if already exists
- [x] Update GitLab store to not create a new file if already exists
- [x] Update S3 store to not create a new file if already exists