### PR TITLE
Refactor `Indiekit` class

### DIFF
--- a/helpers/config/index.js
+++ b/helpers/config/index.js
@@ -42,6 +42,7 @@ export const testConfig = async (options) => {
     },
     plugins: ["@indiekit-test/store", ...(options.plugins || [])],
     publication: {
+      categories: options?.publication?.categories,
       me: options?.publication?.me || "https://website.example",
       ...(options.usePostTypes && { postTypes }),
     },

--- a/packages/endpoint-posts/lib/middleware/validation.js
+++ b/packages/endpoint-posts/lib/middleware/validation.js
@@ -2,10 +2,10 @@ import { check, checkSchema } from "express-validator";
 
 export const validate = {
   async form(request, response, next) {
-    const { application } = request.app.locals;
+    const { validationSchemas } = request.app.locals;
     const validations = [];
 
-    for (const schema of [application.validationSchemas]) {
+    for (const schema of [Object.fromEntries(validationSchemas)]) {
       validations.push(checkSchema(schema));
     }
 

--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -10,7 +10,6 @@ export const defaultConfig = {
     themeColorScheme: "automatic",
     timeZone: "UTC",
     ttl: 604_800, // 7 days
-    validationSchemas: {},
   },
   plugins: [
     "@indiekit/endpoint-auth",

--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -5,7 +5,6 @@ export const defaultConfig = {
     mongodbUrl: process.env.MONGO_URL || false,
     name: "Indiekit",
     port: process.env.PORT || "3000",
-    postTypes: {},
     themeColor: "#04f",
     themeColorScheme: "automatic",
     timeZone: "UTC",

--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -7,7 +7,6 @@ export const defaultConfig = {
     name: "Indiekit",
     port: process.env.PORT || "3000",
     postTypes: {},
-    stores: [],
     themeColor: "#04f",
     themeColorScheme: "automatic",
     timeZone: "UTC",

--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -2,7 +2,6 @@ import process from "node:process";
 
 export const defaultConfig = {
   application: {
-    endpoints: [],
     mongodbUrl: process.env.MONGO_URL || false,
     name: "Indiekit",
     port: process.env.PORT || "3000",

--- a/packages/indiekit/config/defaults.js
+++ b/packages/indiekit/config/defaults.js
@@ -3,21 +3,6 @@ import process from "node:process";
 export const defaultConfig = {
   application: {
     endpoints: [],
-    localesAvailable: [
-      "de",
-      "en",
-      "es",
-      "es-419",
-      "fr",
-      "hi",
-      "id",
-      "nl",
-      "pl",
-      "pt",
-      "sr",
-      "sv",
-      "zh-Hans-CN",
-    ],
     mongodbUrl: process.env.MONGO_URL || false,
     name: "Indiekit",
     port: process.env.PORT || "3000",

--- a/packages/indiekit/config/locales.js
+++ b/packages/indiekit/config/locales.js
@@ -1,0 +1,15 @@
+export const locales = new Set([
+  "de",
+  "en",
+  "es",
+  "es-419",
+  "fr",
+  "hi",
+  "id",
+  "nl",
+  "pl",
+  "pt",
+  "sr",
+  "sv",
+  "zh-Hans-CN",
+]);

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -32,6 +32,7 @@ export const Indiekit = class {
     this.publication = this.config.publication;
 
     this.collections = new Map();
+    this.installedPlugins = new Set();
     this.locales = locales;
   }
 
@@ -141,6 +142,10 @@ export const Indiekit = class {
     return getLocaleCatalog(this);
   }
 
+  async installPlugins() {
+    await getInstalledPlugins(this);
+  }
+
   async bootstrap() {
     debug(`Bootstrap: check for required configuration options`);
     // Check for required configuration options
@@ -149,9 +154,6 @@ export const Indiekit = class {
       console.info("https://getindiekit.com/configuration/publication#me");
       process.exit();
     }
-
-    // Update application configuration
-    this.application.installedPlugins = await getInstalledPlugins(this);
 
     // Update publication configuration
     this.publication.categories = await getCategories(this);
@@ -175,6 +177,7 @@ export const Indiekit = class {
 
   async server(options = {}) {
     await this.connectMongodbClient();
+    await this.installPlugins();
     const config = await this.bootstrap();
     const app = expressConfig(config);
     let { name, port } = config.application;

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -35,6 +35,7 @@ export const Indiekit = class {
     this.endpoints = new Set();
     this.installedPlugins = new Set();
     this.locales = locales;
+    this.postTypes = new Map();
     this.stores = new Set();
     this.validationSchemas = new Map();
   }
@@ -64,10 +65,10 @@ export const Indiekit = class {
 
   addPostType(type, postType) {
     if (postType.config) {
-      this.application.postTypes[type] = {
-        ...this.application.postTypes[type],
+      this.postTypes.set(type, {
+        ...this.postTypes.get(type),
         ...postType.config,
-      };
+      });
     }
 
     if (postType.validationSchemas) {

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -36,6 +36,7 @@ export const Indiekit = class {
     this.installedPlugins = new Set();
     this.locales = locales;
     this.stores = new Set();
+    this.validationSchemas = new Map();
   }
 
   static async initialize(options = {}) {
@@ -70,10 +71,11 @@ export const Indiekit = class {
     }
 
     if (postType.validationSchemas) {
-      this.application.validationSchemas = {
-        ...this.application.validationSchemas,
-        ...postType.validationSchemas,
-      };
+      for (const [field, schema] of Object.entries(
+        postType.validationSchemas,
+      )) {
+        this.validationSchemas.set(field, schema);
+      }
     }
   }
 

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -150,23 +150,18 @@ export const Indiekit = class {
     await getInstalledPlugins(this);
   }
 
-  async bootstrap() {
-    debug(`Bootstrap: check for required configuration options`);
-    // Check for required configuration options
+  async updatePublicationConfig() {
     if (!this.publication.me) {
       console.error("No publication URL in configuration");
       console.info("https://getindiekit.com/configuration/publication#me");
       process.exit();
     }
 
-    // Update publication configuration
     this.publication.categories = await getCategories(this);
     this.publication.mediaStore = getMediaStore(this);
     this.publication.postTemplate = getPostTemplate(this.publication);
     this.publication.postTypes = getPostTypes(this);
     this.publication.store = getStore(this);
-
-    return this;
   }
 
   stop(server, name) {
@@ -182,9 +177,10 @@ export const Indiekit = class {
   async server(options = {}) {
     await this.connectMongodbClient();
     await this.installPlugins();
-    const config = await this.bootstrap();
-    const app = expressConfig(config);
-    let { name, port } = config.application;
+    await this.updatePublicationConfig();
+
+    const app = expressConfig(this);
+    let { name, port } = this.config.application;
     const { version } = this.package;
     port = options.port || port;
 

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -34,6 +34,7 @@ export const Indiekit = class {
     this.endpoints = new Set();
     this.installedPlugins = new Set();
     this.locales = locales;
+    this.mongodbUrl = config.application.mongodbUrl;
     this.postTypes = new Map();
     this.stores = new Set();
     this.validationSchemas = new Map();
@@ -102,9 +103,7 @@ export const Indiekit = class {
   }
 
   async connectMongodbClient() {
-    const mongodbClientOrError = await getMongodbClient(
-      this.application.mongodbUrl,
-    );
+    const mongodbClientOrError = await getMongodbClient(this.mongodbUrl);
 
     if (mongodbClientOrError?.client) {
       this.mongodbClient = mongodbClientOrError.client;
@@ -124,7 +123,7 @@ export const Indiekit = class {
 
   get cache() {
     return this.mongodbClient
-      ? new Keyv(new KeyvMongo(this.application.mongodbUrl))
+      ? new Keyv(new KeyvMongo(this.mongodbUrl))
       : false;
   }
 

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -34,6 +34,7 @@ export const Indiekit = class {
     this.collections = new Map();
     this.installedPlugins = new Set();
     this.locales = locales;
+    this.stores = new Set();
   }
 
   static async initialize(options = {}) {
@@ -80,7 +81,7 @@ export const Indiekit = class {
   }
 
   addStore(store) {
-    this.application.stores.push(store);
+    this.stores.add(store);
     debug(`Added content store: ${store.name}`);
   }
 

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -32,6 +32,7 @@ export const Indiekit = class {
     this.publication = this.config.publication;
 
     this.collections = new Map();
+    this.endpoints = new Set();
     this.installedPlugins = new Set();
     this.locales = locales;
     this.stores = new Set();
@@ -56,7 +57,8 @@ export const Indiekit = class {
   }
 
   addEndpoint(endpoint) {
-    this.application.endpoints.push(endpoint);
+    this.endpoints.add(endpoint);
+    debug(`Added endpoint: ${endpoint.name}`);
   }
 
   addPostType(type, postType) {

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -5,6 +5,7 @@ import makeDebug from "debug";
 import { default as Keyv } from "keyv";
 import { default as KeyvMongo } from "@keyv/mongo";
 import { expressConfig } from "./config/express.js";
+import { locales } from "./config/locales.js";
 import { getCategories } from "./lib/categories.js";
 import { getIndiekitConfig } from "./lib/config.js";
 import { getLocaleCatalog } from "./lib/locale-catalog.js";
@@ -25,11 +26,13 @@ export const Indiekit = class {
    */
   constructor(config) {
     this.config = config;
-    this.collections = new Map();
     this.application = this.config.application;
     this.package = package_;
     this.plugins = this.config.plugins;
     this.publication = this.config.publication;
+
+    this.collections = new Map();
+    this.locales = locales;
   }
 
   static async initialize(options = {}) {
@@ -134,6 +137,10 @@ export const Indiekit = class {
     return false;
   }
 
+  get localeCatalog() {
+    return getLocaleCatalog(this);
+  }
+
   async bootstrap() {
     debug(`Bootstrap: check for required configuration options`);
     // Check for required configuration options
@@ -145,7 +152,6 @@ export const Indiekit = class {
 
     // Update application configuration
     this.application.installedPlugins = await getInstalledPlugins(this);
-    this.application.localeCatalog = await getLocaleCatalog(this.application);
 
     // Update publication configuration
     this.publication.categories = await getCategories(this);

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -28,7 +28,6 @@ export const Indiekit = class {
     this.config = config;
     this.application = this.config.application;
     this.package = package_;
-    this.plugins = this.config.plugins;
     this.publication = this.config.publication;
 
     this.collections = new Map();

--- a/packages/indiekit/lib/controllers/plugin.js
+++ b/packages/indiekit/lib/controllers/plugin.js
@@ -2,9 +2,9 @@ import path from "node:path";
 import { getPackageData } from "../utils.js";
 
 export const list = (request, response) => {
-  const { application } = response.app.locals;
+  const { installedPlugins } = response.app.locals;
 
-  const plugins = application.installedPlugins.map((plugin) => {
+  const plugins = [...installedPlugins].map((plugin) => {
     const _package = getPackageData(plugin.filePath);
     plugin.photo = {
       srcOnError: "/assets/plug-in.svg",
@@ -29,12 +29,10 @@ export const list = (request, response) => {
 };
 
 export const view = (request, response) => {
-  const { application } = response.app.locals;
+  const { installedPlugins } = response.app.locals;
   const { pluginId } = request.params;
 
-  const plugin = application.installedPlugins.find(
-    (plugin) => plugin.id === pluginId,
-  );
+  const plugin = installedPlugins.find((plugin) => plugin.id === pluginId);
   plugin.package = getPackageData(plugin.filePath);
 
   response.render("plugins/view", {

--- a/packages/indiekit/lib/locale-catalog.js
+++ b/packages/indiekit/lib/locale-catalog.js
@@ -11,9 +11,8 @@ const require = createRequire(import.meta.url);
  */
 export const getLocaleCatalog = (Indiekit) => {
   const catalog = new Map();
-  const { application, locales } = Indiekit;
 
-  for (const locale of locales) {
+  for (const locale of Indiekit.locales) {
     const translations = [
       // Application translations
       require(`../locales/${locale}.json`),
@@ -24,7 +23,7 @@ export const getLocaleCatalog = (Indiekit) => {
     ];
 
     // Plug-in translations
-    for (const plugin of application.installedPlugins) {
+    for (const plugin of Indiekit.installedPlugins) {
       const localePath = path.join(plugin.filePath, `locales/${locale}.json`);
       try {
         translations.push(require(localePath));

--- a/packages/indiekit/lib/locale-catalog.js
+++ b/packages/indiekit/lib/locale-catalog.js
@@ -6,13 +6,14 @@ const require = createRequire(import.meta.url);
 
 /**
  * Add catalog of localised strings to application configuration
- * @param {object} application - Application config
+ * @param {object} Indiekit - Indiekit instance
  * @returns {object} Catalog of localised strings
  */
-export const getLocaleCatalog = (application) => {
+export const getLocaleCatalog = (Indiekit) => {
   const catalog = new Map();
+  const { application, locales } = Indiekit;
 
-  for (const locale of application.localesAvailable) {
+  for (const locale of locales) {
     const translations = [
       // Application translations
       require(`../locales/${locale}.json`),

--- a/packages/indiekit/lib/middleware/internationalisation.js
+++ b/packages/indiekit/lib/middleware/internationalisation.js
@@ -8,7 +8,7 @@ import i18n from "i18n";
 export const internationalisation = (Indiekit) =>
   function (request, response, next) {
     try {
-      const { application } = Indiekit;
+      const { application, localeCatalog } = Indiekit;
 
       i18n.configure({
         cookie: "locale",
@@ -16,7 +16,7 @@ export const internationalisation = (Indiekit) =>
         indent: "  ",
         objectNotation: true,
         queryParameter: "lang",
-        staticCatalog: Object.fromEntries(application.localeCatalog),
+        staticCatalog: Object.fromEntries(localeCatalog),
       });
 
       i18n.init(request, response);

--- a/packages/indiekit/lib/middleware/locals.js
+++ b/packages/indiekit/lib/middleware/locals.js
@@ -23,6 +23,7 @@ export const locals = (Indiekit) =>
         installedPlugins,
         mongodbClientError,
         publication,
+        validationSchemas,
       } = Indiekit;
 
       // Application
@@ -73,6 +74,9 @@ export const locals = (Indiekit) =>
 
       // Publication
       request.app.locals.publication = publication;
+
+      // Publication
+      request.app.locals.validationSchemas = validationSchemas;
 
       // Persist scope and token
       request.app.locals.scope =

--- a/packages/indiekit/lib/middleware/locals.js
+++ b/packages/indiekit/lib/middleware/locals.js
@@ -56,11 +56,11 @@ export const locals = (Indiekit) =>
       // Application navigation
       // Only update if serving HTML to prevent wrong session link being shown
       if (request.accepts("html")) {
-        application.navigation = getNavigation(application, request, response);
+        application.navigation = getNavigation(Indiekit, request, response);
       }
 
       // Application shortcuts
-      application.shortcuts = getShortcuts(application, response);
+      application.shortcuts = getShortcuts(Indiekit, response);
 
       // Application endpoints
       request.app.locals.application = {

--- a/packages/indiekit/lib/middleware/locals.js
+++ b/packages/indiekit/lib/middleware/locals.js
@@ -20,6 +20,7 @@ export const locals = (Indiekit) =>
         application,
         collections,
         database,
+        installedPlugins,
         mongodbClientError,
         publication,
       } = Indiekit;
@@ -66,6 +67,9 @@ export const locals = (Indiekit) =>
         ...application,
         ...getEndpointUrls(application, request),
       };
+
+      // Installed plug-ins
+      request.app.locals.installedPlugins = installedPlugins;
 
       // Publication
       request.app.locals.publication = publication;

--- a/packages/indiekit/lib/navigation.js
+++ b/packages/indiekit/lib/navigation.js
@@ -1,4 +1,13 @@
-export const getNavigation = (application, request, response) => {
+/**
+ * Get navigation items
+ * @param {object} Indiekit - Indiekit instance
+ * @param {import("express").Request} request - Request
+ * @param {import("express").Response} response - Response
+ * @returns {object} Shortcuts
+ */
+export const getNavigation = (Indiekit, request, response) => {
+  const { application, endpoints } = Indiekit;
+
   // Default navigation items
   let navigation = [
     request.session.access_token
@@ -21,7 +30,7 @@ export const getNavigation = (application, request, response) => {
   }
 
   // Add navigation items from endpoint plug-ins
-  for (const endpoint of application.endpoints) {
+  for (const endpoint of endpoints) {
     if (endpoint.navigationItems) {
       const navigationItems = Array.isArray(endpoint.navigationItems)
         ? endpoint.navigationItems

--- a/packages/indiekit/lib/plugins.js
+++ b/packages/indiekit/lib/plugins.js
@@ -5,11 +5,8 @@ const require = createRequire(import.meta.url);
 /**
  * Add plug-ins to application configuration
  * @param {object} Indiekit - Indiekit instance
- * @returns {Promise<Array>} Installed plug-ins
  */
-export const getInstalledPlugins = async (Indiekit) => {
-  const installedPlugins = [];
-
+export async function getInstalledPlugins(Indiekit) {
   for await (const pluginName of Indiekit.config.plugins) {
     const { default: IndiekitPlugin } = await import(pluginName);
     const plugin = new IndiekitPlugin(Indiekit.config[pluginName]);
@@ -23,21 +20,19 @@ export const getInstalledPlugins = async (Indiekit) => {
     // Register plug-in functions
     if (plugin.init) {
       await plugin.init(Indiekit);
-      installedPlugins.push(plugin);
+      Indiekit.installedPlugins.add(plugin);
     }
   }
-
-  return installedPlugins;
-};
+}
 
 /**
  * Get installed plug-in
- * @param {object} application - Application configuration
+ * @param {Set} installedPlugins - Installed plug-ins
  * @param {string} pluginName - Plug-in Name
  * @returns {string} Plug-in ID
  */
-export const getInstalledPlugin = (application, pluginName) => {
-  return application.installedPlugins.find(
+export const getInstalledPlugin = (installedPlugins, pluginName) => {
+  return [...installedPlugins].find(
     (plugin) => plugin.id === getPluginId(pluginName),
   );
 };

--- a/packages/indiekit/lib/post-types.js
+++ b/packages/indiekit/lib/post-types.js
@@ -3,12 +3,12 @@ import _ from "lodash";
 /**
  * Get merged preset and custom post types
  * @param {object} Indiekit - Indiekit instance
- * @param {object} Indiekit.application - Application configuration
+ * @param {Map} Indiekit.postTypes - Application post types
  * @param {object} Indiekit.publication - Publication configuration
  * @returns {object} Merged configuration
  */
-export const getPostTypes = ({ application, publication }) => {
-  let { postTypes } = application;
+export const getPostTypes = ({ postTypes, publication }) => {
+  postTypes = Object.fromEntries(postTypes);
 
   // Add publication preset values
   if (publication.preset?.postTypes) {

--- a/packages/indiekit/lib/routes.js
+++ b/packages/indiekit/lib/routes.js
@@ -28,7 +28,7 @@ const limit = rateLimit({
  * @returns {import("express").Router} Express router
  */
 export const routes = (Indiekit) => {
-  const { application, publication } = Indiekit;
+  const { application, installedPlugins, publication } = Indiekit;
 
   const indieauth = new IndieAuth({
     devMode: process.env.NODE_ENV === "development",
@@ -63,7 +63,7 @@ export const routes = (Indiekit) => {
   router.get("/offline", offlineController.offline);
 
   // Plug-in assets
-  for (const plugin of application.installedPlugins) {
+  for (const plugin of installedPlugins) {
     if (plugin.filePath) {
       const assetsPath = path.join(plugin.filePath, "assets");
       router.use(`/assets/${plugin.id}`, express.static(assetsPath));

--- a/packages/indiekit/lib/routes.js
+++ b/packages/indiekit/lib/routes.js
@@ -28,7 +28,7 @@ const limit = rateLimit({
  * @returns {import("express").Router} Express router
  */
 export const routes = (Indiekit) => {
-  const { application, installedPlugins, publication } = Indiekit;
+  const { endpoints, installedPlugins, publication } = Indiekit;
 
   const indieauth = new IndieAuth({
     devMode: process.env.NODE_ENV === "development",
@@ -86,7 +86,7 @@ export const routes = (Indiekit) => {
   router.get("/session/logout", sessionController.logout);
 
   // Public and .well-known endpoints
-  for (const endpoint of application.endpoints) {
+  for (const endpoint of endpoints) {
     // Internal routing
     // Currently used for endpoint-image which requires configuration values
     // to be passed on to express-sharp middleware
@@ -117,7 +117,7 @@ export const routes = (Indiekit) => {
   router.get("/status", limit, statusController.viewStatus);
 
   // Authenticated endpoints
-  for (const endpoint of application.endpoints) {
+  for (const endpoint of endpoints) {
     if (endpoint.mountPath && endpoint.routes) {
       router.use(endpoint.mountPath, limit, endpoint.routes);
     }

--- a/packages/indiekit/lib/shortcuts.js
+++ b/packages/indiekit/lib/shortcuts.js
@@ -1,9 +1,17 @@
-export const getShortcuts = (application, response) => {
+/**
+ * Get shortcuts
+ * @param {object} Indiekit - Indiekit instance
+ * @param {import("express").Response} response - Response
+ * @returns {object} Shortcuts
+ */
+export const getShortcuts = (Indiekit, response) => {
+  const { application, endpoints } = Indiekit;
+
   // Default shortcut items
   let shortcuts = [];
 
   // Add shortcut items from endpoint plug-ins
-  for (const endpoint of application.endpoints) {
+  for (const endpoint of endpoints) {
     if (endpoint.shortcutItems) {
       const shortcutItems = Array.isArray(endpoint.shortcutItems)
         ? endpoint.shortcutItems

--- a/packages/indiekit/lib/store.js
+++ b/packages/indiekit/lib/store.js
@@ -6,7 +6,7 @@ import { getInstalledPlugin } from "./plugins.js";
  * @returns {object} Content store
  */
 export const getStore = (Indiekit) => {
-  const { application, installedPlugins, publication } = Indiekit;
+  const { installedPlugins, publication, stores } = Indiekit;
 
   // `publication.store` may already be a resolved store function
   if (typeof publication?.store === "object") {
@@ -15,7 +15,7 @@ export const getStore = (Indiekit) => {
 
   return publication?.store
     ? getInstalledPlugin(installedPlugins, publication.store)
-    : application?.stores[0];
+    : [...stores][0];
 };
 
 /**

--- a/packages/indiekit/lib/store.js
+++ b/packages/indiekit/lib/store.js
@@ -6,7 +6,7 @@ import { getInstalledPlugin } from "./plugins.js";
  * @returns {object} Content store
  */
 export const getStore = (Indiekit) => {
-  const { application, publication } = Indiekit;
+  const { application, installedPlugins, publication } = Indiekit;
 
   // `publication.store` may already be a resolved store function
   if (typeof publication?.store === "object") {
@@ -14,7 +14,7 @@ export const getStore = (Indiekit) => {
   }
 
   return publication?.store
-    ? getInstalledPlugin(application, publication.store)
+    ? getInstalledPlugin(installedPlugins, publication.store)
     : application?.stores[0];
 };
 
@@ -24,7 +24,7 @@ export const getStore = (Indiekit) => {
  * @returns {object} Media store
  */
 export const getMediaStore = (Indiekit) => {
-  const { application, publication } = Indiekit;
+  const { installedPlugins, publication } = Indiekit;
 
   // `publication.mediaStore` may already be a resolved store function
   if (typeof publication?.mediaStore === "object") {
@@ -32,6 +32,6 @@ export const getMediaStore = (Indiekit) => {
   }
 
   return publication?.mediaStore
-    ? getInstalledPlugin(application, publication.mediaStore)
+    ? getInstalledPlugin(installedPlugins, publication.mediaStore)
     : getStore(Indiekit);
 };

--- a/packages/indiekit/lib/views.js
+++ b/packages/indiekit/lib/views.js
@@ -7,13 +7,11 @@ import { fileURLToPath } from "node:url";
  * @returns {Array} Directories containing view templates
  */
 export const views = (Indiekit) => {
-  const { application } = Indiekit;
-
   // Application views
   const views = [fileURLToPath(new URL("../views", import.meta.url))];
 
   // Plug-in views
-  for (const plugin of application.installedPlugins) {
+  for (const plugin of Indiekit.installedPlugins) {
     if (plugin.filePath) {
       views.push(
         path.join(plugin.filePath, "includes"),

--- a/packages/indiekit/test/index.js
+++ b/packages/indiekit/test/index.js
@@ -47,7 +47,7 @@ describe("indiekit", async () => {
     const testEndpoint = new TestEndpoint();
     indiekit.addEndpoint(testEndpoint);
 
-    assert.equal(indiekit.application.endpoints.at(-1).name, "Test endpoint");
+    assert.equal([...indiekit.endpoints].at(-1).name, "Test endpoint");
   });
 
   it("Adds publication preset", () => {

--- a/packages/indiekit/test/index.js
+++ b/packages/indiekit/test/index.js
@@ -71,6 +71,6 @@ describe("indiekit", async () => {
     const testStore = new TestStore();
     indiekit.addStore(testStore);
 
-    assert.equal(indiekit.application.stores[0].info.name, "Test store");
+    assert.equal([...indiekit.stores][0].info.name, "Test store");
   });
 });

--- a/packages/indiekit/test/server.js
+++ b/packages/indiekit/test/server.js
@@ -10,9 +10,9 @@ describe("indiekit server", async () => {
   before(async () => {
     const config = await testConfig();
     indiekit = await Indiekit.initialize({ config });
-    const bootstrappedConfig = await indiekit.bootstrap();
-    application = bootstrappedConfig.application;
-    publication = bootstrappedConfig.publication;
+    await indiekit.updatePublicationConfig();
+    application = indiekit.config.application;
+    publication = indiekit.config.publication;
   });
 
   it("Gets application configuration value", () => {

--- a/packages/indiekit/test/unit/categories.js
+++ b/packages/indiekit/test/unit/categories.js
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { beforeEach, describe, it, mock } from "node:test";
+import { describe, it, mock } from "node:test";
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { testConfig } from "@indiekit-test/config";
 import { Indiekit } from "../../index.js";
@@ -8,26 +8,22 @@ import { getCategories } from "../../lib/categories.js";
 await mockAgent("indiekit");
 
 describe("indiekit/lib/categories", async () => {
-  let bootstrappedConfig;
-
-  beforeEach(async () => {
-    const config = await testConfig();
-    const indiekit = await Indiekit.initialize({ config });
-    bootstrappedConfig = await indiekit.bootstrap();
-  });
-
   it("Returns array of available categories", async () => {
-    bootstrappedConfig.publication.categories = ["Foo", "Bar"];
-
-    const result = await getCategories(bootstrappedConfig);
+    const config = await testConfig({
+      publication: { categories: ["Foo", "Bar"] },
+    });
+    const indiekit = await Indiekit.initialize({ config });
+    const result = await getCategories(indiekit);
 
     assert.deepEqual(result, ["Bar", "Foo"]);
   });
 
   it("Fetches array from remote JSON file", async () => {
-    bootstrappedConfig.publication.categories =
-      "https://website.example/categories.json";
-    const result = await getCategories(bootstrappedConfig);
+    const config = await testConfig({
+      publication: { categories: "https://website.example/categories.json" },
+    });
+    const indiekit = await Indiekit.initialize({ config });
+    const result = await getCategories(indiekit);
 
     assert.deepEqual(result, ["Bar", "Foo"]);
   });
@@ -35,23 +31,29 @@ describe("indiekit/lib/categories", async () => {
   it("Returns empty array if remote JSON file not found", async () => {
     mock.method(console, "error", () => {});
 
-    bootstrappedConfig.publication.categories =
-      "https://website.example/404.json";
-    const result = await getCategories(bootstrappedConfig);
+    const config = await testConfig({
+      publication: { categories: "https://website.example/404.json" },
+    });
+    const indiekit = await Indiekit.initialize({ config });
+    const result = await getCategories(indiekit);
 
     assert.deepEqual(result, []);
   });
 
   it("Returns empty array if remote JSON file not reachable", async () => {
-    bootstrappedConfig.publication.categories =
-      "https://foo.bar/categories.json";
-    const result = await getCategories(bootstrappedConfig);
+    const config = await testConfig({
+      publication: { categories: "https://foo.bar/categories.json" },
+    });
+    const indiekit = await Indiekit.initialize({ config });
+    const result = await getCategories(indiekit);
 
     assert.deepEqual(result, []);
   });
 
   it("Returns empty array if no publication configuration", async () => {
-    const result = await getCategories(bootstrappedConfig);
+    const config = await testConfig();
+    const indiekit = await Indiekit.initialize({ config });
+    const result = await getCategories(indiekit);
 
     assert.deepEqual(result, []);
   });

--- a/packages/indiekit/test/unit/navigation.js
+++ b/packages/indiekit/test/unit/navigation.js
@@ -1,12 +1,12 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
-import { mockResponse } from "mock-req-res";
+import { mockRequest, mockResponse } from "mock-req-res";
 import { getNavigation } from "../../lib/navigation.js";
 
-const application = {
-  installedPlugins: [],
-  locale: "en",
-  endpoints: [
+const Indiekit = {
+  application: { locale: "en" },
+  installedPlugins: new Set(),
+  endpoints: new Set([
     {
       id: "foo",
       name: "Foo plug-in",
@@ -22,7 +22,7 @@ const application = {
         },
       ],
     },
-  ],
+  ]),
 };
 const response = mockResponse({
   locals: { __: (value) => value },
@@ -31,8 +31,8 @@ const response = mockResponse({
 describe("indiekit/lib/navigation", () => {
   it("Returns logged out navigation", () => {
     const result = getNavigation(
-      application,
-      { path: "/bar", session: {} },
+      Indiekit,
+      mockRequest({ path: "/bar", session: {} }),
       response,
     );
 
@@ -41,8 +41,8 @@ describe("indiekit/lib/navigation", () => {
 
   it("Returns navigation items that require a database", () => {
     const result = getNavigation(
-      application,
-      { path: "/bar", session: {} },
+      Indiekit,
+      mockRequest({ path: "/bar", session: {} }),
       response,
     );
 
@@ -52,8 +52,8 @@ describe("indiekit/lib/navigation", () => {
 
   it("Returns logged in navigation", () => {
     const result = getNavigation(
-      application,
-      { path: "/bar", session: { access_token: "token" } },
+      Indiekit,
+      mockRequest({ path: "/bar", session: { access_token: "token" } }),
       response,
     );
 
@@ -62,8 +62,8 @@ describe("indiekit/lib/navigation", () => {
 
   it("Indicates current item in navigation", () => {
     const result = getNavigation(
-      application,
-      { path: "/bar", session: { access_token: "token" } },
+      Indiekit,
+      mockRequest({ path: "/bar", session: { access_token: "token" } }),
       response,
     );
 

--- a/packages/indiekit/test/unit/plugins.js
+++ b/packages/indiekit/test/unit/plugins.js
@@ -4,17 +4,18 @@ import { getInstalledPlugin, getPluginId } from "../../lib/plugins.js";
 
 describe("indiekit/lib/plugins", async () => {
   it("Gets installed plug-in", () => {
-    const application = {
-      installedPlugins: [
-        {
-          id: "@scope-package-name",
-        },
-      ],
-    };
+    const installedPlugins = new Set([
+      {
+        id: "@scope-package-name",
+      },
+    ]);
 
-    assert.deepEqual(getInstalledPlugin(application, "@scope/package-name"), {
-      id: "@scope-package-name",
-    });
+    assert.deepEqual(
+      getInstalledPlugin(installedPlugins, "@scope/package-name"),
+      {
+        id: "@scope-package-name",
+      },
+    );
   });
 
   it("Gets normalised plug-in ID", () => {

--- a/packages/indiekit/test/unit/post-template.js
+++ b/packages/indiekit/test/unit/post-template.js
@@ -20,6 +20,7 @@ describe("indiekit/lib/post-templates", () => {
       plugins: ["@indiekit/preset-jekyll"],
     });
     const indiekit = await Indiekit.initialize({ config });
+    await indiekit.installPlugins();
     const { publication } = await indiekit.bootstrap();
     const postTemplate = getPostTemplate(publication);
     const result = postTemplate({ published: "2021-01-21" });

--- a/packages/indiekit/test/unit/post-template.js
+++ b/packages/indiekit/test/unit/post-template.js
@@ -21,8 +21,8 @@ describe("indiekit/lib/post-templates", () => {
     });
     const indiekit = await Indiekit.initialize({ config });
     await indiekit.installPlugins();
-    const { publication } = await indiekit.bootstrap();
-    const postTemplate = getPostTemplate(publication);
+    await indiekit.updatePublicationConfig();
+    const postTemplate = getPostTemplate(indiekit.publication);
     const result = postTemplate({ published: "2021-01-21" });
 
     assert.equal(result, "---\ndate: 2021-01-21\n---\n");

--- a/packages/indiekit/test/unit/post-types.js
+++ b/packages/indiekit/test/unit/post-types.js
@@ -12,8 +12,8 @@ describe("indiekit/lib/post-types", () => {
     });
     const indiekit = await Indiekit.initialize({ config });
     await indiekit.installPlugins();
-    const bootstrappedConfig = await indiekit.bootstrap();
-    const { article: result } = getPostTypes(bootstrappedConfig);
+    await indiekit.bootstrap();
+    const { article: result } = getPostTypes(indiekit);
 
     assert.equal(result.name, "Article");
     assert.equal(result.type, "article");
@@ -33,8 +33,8 @@ describe("indiekit/lib/post-types", () => {
   it("Returns custom post types", async () => {
     const config = await testConfig({ usePostTypes: true });
     const indiekit = await Indiekit.initialize({ config });
-    const bootstrappedConfig = await indiekit.bootstrap();
-    const { note: result } = getPostTypes(bootstrappedConfig);
+    await indiekit.bootstrap();
+    const { note: result } = getPostTypes(indiekit);
 
     assert.equal(result.name, "Custom note post type");
   });
@@ -45,9 +45,9 @@ describe("indiekit/lib/post-types", () => {
       usePreset: false,
     });
     const indiekit = await Indiekit.initialize({ config });
-    const bootstrappedConfig = await indiekit.bootstrap();
+    await indiekit.bootstrap();
     await indiekit.installPlugins();
-    const result = getPostTypes(bootstrappedConfig);
+    const result = getPostTypes(indiekit);
 
     assert.equal(result.article.name, "Article");
     assert.equal(result.like.name, "Like");

--- a/packages/indiekit/test/unit/post-types.js
+++ b/packages/indiekit/test/unit/post-types.js
@@ -12,7 +12,7 @@ describe("indiekit/lib/post-types", () => {
     });
     const indiekit = await Indiekit.initialize({ config });
     await indiekit.installPlugins();
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
     const { article: result } = getPostTypes(indiekit);
 
     assert.equal(result.name, "Article");
@@ -33,7 +33,7 @@ describe("indiekit/lib/post-types", () => {
   it("Returns custom post types", async () => {
     const config = await testConfig({ usePostTypes: true });
     const indiekit = await Indiekit.initialize({ config });
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
     const { note: result } = getPostTypes(indiekit);
 
     assert.equal(result.name, "Custom note post type");
@@ -45,7 +45,7 @@ describe("indiekit/lib/post-types", () => {
       usePreset: false,
     });
     const indiekit = await Indiekit.initialize({ config });
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
     await indiekit.installPlugins();
     const result = getPostTypes(indiekit);
 

--- a/packages/indiekit/test/unit/post-types.js
+++ b/packages/indiekit/test/unit/post-types.js
@@ -11,6 +11,7 @@ describe("indiekit/lib/post-types", () => {
       usePostTypes: true,
     });
     const indiekit = await Indiekit.initialize({ config });
+    await indiekit.installPlugins();
     const bootstrappedConfig = await indiekit.bootstrap();
     const { article: result } = getPostTypes(bootstrappedConfig);
 
@@ -45,6 +46,7 @@ describe("indiekit/lib/post-types", () => {
     });
     const indiekit = await Indiekit.initialize({ config });
     const bootstrappedConfig = await indiekit.bootstrap();
+    await indiekit.installPlugins();
     const result = getPostTypes(bootstrappedConfig);
 
     assert.equal(result.article.name, "Article");

--- a/packages/indiekit/test/unit/shortcuts.js
+++ b/packages/indiekit/test/unit/shortcuts.js
@@ -3,10 +3,10 @@ import { describe, it } from "node:test";
 import { mockResponse } from "mock-req-res";
 import { getShortcuts } from "../../lib/shortcuts.js";
 
-const application = {
-  installedPlugins: [],
-  locale: "en",
-  endpoints: [
+const Indiekit = {
+  application: { locale: "en" },
+  installedPlugins: new Set(),
+  endpoints: new Set([
     {
       id: "foo",
       name: "Foo plug-in",
@@ -22,7 +22,7 @@ const application = {
         },
       ],
     },
-  ],
+  ]),
 };
 const response = mockResponse({
   locals: { __: (value) => value },
@@ -30,7 +30,7 @@ const response = mockResponse({
 
 describe("indiekit/lib/shortcuts", () => {
   it("Returns shortcut items that require a database", () => {
-    const result = getShortcuts(application, response);
+    const result = getShortcuts(Indiekit, response);
 
     assert.notEqual(result[0].url, "/foo");
     assert.equal(result[0].url, "/bar");

--- a/packages/indiekit/test/unit/store.js
+++ b/packages/indiekit/test/unit/store.js
@@ -17,7 +17,7 @@ describe("indiekit/lib/store", async () => {
 
   it("Gets store from publication config", () => {
     const Indiekit = {
-      application: { installedPlugins: [store] },
+      installedPlugins: new Set([store]),
       publication: { store: "@indiekit-test/store" },
     };
     const result = getStore(Indiekit);
@@ -27,7 +27,7 @@ describe("indiekit/lib/store", async () => {
 
   it("Gets media store from publication config", () => {
     const Indiekit = {
-      application: { installedPlugins: [store] },
+      installedPlugins: new Set([store]),
       publication: { mediaStore: "@indiekit-test/store" },
     };
     const result = getMediaStore(Indiekit);

--- a/packages/indiekit/test/unit/store.js
+++ b/packages/indiekit/test/unit/store.js
@@ -9,7 +9,7 @@ describe("indiekit/lib/store", async () => {
   store.id = "@indiekit-test-store";
 
   it("Gets store from application config", () => {
-    const Indiekit = { application: { stores: [store] } };
+    const Indiekit = { stores: new Set([store]) };
     const result = getStore(Indiekit);
 
     assert.equal(result.info.name, "Test store");

--- a/packages/indiekit/views/homepage.njk
+++ b/packages/indiekit/views/homepage.njk
@@ -17,7 +17,7 @@
   }) }}
 
 <div class="widget-grid">
-{% for plugin in application.installedPlugins -%}
+{% for plugin in installedPlugins -%}
   {% include plugin.id + "-widget.njk" ignore missing %}
 {%- endfor %}
 </div>

--- a/packages/preset-eleventy/index.js
+++ b/packages/preset-eleventy/index.js
@@ -17,8 +17,7 @@ export default class EleventyPreset {
   }
 
   init(Indiekit) {
-    const { application } = Indiekit.config;
-    this.postTypes = getPostTypes(application.postTypes);
+    this.postTypes = getPostTypes(Indiekit.postTypes);
 
     Indiekit.addPreset(this);
   }

--- a/packages/preset-eleventy/lib/post-types.js
+++ b/packages/preset-eleventy/lib/post-types.js
@@ -6,11 +6,11 @@ import plur from "plur";
  * @returns {object} Updated post type configuration
  */
 export const getPostTypes = (postTypes) => {
-  for (const type of Object.keys(postTypes)) {
+  for (const type of postTypes.keys()) {
     const collection = plur(type);
 
-    postTypes[type] = {
-      ...postTypes[type],
+    postTypes.set(type, {
+      ...postTypes.get(type),
       post: {
         path: `${collection}/{yyyy}-{MM}-{dd}-{slug}.md`,
         url: `${collection}/{yyyy}/{MM}/{dd}/{slug}`,
@@ -18,7 +18,7 @@ export const getPostTypes = (postTypes) => {
       media: {
         path: `media/${collection}/{yyyy}/{MM}/{dd}/{filename}`,
       },
-    };
+    });
   }
 
   return postTypes;

--- a/packages/preset-eleventy/test/index.js
+++ b/packages/preset-eleventy/test/index.js
@@ -17,6 +17,7 @@ describe("preset-eleventy", async () => {
       },
     },
   });
+  await indiekit.installPlugins();
   const bootstrappedConfig = await indiekit.bootstrap();
 
   eleventy.init(bootstrappedConfig);

--- a/packages/preset-eleventy/test/index.js
+++ b/packages/preset-eleventy/test/index.js
@@ -18,9 +18,9 @@ describe("preset-eleventy", async () => {
     },
   });
   await indiekit.installPlugins();
-  const bootstrappedConfig = await indiekit.bootstrap();
+  await indiekit.updatePublicationConfig();
 
-  eleventy.init(bootstrappedConfig);
+  eleventy.init(indiekit);
 
   it("Initiates plug-in", async () => {
     assert.equal(indiekit.publication.preset.info.name, "Eleventy");

--- a/packages/preset-eleventy/test/index.js
+++ b/packages/preset-eleventy/test/index.js
@@ -32,7 +32,7 @@ describe("preset-eleventy", async () => {
   });
 
   it("Gets publication post types", () => {
-    assert.deepEqual(eleventy.postTypes.article.post, {
+    assert.deepEqual(eleventy.postTypes.get("article").post, {
       path: "articles/{yyyy}-{MM}-{dd}-{slug}.md",
       url: "articles/{yyyy}/{MM}/{dd}/{slug}",
     });

--- a/packages/preset-eleventy/test/unit/post-types.js
+++ b/packages/preset-eleventy/test/unit/post-types.js
@@ -2,50 +2,43 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { getPostTypes } from "../../lib/post-types.js";
 
-const postTypes = {
-  article: {
-    name: "Journal post",
-  },
-  note: {
-    name: "Micro post",
-  },
-  puppy: {
-    name: "Puppy post",
-  },
-};
+const postTypes = new Map();
+postTypes.set("article", { name: "Journal post" });
+postTypes.set("note", { name: "Micro post" });
+postTypes.set("puppy", { name: "Puppy post" });
 
 describe("preset-jekyll/lib/post-types", () => {
   it("Gets paths and URLs for configured post types", () => {
-    assert.deepEqual(getPostTypes(postTypes), {
-      article: {
-        name: "Journal post",
-        post: {
-          path: "articles/{yyyy}-{MM}-{dd}-{slug}.md",
-          url: "articles/{yyyy}/{MM}/{dd}/{slug}",
-        },
-        media: {
-          path: "media/articles/{yyyy}/{MM}/{dd}/{filename}",
-        },
+    const result = getPostTypes(postTypes);
+
+    assert.deepEqual(result.get("article"), {
+      name: "Journal post",
+      post: {
+        path: "articles/{yyyy}-{MM}-{dd}-{slug}.md",
+        url: "articles/{yyyy}/{MM}/{dd}/{slug}",
       },
-      note: {
-        name: "Micro post",
-        post: {
-          path: "notes/{yyyy}-{MM}-{dd}-{slug}.md",
-          url: "notes/{yyyy}/{MM}/{dd}/{slug}",
-        },
-        media: {
-          path: "media/notes/{yyyy}/{MM}/{dd}/{filename}",
-        },
+      media: {
+        path: "media/articles/{yyyy}/{MM}/{dd}/{filename}",
       },
-      puppy: {
-        name: "Puppy post",
-        post: {
-          path: "puppies/{yyyy}-{MM}-{dd}-{slug}.md",
-          url: "puppies/{yyyy}/{MM}/{dd}/{slug}",
-        },
-        media: {
-          path: "media/puppies/{yyyy}/{MM}/{dd}/{filename}",
-        },
+    });
+    assert.deepEqual(result.get("note"), {
+      name: "Micro post",
+      post: {
+        path: "notes/{yyyy}-{MM}-{dd}-{slug}.md",
+        url: "notes/{yyyy}/{MM}/{dd}/{slug}",
+      },
+      media: {
+        path: "media/notes/{yyyy}/{MM}/{dd}/{filename}",
+      },
+    });
+    assert.deepEqual(result.get("puppy"), {
+      name: "Puppy post",
+      post: {
+        path: "puppies/{yyyy}-{MM}-{dd}-{slug}.md",
+        url: "puppies/{yyyy}/{MM}/{dd}/{slug}",
+      },
+      media: {
+        path: "media/puppies/{yyyy}/{MM}/{dd}/{filename}",
       },
     });
   });

--- a/packages/preset-hugo/index.js
+++ b/packages/preset-hugo/index.js
@@ -47,8 +47,7 @@ export default class HugoPreset {
   }
 
   init(Indiekit) {
-    const { application } = Indiekit.config;
-    this.postTypes = getPostTypes(application.postTypes);
+    this.postTypes = getPostTypes(Indiekit.postTypes);
 
     Indiekit.addPreset(this);
   }

--- a/packages/preset-hugo/lib/post-types.js
+++ b/packages/preset-hugo/lib/post-types.js
@@ -2,11 +2,11 @@ import plur from "plur";
 
 /**
  * Get paths and URLs for configured post types
- * @param {object} postTypes - Post type configuration
+ * @param {Map} postTypes - Post type configuration
  * @returns {object} Updated post type configuration
  */
 export const getPostTypes = (postTypes) => {
-  for (const type of Object.keys(postTypes)) {
+  for (const type of postTypes.keys()) {
     const section = plur(type);
 
     /**
@@ -14,8 +14,8 @@ export const getPostTypes = (postTypes) => {
      * @see {@link https://gohugo.io/content-management/organization/}
      * @see {@link https://gohugo.io/content-management/static-files/}
      */
-    postTypes[type] = {
-      ...postTypes[type],
+    postTypes.set(type, {
+      ...postTypes.get(type),
       post: {
         path: `content/${section}/{slug}.md`,
         url: `${section}/{slug}`,
@@ -24,7 +24,7 @@ export const getPostTypes = (postTypes) => {
         path: `static/${section}/{filename}`,
         url: `${section}/{filename}`,
       },
-    };
+    });
   }
 
   return postTypes;

--- a/packages/preset-hugo/test/index.js
+++ b/packages/preset-hugo/test/index.js
@@ -18,9 +18,9 @@ describe("preset-hugo", async () => {
     },
   });
   await indiekit.installPlugins();
-  const bootstrappedConfig = await indiekit.bootstrap();
+  await indiekit.updatePublicationConfig();
 
-  hugo.init(bootstrappedConfig);
+  hugo.init(indiekit);
 
   it("Initiates plug-in", async () => {
     assert.equal(indiekit.publication.preset.info.name, "Hugo");

--- a/packages/preset-hugo/test/index.js
+++ b/packages/preset-hugo/test/index.js
@@ -17,6 +17,7 @@ describe("preset-hugo", async () => {
       },
     },
   });
+  await indiekit.installPlugins();
   const bootstrappedConfig = await indiekit.bootstrap();
 
   hugo.init(bootstrappedConfig);

--- a/packages/preset-hugo/test/index.js
+++ b/packages/preset-hugo/test/index.js
@@ -39,7 +39,7 @@ describe("preset-hugo", async () => {
   });
 
   it("Gets publication post types", () => {
-    assert.deepEqual(hugo.postTypes.article.post, {
+    assert.deepEqual(hugo.postTypes.get("article").post, {
       path: "content/articles/{slug}.md",
       url: "articles/{slug}",
     });

--- a/packages/preset-hugo/test/unit/post-types.js
+++ b/packages/preset-hugo/test/unit/post-types.js
@@ -2,53 +2,46 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { getPostTypes } from "../../lib/post-types.js";
 
-const postTypes = {
-  article: {
-    name: "Journal post",
-  },
-  note: {
-    name: "Micro post",
-  },
-  puppy: {
-    name: "Puppy post",
-  },
-};
+const postTypes = new Map();
+postTypes.set("article", { name: "Journal post" });
+postTypes.set("note", { name: "Micro post" });
+postTypes.set("puppy", { name: "Puppy post" });
 
 describe("preset-hugo/lib/post-types", () => {
   it("Gets paths and URLs for configured post types", () => {
-    assert.deepEqual(getPostTypes(postTypes), {
-      article: {
-        name: "Journal post",
-        post: {
-          path: "content/articles/{slug}.md",
-          url: "articles/{slug}",
-        },
-        media: {
-          path: "static/articles/{filename}",
-          url: "articles/{filename}",
-        },
+    const result = getPostTypes(postTypes);
+
+    assert.deepEqual(result.get("article"), {
+      name: "Journal post",
+      post: {
+        path: "content/articles/{slug}.md",
+        url: "articles/{slug}",
       },
-      note: {
-        name: "Micro post",
-        post: {
-          path: "content/notes/{slug}.md",
-          url: "notes/{slug}",
-        },
-        media: {
-          path: "static/notes/{filename}",
-          url: "notes/{filename}",
-        },
+      media: {
+        path: "static/articles/{filename}",
+        url: "articles/{filename}",
       },
-      puppy: {
-        name: "Puppy post",
-        post: {
-          path: "content/puppies/{slug}.md",
-          url: "puppies/{slug}",
-        },
-        media: {
-          path: "static/puppies/{filename}",
-          url: "puppies/{filename}",
-        },
+    });
+    assert.deepEqual(result.get("note"), {
+      name: "Micro post",
+      post: {
+        path: "content/notes/{slug}.md",
+        url: "notes/{slug}",
+      },
+      media: {
+        path: "static/notes/{filename}",
+        url: "notes/{filename}",
+      },
+    });
+    assert.deepEqual(result.get("puppy"), {
+      name: "Puppy post",
+      post: {
+        path: "content/puppies/{slug}.md",
+        url: "puppies/{slug}",
+      },
+      media: {
+        path: "static/puppies/{filename}",
+        url: "puppies/{filename}",
       },
     });
   });

--- a/packages/preset-jekyll/index.js
+++ b/packages/preset-jekyll/index.js
@@ -17,8 +17,7 @@ export default class JekyllPreset {
   }
 
   init(Indiekit) {
-    const { application } = Indiekit.config;
-    this.postTypes = getPostTypes(application.postTypes);
+    this.postTypes = getPostTypes(Indiekit.postTypes);
 
     Indiekit.addPreset(this);
   }

--- a/packages/preset-jekyll/lib/post-types.js
+++ b/packages/preset-jekyll/lib/post-types.js
@@ -2,11 +2,11 @@ import plur from "plur";
 
 /**
  * Get paths and URLs for configured post types
- * @param {object} postTypes - Post type configuration
+ * @param {Map} postTypes - Post type configuration
  * @returns {object} Updated post type configuration
  */
 export const getPostTypes = (postTypes) => {
-  for (const type of Object.keys(postTypes)) {
+  for (const type of postTypes.keys()) {
     const collection = plur(type);
 
     if (type === "article") {
@@ -14,8 +14,8 @@ export const getPostTypes = (postTypes) => {
        * Posts use `_posts` folder
        * @see {@link https://jekyllrb.com/docs/posts/}
        */
-      postTypes.article = {
-        ...postTypes.article,
+      postTypes.set("article", {
+        ...postTypes.get("article"),
         post: {
           path: "_posts/{yyyy}-{MM}-{dd}-{slug}.md",
           url: "{yyyy}/{MM}/{dd}/{slug}",
@@ -23,14 +23,14 @@ export const getPostTypes = (postTypes) => {
         media: {
           path: "media/{yyyy}/{MM}/{dd}/{filename}",
         },
-      };
+      });
     } else {
       /**
        * Other post types use collection folders
        * @see {@link https://jekyllrb.com/docs/collections/}
        */
-      postTypes[type] = {
-        ...postTypes[type],
+      postTypes.set(type, {
+        ...postTypes.get(type),
         post: {
           path: `_${collection}/{yyyy}-{MM}-{dd}-{slug}.md`,
           url: `${collection}/{yyyy}/{MM}/{dd}/{slug}`,
@@ -38,7 +38,7 @@ export const getPostTypes = (postTypes) => {
         media: {
           path: `media/${collection}/{yyyy}/{MM}/{dd}/{filename}`,
         },
-      };
+      });
     }
   }
 

--- a/packages/preset-jekyll/test/index.js
+++ b/packages/preset-jekyll/test/index.js
@@ -18,9 +18,9 @@ describe("preset-jekyll", async () => {
     },
   });
   await indiekit.installPlugins();
-  const bootstrappedConfig = await indiekit.bootstrap();
+  await indiekit.updatePublicationConfig();
 
-  jekyll.init(bootstrappedConfig);
+  jekyll.init(indiekit);
 
   it("Initiates plug-in", async () => {
     assert.equal(indiekit.publication.preset.info.name, "Jekyll");

--- a/packages/preset-jekyll/test/index.js
+++ b/packages/preset-jekyll/test/index.js
@@ -32,7 +32,7 @@ describe("preset-jekyll", async () => {
   });
 
   it("Gets publication post types", () => {
-    assert.deepEqual(jekyll.postTypes.article.post, {
+    assert.deepEqual(jekyll.postTypes.get("article").post, {
       path: "_posts/{yyyy}-{MM}-{dd}-{slug}.md",
       url: "{yyyy}/{MM}/{dd}/{slug}",
     });

--- a/packages/preset-jekyll/test/index.js
+++ b/packages/preset-jekyll/test/index.js
@@ -17,6 +17,7 @@ describe("preset-jekyll", async () => {
       },
     },
   });
+  await indiekit.installPlugins();
   const bootstrappedConfig = await indiekit.bootstrap();
 
   jekyll.init(bootstrappedConfig);

--- a/packages/preset-jekyll/test/unit/post-types.js
+++ b/packages/preset-jekyll/test/unit/post-types.js
@@ -2,50 +2,43 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { getPostTypes } from "../../lib/post-types.js";
 
-const postTypes = {
-  article: {
-    name: "Journal post",
-  },
-  note: {
-    name: "Micro post",
-  },
-  puppy: {
-    name: "Puppy post",
-  },
-};
+const postTypes = new Map();
+postTypes.set("article", { name: "Journal post" });
+postTypes.set("note", { name: "Micro post" });
+postTypes.set("puppy", { name: "Puppy post" });
 
 describe("preset-jekyll/lib/post-types", () => {
   it("Gets paths and URLs for configured post types", () => {
-    assert.deepEqual(getPostTypes(postTypes), {
-      article: {
-        name: "Journal post",
-        post: {
-          path: "_posts/{yyyy}-{MM}-{dd}-{slug}.md",
-          url: "{yyyy}/{MM}/{dd}/{slug}",
-        },
-        media: {
-          path: "media/{yyyy}/{MM}/{dd}/{filename}",
-        },
+    const result = getPostTypes(postTypes);
+
+    assert.deepEqual(result.get("article"), {
+      name: "Journal post",
+      post: {
+        path: "_posts/{yyyy}-{MM}-{dd}-{slug}.md",
+        url: "{yyyy}/{MM}/{dd}/{slug}",
       },
-      note: {
-        name: "Micro post",
-        post: {
-          path: "_notes/{yyyy}-{MM}-{dd}-{slug}.md",
-          url: "notes/{yyyy}/{MM}/{dd}/{slug}",
-        },
-        media: {
-          path: "media/notes/{yyyy}/{MM}/{dd}/{filename}",
-        },
+      media: {
+        path: "media/{yyyy}/{MM}/{dd}/{filename}",
       },
-      puppy: {
-        name: "Puppy post",
-        post: {
-          path: "_puppies/{yyyy}-{MM}-{dd}-{slug}.md",
-          url: "puppies/{yyyy}/{MM}/{dd}/{slug}",
-        },
-        media: {
-          path: "media/puppies/{yyyy}/{MM}/{dd}/{filename}",
-        },
+    });
+    assert.deepEqual(result.get("note"), {
+      name: "Micro post",
+      post: {
+        path: "_notes/{yyyy}-{MM}-{dd}-{slug}.md",
+        url: "notes/{yyyy}/{MM}/{dd}/{slug}",
+      },
+      media: {
+        path: "media/notes/{yyyy}/{MM}/{dd}/{filename}",
+      },
+    });
+    assert.deepEqual(result.get("puppy"), {
+      name: "Puppy post",
+      post: {
+        path: "_puppies/{yyyy}-{MM}-{dd}-{slug}.md",
+        url: "puppies/{yyyy}/{MM}/{dd}/{slug}",
+      },
+      media: {
+        path: "media/puppies/{yyyy}/{MM}/{dd}/{filename}",
       },
     });
   });

--- a/packages/store-bitbucket/test/index.js
+++ b/packages/store-bitbucket/test/index.js
@@ -39,7 +39,7 @@ describe("store-bitbucket", () => {
       },
     });
     await indiekit.installPlugins();
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
 
     assert.equal(
       indiekit.publication.store.info.name,

--- a/packages/store-bitbucket/test/index.js
+++ b/packages/store-bitbucket/test/index.js
@@ -38,6 +38,7 @@ describe("store-bitbucket", () => {
         "@indiekit/store-bitbucket": { user: "user", repo: "repo" },
       },
     });
+    await indiekit.installPlugins();
     await indiekit.bootstrap();
 
     assert.equal(

--- a/packages/store-file-system/test/index.js
+++ b/packages/store-file-system/test/index.js
@@ -37,7 +37,7 @@ describe("store-file-system", () => {
       },
     });
     await indiekit.installPlugins();
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
 
     assert.equal(indiekit.publication.store.info.name, "directory");
   });

--- a/packages/store-file-system/test/index.js
+++ b/packages/store-file-system/test/index.js
@@ -36,6 +36,7 @@ describe("store-file-system", () => {
         "@indiekit/store-file-system": { directory: "directory" },
       },
     });
+    await indiekit.installPlugins();
     await indiekit.bootstrap();
 
     assert.equal(indiekit.publication.store.info.name, "directory");

--- a/packages/store-ftp/test/index.js
+++ b/packages/store-ftp/test/index.js
@@ -56,6 +56,7 @@ describe("store-ftp", () => {
         "@indiekit/store-ftp": { user: "username", host: "127.0.0.1" },
       },
     });
+    await indiekit.installPlugins();
     await indiekit.bootstrap();
 
     assert.equal(indiekit.publication.store.info.name, "username on 127.0.0.1");

--- a/packages/store-ftp/test/index.js
+++ b/packages/store-ftp/test/index.js
@@ -57,7 +57,7 @@ describe("store-ftp", () => {
       },
     });
     await indiekit.installPlugins();
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
 
     assert.equal(indiekit.publication.store.info.name, "username on 127.0.0.1");
   });

--- a/packages/store-gitea/test/index.js
+++ b/packages/store-gitea/test/index.js
@@ -43,7 +43,7 @@ describe("store-github", async () => {
       },
     });
     await indiekit.installPlugins();
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
 
     assert.equal(indiekit.publication.store.info.name, "user/repo on Gitea");
   });

--- a/packages/store-gitea/test/index.js
+++ b/packages/store-gitea/test/index.js
@@ -42,6 +42,7 @@ describe("store-github", async () => {
         "@indiekit/store-gitea": { user: "user", repo: "repo" },
       },
     });
+    await indiekit.installPlugins();
     await indiekit.bootstrap();
 
     assert.equal(indiekit.publication.store.info.name, "user/repo on Gitea");

--- a/packages/store-github/test/index.js
+++ b/packages/store-github/test/index.js
@@ -36,6 +36,7 @@ describe("store-github", async () => {
         "@indiekit/store-github": { user: "user", repo: "repo", token: "123" },
       },
     });
+    await indiekit.installPlugins();
     await indiekit.bootstrap();
 
     assert.equal(indiekit.publication.store.info.name, "user/repo on GitHub");

--- a/packages/store-github/test/index.js
+++ b/packages/store-github/test/index.js
@@ -37,7 +37,7 @@ describe("store-github", async () => {
       },
     });
     await indiekit.installPlugins();
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
 
     assert.equal(indiekit.publication.store.info.name, "user/repo on GitHub");
   });

--- a/packages/store-gitlab/test/index.js
+++ b/packages/store-gitlab/test/index.js
@@ -41,6 +41,7 @@ describe("store-gitlab", async () => {
         "@indiekit/store-gitlab": { user: "username", repo: "repo" },
       },
     });
+    await indiekit.installPlugins();
     await indiekit.bootstrap();
 
     assert.equal(

--- a/packages/store-gitlab/test/index.js
+++ b/packages/store-gitlab/test/index.js
@@ -42,7 +42,7 @@ describe("store-gitlab", async () => {
       },
     });
     await indiekit.installPlugins();
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
 
     assert.equal(
       indiekit.publication.store.info.name,

--- a/packages/store-s3/test/index.js
+++ b/packages/store-s3/test/index.js
@@ -37,6 +37,7 @@ describe("store-s3", () => {
         "@indiekit/store-s3": { bucket: "website" },
       },
     });
+    await indiekit.installPlugins();
     await indiekit.bootstrap();
 
     assert.equal(indiekit.publication.store.info.name, "website bucket");

--- a/packages/store-s3/test/index.js
+++ b/packages/store-s3/test/index.js
@@ -38,7 +38,7 @@ describe("store-s3", () => {
       },
     });
     await indiekit.installPlugins();
-    await indiekit.bootstrap();
+    await indiekit.updatePublicationConfig();
 
     assert.equal(indiekit.publication.store.info.name, "website bucket");
   });


### PR DESCRIPTION
- Have plug-ins register features directly onto properties of `Indiekit` class
- Use `Set()` for `Indiekit.endpoints`, `Indiekit.installedPlugins`, `Indiekit.locales` and `Indiekit.stores`
- Use `Map()` for `Indiekit.localeCatalog`, `Indiekit.postTypes` and `Indiekit.validationSchemas` (in addition to [preceding refactor](https://github.com/getindiekit/indiekit/pull/780) which introduced a map for `Indiekit.collections`)
- Rename `bootstrap` to `updatePublicationConfig`; now that this method has a single purpose we can give it a clearer name
- The default config now shares the [same shape as that used by consumers](https://getindiekit.com/configuration/) and no longer adds private or undocumented values.

Introduces the following breaking API change:
- `Indiekit.config.application.postTypes` object replaced by `Indiekit.postTypes` map

While this makes the Indiekit class and its properties and methods clearer, some confusion is still potentially created in that these properties are added to `request.app.locals` under the `application` key. Refactoring how locals are named and assigned, and the impacting changes to endpoints that use these values will be tackled in a separate PR. Ideally by the end of this refactor, it should be clearer how Indiekit is structured.