### PR TITLE
Micropub channels

### DIFF
--- a/docs/configuration/publication.md
+++ b/docs/configuration/publication.md
@@ -53,6 +53,44 @@ export default {
 
 :::
 
+## `channels`
+
+A keyed collection of configuration properties for different channels, which can be used to organise posts within your publication. For example:
+
+::: code-group
+
+```json [JSON]
+{
+  "publication": {
+    "channels": {
+      "posts": {
+        "name": "Posts"
+      },
+      "pages": {
+        "name": "Pages"
+      }
+    }
+  }
+}
+```
+
+```js [JavaScript]
+export default {
+  publication: {
+    channels: {
+      posts: {
+        name: "Posts"
+      },
+      pages: {
+        name: "Pages"
+      }
+    }
+  }
+}
+```
+
+:::
+
 ## `enrichPostData`
 
 A boolean to determine if data about URLs referenced in new posts is fetched and appended to a post’s properties.

--- a/docs/configuration/tokens.md
+++ b/docs/configuration/tokens.md
@@ -59,6 +59,7 @@ The following tokens are only available for post files:
 
 | Token | Description |
 | :---- | :---------- |
+| `channel` | Channel provided in `mp-channel` property, else default channel UID. Token only available if `publication.channels` is configured. |
 | `slug` | Slug provided in `mp-slug` property, else slugified `name` property, else a 5 character string, for example `ycf9o` |
 
 ### Media file tokens

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -56,6 +56,7 @@ The following [scopes](https://indieweb.org/scope) are supported:
 ### Extensions
 
 * [x] [Category](https://github.com/indieweb/micropub-extensions/issues/5) query
+* [x] [Channel](https://github.com/indieweb/micropub-extensions/issues/40) query
 * [x] [Post list](https://github.com/indieweb/micropub-extensions/issues/4) query
 * [x] [Supported properties](https://github.com/indieweb/micropub-extensions/issues/33) query
 * [x] [Supported queries](https://github.com/indieweb/micropub-extensions/issues/7) query
@@ -71,6 +72,7 @@ The following [scopes](https://indieweb.org/scope) are supported:
 
 ### Server commands
 
+* [x] `mp-channel`: Channel(s) to use for a published post
 * [x] `mp-photo-alt`: Alternative text to use for a published photo
 * [x] `mp-slug`: URL slug to use in published post
 * [x] `mp-syndicate-to`: Which syndication targets to syndicate post to

--- a/indiekit.config.js
+++ b/indiekit.config.js
@@ -32,6 +32,14 @@ const config = {
   publication: {
     me: process.env.PUBLICATION_URL,
     categories: ["internet", "indieweb", "indiekit", "test", "testing"],
+    channels: {
+      posts: {
+        name: "Posts",
+      },
+      pages: {
+        name: "Pages",
+      },
+    },
     enrichPostData: true,
     postTypes: {
       like: {

--- a/packages/endpoint-micropub/lib/config.js
+++ b/packages/endpoint-micropub/lib/config.js
@@ -6,11 +6,12 @@
  */
 export const getConfig = (application, publication) => {
   const { mediaEndpoint, url } = application;
-  const { categories, postTypes, syndicationTargets } = publication;
+  const { categories, channels, postTypes, syndicationTargets } = publication;
 
   // Supported queries
   const q = [
     "category",
+    "channel",
     "config",
     "media-endpoint",
     "post-types",
@@ -28,6 +29,10 @@ export const getConfig = (application, publication) => {
 
   return {
     categories,
+    channels: Object.entries(channels).map(([uid, channel]) => ({
+      uid,
+      name: channel.name,
+    })),
     "media-endpoint": mediaEndpoint,
     "post-types": Object.values(postTypes).map((postType) => ({
       type: postType.type,

--- a/packages/endpoint-micropub/lib/controllers/query.js
+++ b/packages/endpoint-micropub/lib/controllers/query.js
@@ -25,6 +25,9 @@ export const queryController = async (request, response, next) => {
     // `category` param is used to query `categories` configuration property
     q = q === "category" ? "categories" : String(q);
 
+    // `channel` param is used to query `channels` configuration property
+    q = q === "channel" ? "channels" : String(q);
+
     switch (q) {
       case "config": {
         response.json(config);

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -48,8 +48,14 @@ export const postData = {
       typeConfig.post.path,
       properties,
       application,
+      publication,
     );
-    const url = await renderPath(typeConfig.post.url, properties, application);
+    const url = await renderPath(
+      typeConfig.post.url,
+      properties,
+      application,
+      publication,
+    );
     properties.url = getCanonicalUrl(url, me);
 
     // Post status
@@ -144,11 +150,13 @@ export const postData = {
       typeConfig.post.path,
       properties,
       application,
+      publication,
     );
     const updatedUrl = await renderPath(
       typeConfig.post.url,
       properties,
       application,
+      publication,
     );
     properties.url = getCanonicalUrl(updatedUrl, me);
 
@@ -208,6 +216,7 @@ export const postData = {
       typeConfig.post.path,
       properties,
       application,
+      publication,
     );
 
     // Update data in posts collection
@@ -249,6 +258,7 @@ export const postData = {
       typeConfig.post.path,
       properties,
       application,
+      publication,
     );
 
     // Post status

--- a/packages/endpoint-micropub/lib/utils.js
+++ b/packages/endpoint-micropub/lib/utils.js
@@ -50,6 +50,11 @@ export const getPostTemplateProperties = (properties) => {
   const templateProperties = structuredClone(properties);
 
   for (let key in templateProperties) {
+    // Pass mp-channel to template as channel
+    if (key === "mp-channel") {
+      templateProperties.channel = templateProperties["mp-channel"];
+    }
+
     // Remove server commands from post template properties
     if (key.startsWith("mp-")) {
       delete templateProperties[key];
@@ -78,12 +83,19 @@ export const relativeMediaPath = (url, me) =>
  * @param {string} path - URI template path
  * @param {object} properties - JF2 properties
  * @param {object} application - Application configuration
+ * @param {object} publication - Publication configuration
  * @returns {Promise<string>} Path
  */
-export const renderPath = async (path, properties, application) => {
+export const renderPath = async (
+  path,
+  properties,
+  application,
+  publication,
+) => {
   const dateObject = new Date(properties.published);
   const serverTimeZone = getTimeZoneDesignator();
   const { locale, timeZone } = application;
+  const { slugSeparator } = publication;
   let tokens = {};
 
   // Add date tokens
@@ -104,6 +116,13 @@ export const renderPath = async (path, properties, application) => {
 
   // Add slug token
   tokens.slug = properties.slug;
+
+  // Add channel token
+  if (properties.channel) {
+    tokens.channel = Array.isArray(properties.channel)
+      ? properties.channel.join(slugSeparator)
+      : properties.channel;
+  }
 
   // Populate URI template path with properties
   path = supplant(path, tokens);

--- a/packages/endpoint-micropub/test/unit/utils.js
+++ b/packages/endpoint-micropub/test/unit/utils.js
@@ -62,9 +62,10 @@ describe("endpoint-media/lib/utils", () => {
   });
 
   it("Renders path from URI template and properties", async () => {
-    const template = "{yyyy}/{MM}/{slug}";
+    const template = "{channel}/{yyyy}/{MM}/{slug}";
     const properties = {
       published: "2020-01-01",
+      channel: ["foo", "bar"],
       slug: "foo",
     };
     const application = {
@@ -83,9 +84,17 @@ describe("endpoint-media/lib/utils", () => {
         },
       },
     };
-    const result = await renderPath(template, properties, application);
+    const publication = {
+      slugSeparator: "_",
+    };
+    const result = await renderPath(
+      template,
+      properties,
+      application,
+      publication,
+    );
 
-    assert.match(result, /\d{4}\/\d{2}\/foo/);
+    assert.match(result, /foo_bar\/\d{4}\/\d{2}\/foo/);
   });
 
   it("Convert string to array if not already an array", () => {

--- a/packages/endpoint-posts/includes/post-types/mp-channel.njk
+++ b/packages/endpoint-posts/includes/post-types/mp-channel.njk
@@ -1,0 +1,4 @@
+{{ tag({
+  label: __("posts.form.mp-channel.label"),
+  items: publication.channels[property].name
+}) if property }}

--- a/packages/endpoint-posts/lib/middleware/post-data.js
+++ b/packages/endpoint-posts/lib/middleware/post-data.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import { IndiekitError } from "@indiekit/error";
 import { statusTypes } from "../status-types.js";
 import {
+  getChannelItems,
   getGeoValue,
   getPostName,
   getPostProperties,
@@ -26,6 +27,7 @@ export const postData = {
     response.locals = {
       accessToken: access_token,
       action: "create",
+      channelItems: getChannelItems(publication),
       fields,
       name,
       postsPath: path.dirname(request.baseUrl + request.path),
@@ -68,6 +70,7 @@ export const postData = {
         accessToken: access_token,
         action: action || "create",
         allDay,
+        channelItems: getChannelItems(publication),
         draftMode: scope?.includes("draft"),
         fields,
         geo,

--- a/packages/endpoint-posts/lib/utils.js
+++ b/packages/endpoint-posts/lib/utils.js
@@ -6,6 +6,18 @@ import { endpoint } from "./endpoint.js";
 import { statusTypes } from "./status-types.js";
 
 /**
+ * Get channel `items` for checkboxes component
+ * @param {object} publication - Publication configuration
+ * @returns {object} Items for checkboxes component
+ */
+export const getChannelItems = (publication) => {
+  return Object.entries(publication.channels).map(([uid, channel]) => ({
+    label: channel.name,
+    value: uid,
+  }));
+};
+
+/**
  * Get geographic coordinates property
  * @param {string} geo - Latitude and longitude, comma separated
  * @returns {object} JF2 geo location property

--- a/packages/endpoint-posts/locales/de.json
+++ b/packages/endpoint-posts/locales/de.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Dateipfad oder URL"
       },
+      "mp-channel": {
+        "label": "Kanal"
+      },
       "mp-slug": {
         "label": "Slug"
       },

--- a/packages/endpoint-posts/locales/en.json
+++ b/packages/endpoint-posts/locales/en.json
@@ -86,6 +86,9 @@
       "media": {
         "label": "File path or URL"
       },
+      "mp-channel": {
+        "label": "Channel"
+      },
       "mp-slug": {
         "label": "URL slug"
       },

--- a/packages/endpoint-posts/locales/es-419.json
+++ b/packages/endpoint-posts/locales/es-419.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Ruta o URL del archivo"
       },
+      "mp-channel": {
+        "label": "Canal"
+      },
       "mp-slug": {
         "label": "Babosa de URL"
       },

--- a/packages/endpoint-posts/locales/es.json
+++ b/packages/endpoint-posts/locales/es.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Ruta o URL del archivo"
       },
+      "mp-channel": {
+        "label": "Canal"
+      },
       "mp-slug": {
         "label": "URL slug"
       },

--- a/packages/endpoint-posts/locales/fr.json
+++ b/packages/endpoint-posts/locales/fr.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Chemin du fichier ou URL"
       },
+      "mp-channel": {
+        "label": "Canal"
+      },
       "mp-slug": {
         "label": "Identifiant unique d’URL (slug)"
       },

--- a/packages/endpoint-posts/locales/hi.json
+++ b/packages/endpoint-posts/locales/hi.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "फ़ाइल पथ या URL"
       },
+      "mp-channel": {
+        "label": "चैनल"
+      },
       "mp-slug": {
         "label": "URL स्लग"
       },

--- a/packages/endpoint-posts/locales/id.json
+++ b/packages/endpoint-posts/locales/id.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Jalur file atau URL"
       },
+      "mp-channel": {
+        "label": "Saluran"
+      },
       "mp-slug": {
         "label": "URL siput"
       },

--- a/packages/endpoint-posts/locales/nl.json
+++ b/packages/endpoint-posts/locales/nl.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Bestandspad of URL"
       },
+      "mp-channel": {
+        "label": "Kanaal"
+      },
       "mp-slug": {
         "label": "URL-slug"
       },

--- a/packages/endpoint-posts/locales/pl.json
+++ b/packages/endpoint-posts/locales/pl.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Ścieżka pliku lub adres URL"
       },
+      "mp-channel": {
+        "label": "Kanał"
+      },
       "mp-slug": {
         "label": "Ślimak URL"
       },

--- a/packages/endpoint-posts/locales/pt.json
+++ b/packages/endpoint-posts/locales/pt.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Caminho do arquivo ou URL"
       },
+      "mp-channel": {
+        "label": "Canal"
+      },
       "mp-slug": {
         "label": "Slug de URL"
       },

--- a/packages/endpoint-posts/locales/sr.json
+++ b/packages/endpoint-posts/locales/sr.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Putanja ili URL datoteke"
       },
+      "mp-channel": {
+        "label": "Kanal"
+      },
       "mp-slug": {
         "label": "URL slag"
       },

--- a/packages/endpoint-posts/locales/sv.json
+++ b/packages/endpoint-posts/locales/sv.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "Filsökväg eller URL"
       },
+      "mp-channel": {
+        "label": "Kanal"
+      },
       "mp-slug": {
         "label": "URL-slug"
       },

--- a/packages/endpoint-posts/locales/zh-Hans-CN.json
+++ b/packages/endpoint-posts/locales/zh-Hans-CN.json
@@ -58,6 +58,9 @@
       "media": {
         "label": "文件路径或 URL"
       },
+      "mp-channel": {
+        "label": "频道"
+      },
       "mp-slug": {
         "label": "网址 slug"
       },

--- a/packages/endpoint-posts/test/unit/utils.js
+++ b/packages/endpoint-posts/test/unit/utils.js
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { mockResponse } from "mock-req-res";
 import {
+  getChannelItems,
   getGeoProperty,
   getGeoValue,
   getLocationProperty,
@@ -14,6 +15,14 @@ import {
 
 const publication = {
   me: "https://website.example",
+  channels: {
+    posts: {
+      name: "Posts",
+    },
+    pages: {
+      name: "Pages",
+    },
+  },
   postTypes: {
     article: {
       name: "Journal entry",
@@ -43,6 +52,16 @@ const publication = {
 };
 
 describe("endpoint-posts/lib/utils", () => {
+  it("Gets channel `items` for checkboxes component", () => {
+    const result = getChannelItems(publication);
+
+    assert.equal(result.length, 2);
+    assert.equal(result[0].label, "Posts");
+    assert.equal(result[0].value, "posts");
+    assert.equal(result[1].label, "Pages");
+    assert.equal(result[1].value, "pages");
+  });
+
   it("Gets geographic coordinates property", () => {
     assert.deepEqual(getGeoProperty("50.8252, -0.1383"), {
       type: "geo",

--- a/packages/endpoint-posts/views/post-form.njk
+++ b/packages/endpoint-posts/views/post-form.njk
@@ -52,6 +52,16 @@
       }]
     }) }}
 
+    {{ checkboxes({
+      name: "mp-channel",
+      values: properties["mp-channel"],
+      fieldset: {
+        legend: __("posts.form.mp-channel.label"),
+        optional: true
+      },
+      items: channelItems
+    }) | indent(2) if publication.channels }}
+
     {{ radios({
       inline: true,
       name: "visibility",

--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -56,6 +56,7 @@ export const defaultConfig = {
   ],
   publication: {
     categories: [],
+    channels: {},
     locale: "en",
     me: undefined,
     postTemplate: undefined,

--- a/packages/indiekit/locales/de.json
+++ b/packages/indiekit/locales/de.json
@@ -90,6 +90,7 @@
       "version": "Version"
     },
     "publication": {
+      "channels": "Kanäle",
       "locale": "Sprache",
       "me": "Webadresse",
       "mediaStore": "Medienspeicher",

--- a/packages/indiekit/locales/en.json
+++ b/packages/indiekit/locales/en.json
@@ -88,6 +88,7 @@
       "version": "Version"
     },
     "publication": {
+      "channels": "Channels",
       "summaryTitle": "Publication settings",
       "me": "Web address",
       "locale": "Language",

--- a/packages/indiekit/locales/es-419.json
+++ b/packages/indiekit/locales/es-419.json
@@ -90,6 +90,7 @@
       "version": "Versión"
     },
     "publication": {
+      "channels": "Canales",
       "locale": "Idioma",
       "me": "Dirección web",
       "mediaStore": "Tienda multimedia",

--- a/packages/indiekit/locales/es.json
+++ b/packages/indiekit/locales/es.json
@@ -90,6 +90,7 @@
       "version": "Versión"
     },
     "publication": {
+      "channels": "Canales",
       "locale": "Idioma",
       "me": "Dirección web",
       "mediaStore": "Tienda multimedia",

--- a/packages/indiekit/locales/fr.json
+++ b/packages/indiekit/locales/fr.json
@@ -90,6 +90,7 @@
       "version": "Version"
     },
     "publication": {
+      "channels": "Chaînes",
       "locale": "Langue",
       "me": "Adresse Web",
       "mediaStore": "Magasin multimédia",

--- a/packages/indiekit/locales/hi.json
+++ b/packages/indiekit/locales/hi.json
@@ -90,6 +90,7 @@
       "version": "वर्ज़न"
     },
     "publication": {
+      "channels": "चैनल",
       "locale": "भाषा",
       "me": "वेब पता",
       "mediaStore": "मीडिया स्टोर",

--- a/packages/indiekit/locales/id.json
+++ b/packages/indiekit/locales/id.json
@@ -90,6 +90,7 @@
       "version": "Versi"
     },
     "publication": {
+      "channels": "Saluran",
       "locale": "Bahasa",
       "me": "Alamat web",
       "mediaStore": "Toko media",

--- a/packages/indiekit/locales/nl.json
+++ b/packages/indiekit/locales/nl.json
@@ -90,6 +90,7 @@
       "version": "Versie"
     },
     "publication": {
+      "channels": "Kanalen",
       "locale": "Taal",
       "me": "Webadres",
       "mediaStore": "Mediawinkel",

--- a/packages/indiekit/locales/pl.json
+++ b/packages/indiekit/locales/pl.json
@@ -90,6 +90,7 @@
       "version": "Wersja"
     },
     "publication": {
+      "channels": "Kanały",
       "locale": "Język",
       "me": "Adres sieci Web",
       "mediaStore": "Sklep multimedialny",

--- a/packages/indiekit/locales/pt.json
+++ b/packages/indiekit/locales/pt.json
@@ -90,6 +90,7 @@
       "version": "Versão"
     },
     "publication": {
+      "channels": "Canais",
       "locale": "Idioma",
       "me": "Endereço Web",
       "mediaStore": "Loja de mídia",

--- a/packages/indiekit/locales/sr.json
+++ b/packages/indiekit/locales/sr.json
@@ -90,6 +90,7 @@
       "version": "Verzija"
     },
     "publication": {
+      "channels": "Kanali",
       "locale": "Jezik",
       "me": "Veb adresa",
       "mediaStore": "Medijska prodavnica",

--- a/packages/indiekit/locales/sv.json
+++ b/packages/indiekit/locales/sv.json
@@ -90,6 +90,7 @@
       "version": "Version"
     },
     "publication": {
+      "channels": "Kanaler",
       "locale": "Språk",
       "me": "Webbadress",
       "mediaStore": "Mediebutik",

--- a/packages/indiekit/locales/zh-Hans-CN.json
+++ b/packages/indiekit/locales/zh-Hans-CN.json
@@ -90,6 +90,7 @@
       "version": "版本"
     },
     "publication": {
+      "channels": "频道",
       "locale": "语言",
       "me": "网址",
       "mediaStore": "媒体商店",

--- a/packages/indiekit/views/status.njk
+++ b/packages/indiekit/views/status.njk
@@ -1,5 +1,14 @@
 {% extends "document.njk" %}
 
+{%- set channelsHtml %}
+  <ul role="list">{% for uid, channel in publication.channels | dictsort %}
+    <li>
+      {{ channel.name }}
+      <small><code class="token attr-name">{{ uid }}</code></small>
+    </li>
+  {% endfor %}</ul>
+{% endset -%}
+
 {%- set postTypesHtml %}
   <ul role="list">{% for type, config in publication.postTypes | dictsort %}
     <li>
@@ -68,6 +77,13 @@
           text: publication.locale.split("-") | first | languageNativeName
         }
       }, {
+        key: {
+          text: __("status.publication.channels")
+        },
+        value: {
+          text: channelsHtml | indent(4)
+        }
+      } if publication.channels, {
         key: {
           text: __("status.publication.postTypes")
         },


### PR DESCRIPTION
Adds support for [the channels extension](https://github.com/indieweb/micropub-extensions/issues/40) in Micropub requests. Fixes #773.

This can be used to dictate where a post gets published within a publication, and potentially allows for posts of the same type to be published to different locations.

Adds:

- New `publication.channels` configuration option
- Querying `/micropub?q=config` includes a `channels` property with configured channels
- Querying `/micropub?q=channel` returns configured channels

If channels are configured:

- The default channel is the first value given for `publication.channels`
- If a request includes an `mp-channel` value, it gets saved to `properties.channel`
- If a request doesn’t include `mp-channel`, the default channel UID is used
- If a request includes values for `mp-channel` that don’t exist in `publication.channels`, they’ll get ignored. If no values match, the default channel UID is used
- Post form shows a ‘Channels’ field under ‘Advanced options’, with checkboxes to select for each of the configured channels
- Post page shows channels specified for a given post
- A `{channel}` token is available to use in paths; if multiple channels are assigned to a post, these will get separated using the slug separator character

![Screenshot of channels in advanced options on post form.](https://github.com/user-attachments/assets/f83f553a-3b19-4c52-b104-e0923a833830)

## Example

In publication config:

```js
publication: {
  channels: {
    en: {
      name: "English"
    },
    de: {
      name: "German"
    }
  },
  postTypes: {
    article: {
      post: {
        path: "_posts/{channel}/{yyyy}-{MM}-{dd}-{slug}.md",
        url: "{channel}/{yyyy}/{MM}/{slug}"
      }
    }
  }
}
```

```http
GET /micropub?q=channel

"channels": [
  {
    "uid": "en",
    "name": "English"
  },
  {
    "uid": "de",
    "name": "German"
  }
]
```

Published to `/en/2024/11/channels`:

```http
POST /micropub
Content-Type: application/json

{
  "type": "h-entry",
  "properties" {
    "mp-channel": "en",
    "name": "Channels",
    "content": "Hello, world."
  }
}
```

Published to `/de/2024/11/kanale`:

```http
POST /micropub
Content-Type: application/json

{
  "type": "h-entry",
  "properties" {
    "mp-channel": "de",
    "name": "Kanäle",
    "content": "Hallo Welt."
  }
}
```

## How should this value be used by presets?

Right now, if a publication has channels configured, the default (or chosen) channel(s) will get saved to `properties.channel`, so for example a post might look like this:

```yaml
----
published: 2024-11-16
title: Channels
channel:
  - en
----
Hello, world.
```

I think channels are analogous to [Eleventy collections](https://www.11ty.dev/docs/collections/), so potentially for that preset, the `channel` property should be used for `tags`? But you might want to use `properties.category` for the `tags` field instead. Not sure what is the right approach, but can figure that out in a separate PR.

Might this value have equivalent representations in other platforms, too?

## Should a default channel be enforced?

Right now, a default channel is enforced. That means, while you might only want to use the channel property for the output path, the `channel` property would still get added to frontmatter properties as well. Maybe that’s fine (though this’d make be twinge…)