### PR TITLE
Use SHA1 algorithm for generating asset hashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12979,34 +12979,6 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "license": "ISC"
     },
-    "node_modules/hasha": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-6.0.0.tgz",
-      "integrity": "sha512-MLydoyGp9QJcjlhE5lsLHXYpWayjjWqkavzju2ZWD2tYa1CgmML1K1gWAu22BLFa2eZ0OfvJ/DlfoVjaD54U2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-stream": "^3.0.0",
-        "type-fest": "^4.7.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/hasha/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -22989,7 +22961,6 @@
         "express": "^4.17.1",
         "express-fileupload": "^1.4.0",
         "express-rate-limit": "^7.0.0",
-        "hasha": "^6.0.0",
         "i18n": "^0.15.0",
         "keyv": "^5.0.0",
         "lodash": "^4.17.21",

--- a/packages/indiekit/lib/middleware/locals.js
+++ b/packages/indiekit/lib/middleware/locals.js
@@ -1,12 +1,12 @@
 import { scripts, styles } from "@indiekit/frontend";
-import { hash } from "hasha";
+import { sha1 } from "@indiekit/util";
 import { getEndpoints } from "../endpoints.js";
 import { getNavigation } from "../navigation.js";
 import { getShortcuts } from "../shortcuts.js";
 import { getUrl } from "../utils.js";
 
-const jsHash = await hash(await scripts(), { algorithm: "md5" });
-const cssHash = await hash(await styles(), { algorithm: "md5" });
+const jsHash = sha1(await scripts());
+const cssHash = sha1(await styles());
 
 /**
  * Expose configuration to frontend templates and plug-ins

--- a/packages/indiekit/package.json
+++ b/packages/indiekit/package.json
@@ -66,7 +66,6 @@
     "express": "^4.17.1",
     "express-fileupload": "^1.4.0",
     "express-rate-limit": "^7.0.0",
-    "hasha": "^6.0.0",
     "i18n": "^0.15.0",
     "keyv": "^5.0.0",
     "lodash": "^4.17.21",

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -10,6 +10,6 @@ export {
 } from "./lib/date.js";
 export { sanitise } from "./lib/object.js";
 export { ISO_6709_RE } from "./lib/regex.js";
-export { md5, randomString, slugify, supplant } from "./lib/string.js";
+export { md5, randomString, sha1, slugify, supplant } from "./lib/string.js";
 export { getCanonicalUrl, isSameOrigin } from "./lib/url.js";
 export { isRequired } from "./lib/validation-schema.js";

--- a/packages/util/lib/string.js
+++ b/packages/util/lib/string.js
@@ -9,6 +9,13 @@ import slugifyString from "@sindresorhus/slugify";
 export const md5 = (string) => createHash("md5").update(string).digest("hex");
 
 /**
+ * Generate SHA1 hashed string
+ * @param {string} string - String
+ * @returns {string} SHA1 hashed string
+ */
+export const sha1 = (string) => createHash("sha1").update(string).digest("hex");
+
+/**
  * Generate cryptographically random string
  * @param {number} [length] - Length of string
  * @returns {string} Random string

--- a/packages/util/test/unit/string.js
+++ b/packages/util/test/unit/string.js
@@ -1,13 +1,25 @@
 import { strict as assert } from "node:assert";
 import { Buffer } from "node:buffer";
 import { describe, it } from "node:test";
-import { md5, randomString, slugify, supplant } from "../../lib/string.js";
+import {
+  md5,
+  randomString,
+  sha1,
+  slugify,
+  supplant,
+} from "../../lib/string.js";
 
 describe("util/lib/string", () => {
   it("Generates MD5 hashed string", () => {
     const result = md5("foo");
 
     assert.equal(result, "acbd18db4cc2f85cedef654fccc4a4d8");
+  });
+
+  it("Generates SHA1 hashed string", () => {
+    const result = sha1("foo");
+
+    assert.equal(result, "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33");
   });
 
   it("Generates cryptographically random string", () => {


### PR DESCRIPTION
Using SHA1 algorithm, and using `node:crypto` `createHash()` method is faster than using `hasha` with the md5 algorithm. SHA1 is also faster than SHA256 or md5 algorithms.

Running on Railway server:

| Asset (hasher) | Time |
| - | - |
| JS (`hasha`, md5) | 2.136s |
| JS (`hasha`, sha256) | 1.601s |
| JS (`hasha`, sha1) | 1.464s |
| JS (`createHash("sha1")`) | 1.324s |

| Asset (hasher) | Time |
| - | - |
| CSS (`hasha`, md5) | 0.602ms |
| CSS (`hasha`, sha256) | 0.375ms |
| CSS (`hasha`, sha1) | 0.224ms |
| CSS (`createHash("sha1")`) | 0.122ms |