### PR TITLE
VS Code launch configuration to debug the user's Indiekit installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:fix": "npm run lint:prettier:fix && npm run lint:js:fix && npm run lint:css:fix",
     "test": "node --test --test-reporter=spec",
     "test:coverage": "node --test --experimental-test-coverage",
+    "test:create-indiekit": "lerna run test --scope create-indiekit",
     "test:lcov": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/lcov.info"
   },
   "workspaces": [

--- a/packages/create-indiekit/files/template.vscode_launch.json
+++ b/packages/create-indiekit/files/template.vscode_launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Indiekit",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/node_modules/@indiekit/indiekit/bin/cli.js",
+      // "args": ["--config", "path/to/your/indiekit.config.js"]
+      "args": ["serve"],
+      "env": {
+        "GITHUB_TOKEN": "${env:GITHUB_TOKEN}",
+        "MONGO_URL": "${env:MONGO_URL}"
+      }
+    }
+  ]
+}

--- a/packages/create-indiekit/lib/files.js
+++ b/packages/create-indiekit/lib/files.js
@@ -39,6 +39,10 @@ export const getFiles = async (setup) => {
       path: ".gitignore",
       contents: await getFileContents("template.gitignore"),
     },
+    {
+      path: path.join(".vscode", "launch.json"),
+      contents: await getFileContents("template.vscode_launch.json"),
+    },
   ];
 
   if (useDocker) {

--- a/packages/create-indiekit/package.json
+++ b/packages/create-indiekit/package.json
@@ -19,7 +19,7 @@
   "type": "module",
   "main": "index.js",
   "bin": {
-    "create-indiekit": "bin/create.js"
+    "create-indiekit": "bin/create.js delete-me"
   },
   "files": [
     "bin",
@@ -34,6 +34,10 @@
     "type": "git",
     "url": "https://github.com/getindiekit/indiekit.git",
     "directory": "packages/create-indiekit"
+  },
+  "scripts": {
+    "create": "node bin/create.js",
+    "test": "node --test --test-reporter=spec"
   },
   "dependencies": {
     "@indiekit/preset-eleventy": "^1.0.0-beta.10",

--- a/packages/create-indiekit/test/unit/files.js
+++ b/packages/create-indiekit/test/unit/files.js
@@ -1,4 +1,5 @@
 import { strict as assert } from "node:assert";
+import path from "node:path";
 import { describe, it, mock } from "node:test";
 import { getFileContents, getFiles } from "../../lib/files.js";
 
@@ -23,16 +24,17 @@ describe("create-indiekit/lib/files", () => {
   it("Gets files to create", async () => {
     const result = await getFiles({ me: "https://website.example" });
 
-    assert.deepEqual(result, [
-      {
-        path: "README.md",
-        contents: `# Indiekit server for https://website.example\n\nLearn more at <https://getindiekit.com>\n`,
-      },
-      {
-        path: ".gitignore",
-        contents: "node_modules/\n",
-      },
-    ]);
+    assert.deepEqual(result[0], {
+      path: "README.md",
+      contents: `# Indiekit server for https://website.example\n\nLearn more at <https://getindiekit.com>\n`,
+    });
+
+    assert.deepEqual(result[1], {
+      path: ".gitignore",
+      contents: "node_modules/\n",
+    });
+
+    assert.equal(result[2].path, path.join(".vscode", "launch.json"));
   });
 
   it("Gets files to create, including docker files", async () => {
@@ -41,8 +43,8 @@ describe("create-indiekit/lib/files", () => {
       useDocker: true,
     });
 
-    assert.equal(result[2].path, "docker-compose.yml");
-    assert.equal(result[3].path, "Dockerfile");
-    assert.equal(result[4].path, ".dockerignore");
+    assert.equal(result[3].path, "docker-compose.yml");
+    assert.equal(result[4].path, "Dockerfile");
+    assert.equal(result[5].path, ".dockerignore");
   });
 });


### PR DESCRIPTION
This PR adds a template for a VS Code [launch configuration](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) that will be will materialize at `.vscode/launch.json` in the user's Indiekit installation after they run the `create-indiekit` CLI.

This file will allow the user to just press `F5` and start debugging their Indiekit installation.

![debug-indiekit](https://github.com/user-attachments/assets/8f8db373-344b-4bad-820f-684dab464633)
