### PR TITLE
[WIP]: Use class inheritance for plug-in API

### DIFF
--- a/helpers/frontend/index.js
+++ b/helpers/frontend/index.js
@@ -1,20 +1,12 @@
-import express from "express";
+import { IndiekitEndpointPlugin } from "@indiekit/plugin";
 
-const defaults = {
-  mountPath: "/frontend",
-};
+export default class FrontendEndpointPlugin extends IndiekitEndpointPlugin {
+  mountPath = "/frontend";
 
-const router = express.Router({ caseSensitive: true, mergeParams: true });
-
-export default class FrontendEndpoint {
-  constructor(options = {}) {
-    this.name = "Frontend endpoint";
-    this.options = { ...defaults, ...options };
-    this.mountPath = this.options.mountPath;
-  }
+  name = "Frontend endpoint";
 
   get routesPublic() {
-    router.get("/:page", (request, response) => {
+    this.router.get("/:page", (request, response) => {
       const { page } = request.params;
 
       response.render(`frontend-${page}`, {
@@ -22,7 +14,7 @@ export default class FrontendEndpoint {
       });
     });
 
-    router.post("/form", (request, response) => {
+    this.router.post("/form", (request, response) => {
       response.render(`frontend-form`, {
         title: `Frontend form (with errors)`,
         errors: {
@@ -34,10 +26,6 @@ export default class FrontendEndpoint {
       });
     });
 
-    return router;
-  }
-
-  init(Indiekit) {
-    Indiekit.addEndpoint(this);
+    return this.router;
   }
 }

--- a/helpers/store/index.js
+++ b/helpers/store/index.js
@@ -1,4 +1,5 @@
 import { IndiekitError } from "@indiekit/error";
+import { IndiekitStorePlugin } from "@indiekit/plugin";
 
 const defaults = {
   baseUrl: "https://store.example",
@@ -8,17 +9,22 @@ const defaults = {
  * @typedef Response
  * @property {object} response - HTTP response
  */
-export default class TestStore {
-  constructor(options = {}) {
-    this.name = "Test store";
-    this.options = { ...defaults, ...options };
-  }
+export default class TestStorePlugin extends IndiekitStorePlugin {
+  name = "Test store";
 
-  get info() {
-    const { baseUrl, user } = this.options;
-    return {
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.baseUrl] - Base URL
+   * @param {string} [options.user] - Username
+   */
+  constructor(options = {}) {
+    super(options);
+
+    this.options = { ...defaults, ...options };
+
+    this.info = {
       name: "Test store",
-      uid: `${baseUrl}/${user}`,
+      uid: `${this.options.baseUrl}/${this.options.user}`,
     };
   }
 
@@ -101,9 +107,5 @@ export default class TestStore {
   async deleteFile(path, message) {
     await this.#client(path, "DELETE", { message });
     return true;
-  }
-
-  init(Indiekit) {
-    Indiekit.addStore(this);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24470,7 +24470,8 @@
       "version": "1.0.0-beta.15",
       "license": "MIT",
       "dependencies": {
-        "@indiekit/error": "^1.0.0-beta.15"
+        "@indiekit/error": "^1.0.0-beta.15",
+        "@indiekit/plugin": "^1.0.0-beta.19"
       },
       "engines": {
         "node": ">=20"
@@ -24482,6 +24483,7 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19",
         "brevity": "^0.2.9",
         "html-to-text": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7075,12 +7075,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -23683,9 +23677,9 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19",
         "bcrypt": "^5.1.0",
-        "express": "^5.0.0",
         "express-validator": "^7.0.0",
         "jsonwebtoken": "^9.0.0",
         "microformats-parser": "^2.0.0"
@@ -23700,7 +23694,7 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
-        "express": "^5.0.0",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "express-validator": "^7.0.0"
       },
       "engines": {
@@ -23712,7 +23706,7 @@
       "version": "1.0.0-beta.10",
       "license": "MIT",
       "dependencies": {
-        "express": "^5.0.0",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "ipx": "^3.0.0"
       },
       "engines": {
@@ -23724,7 +23718,7 @@
       "version": "1.0.0-beta.10",
       "license": "MIT",
       "dependencies": {
-        "express": "^5.0.0",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "mime-types": "^2.1.35"
       },
       "engines": {
@@ -23758,10 +23752,9 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19",
         "debug": "^4.3.2",
-        "deepmerge": "^4.3.1",
-        "express": "^5.0.0",
         "file-type": "^20.0.0",
         "newbase60": "^1.3.1",
         "sharp": "^0.33.2"
@@ -23793,10 +23786,10 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19",
         "@paulrobertlloyd/mf2tojf2": "^2.1.0",
         "debug": "^4.3.2",
-        "express": "^5.0.0",
         "lodash": "^4.17.21",
         "markdown-it": "^14.0.0",
         "newbase60": "^1.3.1",
@@ -23831,9 +23824,9 @@
         "@indiekit/endpoint-micropub": "^1.0.0-beta.19",
         "@indiekit/error": "^1.0.0-beta.15",
         "@indiekit/frontend": "^1.0.0-beta.19",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19",
         "@paulrobertlloyd/mf2tojf2": "^2.1.0",
-        "express": "^5.0.0",
         "express-validator": "^7.0.0",
         "formatcoords": "^1.1.3"
       },
@@ -23847,7 +23840,7 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
-        "express": "^5.0.0",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "express-validator": "^7.0.0"
       },
       "engines": {
@@ -23860,7 +23853,7 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
-        "express": "^5.0.0",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -23873,308 +23866,11 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
-        "express": "^4.17.1",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "sanitize-html": "^2.14.0"
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
-    },
-    "packages/endpoint-webmention-io/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "packages/endpoint-webmention-io/node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
-    },
-    "packages/endpoint-webmention-io/node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "packages/endpoint-webmention-io/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "packages/error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24356,6 +24356,9 @@
       "name": "@indiekit/post-type-article",
       "version": "1.0.0-beta.10",
       "license": "MIT",
+      "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19"
+      },
       "engines": {
         "node": ">=20"
       }
@@ -24365,6 +24368,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {
@@ -24376,6 +24380,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {
@@ -24387,6 +24392,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {
@@ -24398,6 +24404,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {
@@ -24409,6 +24416,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {
@@ -24419,6 +24427,9 @@
       "name": "@indiekit/post-type-note",
       "version": "1.0.0-beta.8",
       "license": "MIT",
+      "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19"
+      },
       "engines": {
         "node": ">=20"
       }
@@ -24427,6 +24438,10 @@
       "name": "@indiekit/post-type-photo",
       "version": "1.0.0-beta.15",
       "license": "MIT",
+      "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
+        "@indiekit/util": "^1.0.0-beta.19"
+      },
       "engines": {
         "node": ">=20"
       }
@@ -24436,6 +24451,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {
@@ -24447,6 +24463,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {
@@ -24458,6 +24475,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {
@@ -24469,6 +24487,7 @@
       "version": "1.0.0-beta.19",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "@indiekit/util": "^1.0.0-beta.19"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24326,7 +24326,8 @@
       "license": "MIT",
       "dependencies": {
         "@indiekit/error": "^1.0.0-beta.15",
-        "debug": "^4.3.2"
+        "debug": "^4.3.2",
+        "express": "^5.0.0"
       },
       "engines": {
         "node": ">=20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24196,6 +24196,7 @@
       "version": "1.0.0-beta.10",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "camelcase-keys": "^9.0.0",
         "plur": "^5.1.0",
         "yaml": "^2.6.0"
@@ -24276,6 +24277,7 @@
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "camelcase-keys": "^9.0.0",
         "plur": "^5.1.0",
         "yaml": "^2.6.0"
@@ -24355,6 +24357,7 @@
       "version": "1.0.0-beta.15",
       "license": "MIT",
       "dependencies": {
+        "@indiekit/plugin": "^1.0.0-beta.19",
         "plur": "^5.1.0",
         "snakecase-keys": "^8.0.0",
         "yaml": "^2.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "cookie-session": "^2.0.0",
         "create-indiekit": "*",
         "date-fns": "^4.0.0",
-        "eslint": "9.21.0",
+        "eslint": "^9.21.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsdoc": "^50.0.0",
@@ -194,41 +194,41 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.20.3.tgz",
-      "integrity": "sha512-wPOzHYSsW+H97JkBLmnlOdJSpbb9mIiuNPycUCV5DgzSkJFaI/OFxXfZXAh1gqxK+hf0miKue1C9bltjWljrNA==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.20.4.tgz",
+      "integrity": "sha512-OZ3Xvvf+k7NMcwmmioIVX+76E/KKtN607NCMNsBEKe+uHqktZ+I5bmi/EVr2m5VF59Gnh9MTlJCdXtBiGjruxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.20.3.tgz",
-      "integrity": "sha512-XE3iduH9lA7iTQacDGofBQyIyIgaX8qbTRRdj1bOCmfzc9b98CoiMwhNwdTifmmMewmN0EhVF3hP8KjKWwX7Yw==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.20.4.tgz",
+      "integrity": "sha512-8pM5zQpHonCIBxKmMyBLgQoaSKUNBE5u741VEIjn2ArujolhoKRXempRAlLwEg5hrORKl9XIlit00ff4g6LWvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.3.tgz",
-      "integrity": "sha512-IYRd/A/R3BXeaQVT2805lZEdWo54v39Lqa7ABOxIYnUvX2vvOMW1AyzCuT0U7Q+uPdD4UW48zksUKRixShcWxA==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.4.tgz",
+      "integrity": "sha512-OCGa8hKAP6kQKBwi+tu9flTXshz4qeCK5P8J6bI1qq8KYs+/TU1xSotT+E7hO+uyDanGU6dT6soiMSi4A38JgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -236,151 +236,151 @@
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.20.3.tgz",
-      "integrity": "sha512-QGc/bmDUBgzB71rDL6kihI2e1Mx6G6PxYO5Ks84iL3tDcIel1aFuxtRF14P8saGgdIe1B6I6QkpkeIddZ6vWQw==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.20.4.tgz",
+      "integrity": "sha512-MroyJStJFLf/cYeCbguCRdrA2U6miDVqbi3t9ZGovBWWTef7BZwVQG0mLyInzp4MIjBfwqu3xTrhxsiiOavX3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.20.3.tgz",
-      "integrity": "sha512-zuM31VNPDJ1LBIwKbYGz/7+CSm+M8EhlljDamTg8AnDilnCpKjBebWZR5Tftv/FdWSro4tnYGOIz1AURQgZ+tQ==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.20.4.tgz",
+      "integrity": "sha512-bVR5sxFfgCQ+G0ZegGVhBqtaDd7jCfr33m5mGuT43U+bH//xeqAHQyIS4abcmRulwqeIAHNm5Yl2J7grT3z//A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.20.3.tgz",
-      "integrity": "sha512-Nn872PuOI8qzi1bxMMhJ0t2AzVBqN01jbymBQOkypvZHrrjZPso3iTpuuLLo9gi3yc/08vaaWTAwJfPhxPwJUw==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.20.4.tgz",
+      "integrity": "sha512-ZHsV0vceNDR87wIVaz7VjxilwCUCkzbuy4QnqIdnQs3NnC43is7KKbEtKueuNw+YGMdx+wmD5kRI2XKip1R93A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.20.3.tgz",
-      "integrity": "sha512-9+Fm1ahV8/2goSIPIqZnVitV5yHW5E5xTdKy33xnqGd45A9yVv5tTkudWzEXsbfBB47j9Xb3uYPZjAvV5RHbKA==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.20.4.tgz",
+      "integrity": "sha512-hXM2LpwTzG5kGQSyq3feIijzzl6vkjYPP+LF3ru1relNUIh7fWJ4uYQay2NMNbWX5LWQzF8Vr9qlIA139doQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.20.3.tgz",
-      "integrity": "sha512-5GHNTiZ3saLjTNyr6WkP5hzDg2eFFAYWomvPcm9eHWskjzXt8R0IOiW9kkTS6I6hXBwN5H9Zna5mZDSqqJdg+g==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.20.4.tgz",
+      "integrity": "sha512-idAe53XsTlLSSQ7pJcjscUEmc67vEM+VohYkr78Ebfb43vtfKH0ik8ux9OGQpLRNGntaHqpe/lfU5PDRi5/92w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.20.3.tgz",
-      "integrity": "sha512-KUWQbTPoRjP37ivXSQ1+lWMfaifCCMzTnEcEnXwAmherS5Tp7us6BAqQDMGOD4E7xyaS2I8pto6WlOzxH+CxmA==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.20.4.tgz",
+      "integrity": "sha512-O6HjdSWtyu5LhHR7gdU83oWbl1vVVRwoTxkENHF61Ar7l9C1Ok91VtnK7RtXB9pJL1kpIMDExwZOT5sEN2Ppfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.20.3.tgz",
-      "integrity": "sha512-oo/gG77xTTTclkrdFem0Kmx5+iSRFiwuRRdxZETDjwzCI7svutdbwBgV/Vy4D4QpYaX4nhY/P43k84uEowCE4Q==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.20.4.tgz",
+      "integrity": "sha512-p8M78pQjPrN6PudO2TnkWiOJbyp/IPhgCFBW8aZrLshhZpPkV9N4u0YsU/w6OoeYDKSxmXntWQrKYiU1dVRWfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-common": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.3.tgz",
-      "integrity": "sha512-BkkW7otbiI/Er1AiEPZs1h7lxbtSO9p09jFhv3/iT8/0Yz0CY79VJ9iq+Wv1+dq/l0OxnMpBy8mozrieGA3mXQ==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.4.tgz",
+      "integrity": "sha512-Y8GThjDVdhFUurZKKDdzAML/LNKOA/BOydEcaFeb/g4Iv4Iq0qQJs6aIbtdsngUU6cu74qH/2P84kr2h16uVvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3"
+        "@algolia/client-common": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.20.3.tgz",
-      "integrity": "sha512-eAVlXz7UNzTsA1EDr+p0nlIH7WFxo7k3NMxYe8p38DH8YVWLgm2MgOVFUMNg9HCi6ZNOi/A2w/id2ZZ4sKgUOw==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.20.4.tgz",
+      "integrity": "sha512-OrAUSrvbFi46U7AxOXkyl9QQiaW21XWpixWmcx3D2S65P/DCIGOVE6K2741ZE+WiKIqp+RSYkyDFj3BiFHzLTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3"
+        "@algolia/client-common": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.3.tgz",
-      "integrity": "sha512-FqR3pQPfHfQyX1wgcdK6iyqu86yP76MZd4Pzj1y/YLMj9rRmRCY0E0AffKr//nrOFEwv6uY8BQY4fd9/6b0ZCg==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.4.tgz",
+      "integrity": "sha512-Jc/bofGBw4P9nBii4oCzCqqusv8DAFFORfUD2Ce1cZk3fvUPk+q/Qnu7i9JpTSHjMc0MWzqApLdq7Nwh1gelLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.20.3"
+        "@algolia/client-common": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -1314,17 +1314,17 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "19.7.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.7.1.tgz",
-      "integrity": "sha512-iObGjR1tE/PfDtDTEfd+tnRkB3/HJzpQqRTyofS2MPPkDn1mp3DBC8SoPDayokfAy+xKhF8+bwRCJO25Nea0YQ==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.0.tgz",
+      "integrity": "sha512-t/fCrLVu+Ru01h0DtlgHZXbHV2Y8gKocTR5elDOqIRUzQd0/6hpt2VIWOj9b3NDo7y4/gfxeR2zRtXq/qO6iUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^19.5.0",
-        "@commitlint/lint": "^19.7.1",
-        "@commitlint/load": "^19.6.1",
-        "@commitlint/read": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/format": "^19.8.0",
+        "@commitlint/lint": "^19.8.0",
+        "@commitlint/load": "^19.8.0",
+        "@commitlint/read": "^19.8.0",
+        "@commitlint/types": "^19.8.0",
         "tinyexec": "^0.3.0",
         "yargs": "^17.0.0"
       },
@@ -1336,13 +1336,13 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "19.7.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.7.1.tgz",
-      "integrity": "sha512-fsEIF8zgiI/FIWSnykdQNj/0JE4av08MudLTyYHm4FlLWemKoQvPNUYU2M/3tktWcCEyq7aOkDDgtjrmgWFbvg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.0.tgz",
+      "integrity": "sha512-9I2kKJwcAPwMoAj38hwqFXG0CzS2Kj+SAByPUQ0SlHTfb7VUhYVmo7G2w2tBrqmOf7PFd6MpZ/a1GQJo8na8kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "engines": {
@@ -1350,13 +1350,13 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.5.0.tgz",
-      "integrity": "sha512-CHtj92H5rdhKt17RmgALhfQt95VayrUo2tSqY9g2w+laAXyk7K/Ef6uPm9tn5qSIwSmrLjKaXK9eiNuxmQrDBw==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.0.tgz",
+      "integrity": "sha512-+r5ZvD/0hQC3w5VOHJhGcCooiAVdynFlCe2d6I9dU+PvXdV3O+fU4vipVg+6hyLbQUuCH82mz3HnT/cBQTYYuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -1364,13 +1364,13 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.5.0.tgz",
-      "integrity": "sha512-Kv0pYZeMrdg48bHFEU5KKcccRfKmISSm9MvgIgkpI6m+ohFTB55qZlBW6eYqh/XDfRuIO0x4zSmvBjmOwWTwkg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.0.tgz",
+      "integrity": "sha512-kNiNU4/bhEQ/wutI1tp1pVW1mQ0QbAjfPRo5v8SaxoVV+ARhkB8Wjg3BSseNYECPzWWfg/WDqQGIfV1RaBFQZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -1382,9 +1382,9 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.5.0.tgz",
-      "integrity": "sha512-aqyGgytXhl2ejlk+/rfgtwpPexYyri4t8/n4ku6rRJoRhGZpLFMqrZ+YaubeGysCP6oz4mMA34YSTaSOKEeNrg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.0.tgz",
+      "integrity": "sha512-fuLeI+EZ9x2v/+TXKAjplBJWI9CNrHnyi5nvUQGQt4WRkww/d95oVRsc9ajpt4xFrFmqMZkd/xBQHZDvALIY7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1392,13 +1392,13 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.5.0.tgz",
-      "integrity": "sha512-yNy088miE52stCI3dhG/vvxFo9e4jFkU1Mj3xECfzp/bIS/JUay4491huAlVcffOoMK1cd296q0W92NlER6r3A==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.0.tgz",
+      "integrity": "sha512-EOpA8IERpQstxwp/WGnDArA7S+wlZDeTeKi98WMOvaDLKbjptuHWdOYYr790iO7kTCif/z971PKPI2PkWMfOxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "chalk": "^5.3.0"
       },
       "engines": {
@@ -1406,13 +1406,13 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "19.7.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.7.1.tgz",
-      "integrity": "sha512-3IaOc6HVg2hAoGleRK3r9vL9zZ3XY0rf1RsUf6jdQLuaD46ZHnXBiOPTyQ004C4IvYjSWqJwlh0/u2P73aIE3g==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.0.tgz",
+      "integrity": "sha512-L2Jv9yUg/I+jF3zikOV0rdiHUul9X3a/oU5HIXhAJLE2+TXTnEBfqYP9G5yMw/Yb40SnR764g4fyDK6WR2xtpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -1420,32 +1420,32 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "19.7.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.7.1.tgz",
-      "integrity": "sha512-LhcPfVjcOcOZA7LEuBBeO00o3MeZa+tWrX9Xyl1r9PMd5FWsEoZI9IgnGqTKZ0lZt5pO3ZlstgnRyY1CJJc9Xg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.0.tgz",
+      "integrity": "sha512-+/NZKyWKSf39FeNpqhfMebmaLa1P90i1Nrb1SrA7oSU5GNN/lksA4z6+ZTnsft01YfhRZSYMbgGsARXvkr/VLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^19.7.1",
-        "@commitlint/parse": "^19.5.0",
-        "@commitlint/rules": "^19.6.0",
-        "@commitlint/types": "^19.5.0"
+        "@commitlint/is-ignored": "^19.8.0",
+        "@commitlint/parse": "^19.8.0",
+        "@commitlint/rules": "^19.8.0",
+        "@commitlint/types": "^19.8.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "19.6.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.6.1.tgz",
-      "integrity": "sha512-kE4mRKWWNju2QpsCWt428XBvUH55OET2N4QKQ0bF85qS/XbsRGG1MiTByDNlEVpEPceMkDr46LNH95DtRwcsfA==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.0.tgz",
+      "integrity": "sha512-4rvmm3ff81Sfb+mcWT5WKlyOa+Hd33WSbirTVUer0wjS1Hv/Hzr07Uv1ULIV9DkimZKNyOwXn593c+h8lsDQPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^19.5.0",
-        "@commitlint/execute-rule": "^19.5.0",
-        "@commitlint/resolve-extends": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/config-validator": "^19.8.0",
+        "@commitlint/execute-rule": "^19.8.0",
+        "@commitlint/resolve-extends": "^19.8.0",
+        "@commitlint/types": "^19.8.0",
         "chalk": "^5.3.0",
         "cosmiconfig": "^9.0.0",
         "cosmiconfig-typescript-loader": "^6.1.0",
@@ -1458,9 +1458,9 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.5.0.tgz",
-      "integrity": "sha512-R7AM4YnbxN1Joj1tMfCyBryOC5aNJBdxadTZkuqtWi3Xj0kMdutq16XQwuoGbIzL2Pk62TALV1fZDCv36+JhTQ==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.0.tgz",
+      "integrity": "sha512-qs/5Vi9bYjf+ZV40bvdCyBn5DvbuelhR6qewLE8Bh476F7KnNyLfdM/ETJ4cp96WgeeHo6tesA2TMXS0sh5X4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1468,13 +1468,13 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.5.0.tgz",
-      "integrity": "sha512-cZ/IxfAlfWYhAQV0TwcbdR1Oc0/r0Ik1GEessDJ3Lbuma/MRO8FRQX76eurcXtmhJC//rj52ZSZuXUg0oIX0Fw==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.0.tgz",
+      "integrity": "sha512-YNIKAc4EXvNeAvyeEnzgvm1VyAe0/b3Wax7pjJSwXuhqIQ1/t2hD3OYRXb6D5/GffIvaX82RbjD+nWtMZCLL7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
@@ -1483,14 +1483,14 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.5.0.tgz",
-      "integrity": "sha512-TjS3HLPsLsxFPQj6jou8/CZFAmOP2y+6V4PGYt3ihbQKTY1Jnv0QG28WRKl/d1ha6zLODPZqsxLEov52dhR9BQ==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.0.tgz",
+      "integrity": "sha512-6ywxOGYajcxK1y1MfzrOnwsXO6nnErna88gRWEl3qqOOP8MDu/DTeRkGLXBFIZuRZ7mm5yyxU5BmeUvMpNte5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/top-level": "^19.8.0",
+        "@commitlint/types": "^19.8.0",
         "git-raw-commits": "^4.0.0",
         "minimist": "^1.2.8",
         "tinyexec": "^0.3.0"
@@ -1500,14 +1500,14 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.5.0.tgz",
-      "integrity": "sha512-CU/GscZhCUsJwcKTJS9Ndh3AKGZTNFIOoQB2n8CmFnizE0VnEuJoum+COW+C1lNABEeqk6ssfc1Kkalm4bDklA==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.0.tgz",
+      "integrity": "sha512-CLanRQwuG2LPfFVvrkTrBR/L/DMy3+ETsgBqW1OvRxmzp/bbVJW0Xw23LnnExgYcsaFtos967lul1CsbsnJlzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/config-validator": "^19.8.0",
+        "@commitlint/types": "^19.8.0",
         "global-directory": "^4.0.1",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
@@ -1518,25 +1518,25 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.6.0.tgz",
-      "integrity": "sha512-1f2reW7lbrI0X0ozZMesS/WZxgPa4/wi56vFuJENBmed6mWq5KsheN/nxqnl/C23ioxpPO/PL6tXpiiFy5Bhjw==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.0.tgz",
+      "integrity": "sha512-IZ5IE90h6DSWNuNK/cwjABLAKdy8tP8OgGVGbXe1noBEX5hSsu00uRlLu6JuruiXjWJz2dZc+YSw3H0UZyl/mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^19.5.0",
-        "@commitlint/message": "^19.5.0",
-        "@commitlint/to-lines": "^19.5.0",
-        "@commitlint/types": "^19.5.0"
+        "@commitlint/ensure": "^19.8.0",
+        "@commitlint/message": "^19.8.0",
+        "@commitlint/to-lines": "^19.8.0",
+        "@commitlint/types": "^19.8.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.5.0.tgz",
-      "integrity": "sha512-R772oj3NHPkodOSRZ9bBVNq224DOxQtNef5Pl8l2M8ZnkkzQfeSTr4uxawV2Sd3ui05dUVzvLNnzenDBO1KBeQ==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.0.tgz",
+      "integrity": "sha512-3CKLUw41Cur8VMjh16y8LcsOaKbmQjAKCWlXx6B0vOUREplp6em9uIVhI8Cv934qiwkbi2+uv+mVZPnXJi1o9A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1544,9 +1544,9 @@
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.5.0.tgz",
-      "integrity": "sha512-IP1YLmGAk0yWrImPRRc578I3dDUI5A2UBJx9FbSOjxe9sTlzFiwVJ+zeMLgAtHMtGZsC8LUnzmW1qRemkFU4ng==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.0.tgz",
+      "integrity": "sha512-Rphgoc/omYZisoNkcfaBRPQr4myZEHhLPx2/vTXNLjiCw4RgfPR1wEgUpJ9OOmDCiv5ZyIExhprNLhteqH4FuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1557,9 +1557,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.5.0.tgz",
-      "integrity": "sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz",
+      "integrity": "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1821,292 +1821,275 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
@@ -2126,20 +2109,19 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
@@ -2159,88 +2141,83 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3281,9 +3258,9 @@
       }
     },
     "node_modules/@lerna/create": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.2.0.tgz",
-      "integrity": "sha512-kyrAc709xhf79Ci2qM+neMfe3IuT89kJyqdMe+YK16kkTNlXedmmQOSs2ARdlEqVVGCWu7M75Dt2VoCBZPnZ8g==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.2.1.tgz",
+      "integrity": "sha512-Cz2u/fwc03D1EE6VFZCLMmI8FIUtGmxHQ3ECeNblsxv9i0YSKWe4Xm18sjO1xltG/K5ByiH8/HMeY9dlyAv22A==",
       "license": "MIT",
       "dependencies": {
         "@npmcli/arborist": "7.5.4",
@@ -3291,7 +3268,7 @@
         "@npmcli/run-script": "8.1.0",
         "@nx/devkit": ">=17.1.2 < 21",
         "@octokit/plugin-enterprise-rest": "6.0.1",
-        "@octokit/rest": "19.0.11",
+        "@octokit/rest": "20.1.2",
         "aproba": "2.0.0",
         "byte-size": "8.1.1",
         "chalk": "4.1.0",
@@ -4050,9 +4027,9 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.4.6.tgz",
-      "integrity": "sha512-XGnCu4p9HUrs6pDZmfpBF5hmmvXzLvV+oZJP0slFRoi9hVdXiZ31t+Vh0AQc7zSbtPeCxEJDxY4dIJKgdesR0A==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.5.0.tgz",
+      "integrity": "sha512-FLHjNRb6VImdlnDsp3ioIdM600y2xPvN88LFV9zPrG2hDXSaD9Np9YBZvvfCr4x46MrPCTTMoAVwWsCXIBgchg==",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.7",
@@ -4093,9 +4070,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.4.6.tgz",
-      "integrity": "sha512-yYBkXCqx9XDS88IKlbXQUMKAmNE6OA7AwmreDabL0zKCeB5x9qit5iaGwQOYCA7PSdjFQTYvPdKK+S3ytKCJ2w==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.5.0.tgz",
+      "integrity": "sha512-HlMMC4d253kk/yrafiepk8bhXMl+v4BIugftwUzRl7AOznyNgaj5WDaIVXZLZzt+WwYw6CTb+zYxfY4LuPFvOg==",
       "cpu": [
         "arm64"
       ],
@@ -4109,9 +4086,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.4.6.tgz",
-      "integrity": "sha512-YeGCTQPmZmWYSJ3Km8rsx3YhohbQNp8grclyEp4KA7GXrPY+AKA9hcy0e5KwF4hPP41EEYkju2Xpl0XdmOfdBQ==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.5.0.tgz",
+      "integrity": "sha512-+LO8YC5Iy1168saPeItNePChToP2TuRCj3MuxEtTTJXoRlab38rNaOjWaV1itvtcgrzkQi/IohINWMI8WC5b7g==",
       "cpu": [
         "x64"
       ],
@@ -4125,9 +4102,9 @@
       }
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.4.6.tgz",
-      "integrity": "sha512-49Ad0ysTWrNARmZxc02bmWfrGT5XKEnb5+Nms+RGzQVs+5WI6yqKx2iuLGrx2CDY0FEY11Z0zFpwvrZPGnnLXw==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.5.0.tgz",
+      "integrity": "sha512-he3VOuj35XDAAmO3s6LqiWx00CsCMgHceNOHziCELQL0tfQlvvyI0Agmhesw68BAbabt+mKH9g+miENiaMknbg==",
       "cpu": [
         "x64"
       ],
@@ -4141,9 +4118,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.4.6.tgz",
-      "integrity": "sha512-+SMu0xYf2Qim2AC4eYn2SKLXd94UwudMIdPiwbHQUtqRnX88T8rGQKxtINdEAEmIt/KkHyceyJ7lpHGRKmFfbw==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.5.0.tgz",
+      "integrity": "sha512-xeysjXvm4xZa/ED7XlbzuS28sCOGZ0AlS7DKWRxEMv60iprxewj0WKPdH7RveiNNauzgHWOW/wxvTWXRu+i36Q==",
       "cpu": [
         "arm"
       ],
@@ -4157,9 +4134,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.4.6.tgz",
-      "integrity": "sha512-1u+qawDO4R8w6op2mqIECzJ8YEViPhpqyq3RiRyAchPodUgrd1rnYnYj+xgQeED4d+L+djeZfhN6000WDhZ5oA==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.5.0.tgz",
+      "integrity": "sha512-pj+6OA7d1ltkW/ZYFooi3bDtqVFPxi8YYiZlQx7enEuOxbrTvpjEPvBjVyf+oYpCe9rfKlx9ghzufqsI4uGM0w==",
       "cpu": [
         "arm64"
       ],
@@ -4173,9 +4150,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.4.6.tgz",
-      "integrity": "sha512-8sFM3Z8k2iojXpL1E/ynlp+BPD8YWCs12cc+qk/4Ke5uOILcpDQ7XZSmzYoNIxp/0fcbZ1bosE+o7Lx4sbpfjQ==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.5.0.tgz",
+      "integrity": "sha512-gCIJEb/VYv6pxiAcSeizX0jpOmTnPmgYVi2EZLSWus0Pg6FIwMHE4MX5kuqehyvnDt9xInb7Rh8vgz/JBOOsbA==",
       "cpu": [
         "arm64"
       ],
@@ -4189,9 +4166,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.4.6.tgz",
-      "integrity": "sha512-9t8jPREQN8a2j09O9q9aQI4cP6UXn7tOD+UVYhlQ9EO+EsHKCcaTzszeLoatySVxzeG0RB3vutMgaa8AiS4qcA==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.5.0.tgz",
+      "integrity": "sha512-hfCDmfy7TBQJdgBwNvOh55e8Y00Cxcddw2QeKguvy6vsnVa7fesXDWCw2t3m/VPPQDKQGd8cY1lS1JqX3N+wCA==",
       "cpu": [
         "x64"
       ],
@@ -4205,9 +4182,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.4.6.tgz",
-      "integrity": "sha512-4EO71ND0OJcvinYNc+enB3ouFeKWjCcb73xG2RdjF5s8A9/RFFK6Z3zasYTmGWR06nSLm3mi6xiyiNXWvIdZMA==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.5.0.tgz",
+      "integrity": "sha512-RTTCPjZNSDFE5mUdavDFimDw/aXNBY0w+iuRM5q17rDHxwa//DghCY0GEkBdfuxD7wpw+sRwE18mWsNDek5lXA==",
       "cpu": [
         "x64"
       ],
@@ -4221,9 +4198,9 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.4.6.tgz",
-      "integrity": "sha512-o8Vurr2c9SMP+a2jrBD3VUkQqmHXqi1yC+NJHMzO7GiVPaCFoJR1IizAECXIiKUXv5dB+WFQow7yzVkQQAjk6g==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.5.0.tgz",
+      "integrity": "sha512-nT9WlG0QA8D74UJhEP1feGrV00/bas1nnqS+zkwnpJs0vcPmMuIktdETh3lEnqrGD04R7GtwbKtoGIGiZh5m9w==",
       "cpu": [
         "arm64"
       ],
@@ -4237,9 +4214,9 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.4.6.tgz",
-      "integrity": "sha512-PtBlsTJHsHeAEawt2HrWkSEsHbwu7MlqFIrw8cS+tg7ZblpesUWva1L3Ylx0hEcQrY7UjMGDR0RVo2DKAUvKZA==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.5.0.tgz",
+      "integrity": "sha512-KQVqFSYfc8ToSBgzhVNV8WcFEvLdy1zp58qwewa0xnE7DDncMbA+6YoVizUcQ/6GZRlMJ9sdVn3kwm5B8eD5mg==",
       "cpu": [
         "x64"
       ],
@@ -4253,64 +4230,63 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-token": "^3.0.0",
-        "@octokit/graphql": "^5.0.0",
-        "@octokit/request": "^6.0.0",
-        "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "is-plain-object": "^5.0.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^6.0.0",
-        "@octokit/types": "^9.0.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-      "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-enterprise-rest": {
@@ -4320,113 +4296,98 @@
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+      "version": "11.4.4-cjs.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+      "integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@octokit/types": "^9.2.3"
+        "@octokit/types": "^13.7.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=4"
+        "@octokit/core": "5"
       }
     },
     "node_modules/@octokit/plugin-request-log": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@octokit/core": ">=3"
+        "@octokit/core": "5"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-      "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
+      "version": "13.3.2-cjs.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+      "integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^10.0.0"
+        "@octokit/types": "^13.8.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/core": "^5"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^7.0.0",
-        "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
-        "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.7",
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^9.0.0",
+        "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "19.0.11",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.11.tgz",
-      "integrity": "sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==",
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+      "integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^6.1.2",
-        "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
-    "node_modules/@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
-      "license": "MIT"
-    },
     "node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^23.0.1"
       }
     },
     "node_modules/@open-draft/deferred-promise": {
@@ -4829,9 +4790,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
-      "integrity": "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.35.0.tgz",
+      "integrity": "sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ==",
       "cpu": [
         "arm"
       ],
@@ -4843,9 +4804,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.9.tgz",
-      "integrity": "sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.35.0.tgz",
+      "integrity": "sha512-FtKddj9XZudurLhdJnBl9fl6BwCJ3ky8riCXjEw3/UIbjmIY58ppWwPEvU3fNu+W7FUsAsB1CdH+7EQE6CXAPA==",
       "cpu": [
         "arm64"
       ],
@@ -4857,9 +4818,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.9.tgz",
-      "integrity": "sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.35.0.tgz",
+      "integrity": "sha512-Uk+GjOJR6CY844/q6r5DR/6lkPFOw0hjfOIzVx22THJXMxktXG6CbejseJFznU8vHcEBLpiXKY3/6xc+cBm65Q==",
       "cpu": [
         "arm64"
       ],
@@ -4871,9 +4832,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.9.tgz",
-      "integrity": "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.35.0.tgz",
+      "integrity": "sha512-3IrHjfAS6Vkp+5bISNQnPogRAW5GAV1n+bNCrDwXmfMHbPl5EhTmWtfmwlJxFRUCBZ+tZ/OxDyU08aF6NI/N5Q==",
       "cpu": [
         "x64"
       ],
@@ -4885,9 +4846,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.9.tgz",
-      "integrity": "sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.35.0.tgz",
+      "integrity": "sha512-sxjoD/6F9cDLSELuLNnY0fOrM9WA0KrM0vWm57XhrIMf5FGiN8D0l7fn+bpUeBSU7dCgPV2oX4zHAsAXyHFGcQ==",
       "cpu": [
         "arm64"
       ],
@@ -4899,9 +4860,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.9.tgz",
-      "integrity": "sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.35.0.tgz",
+      "integrity": "sha512-2mpHCeRuD1u/2kruUiHSsnjWtHjqVbzhBkNVQ1aVD63CcexKVcQGwJ2g5VphOd84GvxfSvnnlEyBtQCE5hxVVw==",
       "cpu": [
         "x64"
       ],
@@ -4913,9 +4874,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.9.tgz",
-      "integrity": "sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.35.0.tgz",
+      "integrity": "sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==",
       "cpu": [
         "arm"
       ],
@@ -4927,9 +4888,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.9.tgz",
-      "integrity": "sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.35.0.tgz",
+      "integrity": "sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==",
       "cpu": [
         "arm"
       ],
@@ -4941,9 +4902,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.9.tgz",
-      "integrity": "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.35.0.tgz",
+      "integrity": "sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==",
       "cpu": [
         "arm64"
       ],
@@ -4955,9 +4916,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.9.tgz",
-      "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.35.0.tgz",
+      "integrity": "sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==",
       "cpu": [
         "arm64"
       ],
@@ -4969,9 +4930,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.9.tgz",
-      "integrity": "sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.35.0.tgz",
+      "integrity": "sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==",
       "cpu": [
         "loong64"
       ],
@@ -4983,9 +4944,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.9.tgz",
-      "integrity": "sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.35.0.tgz",
+      "integrity": "sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==",
       "cpu": [
         "ppc64"
       ],
@@ -4997,9 +4958,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.9.tgz",
-      "integrity": "sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.35.0.tgz",
+      "integrity": "sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==",
       "cpu": [
         "riscv64"
       ],
@@ -5011,9 +4972,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.9.tgz",
-      "integrity": "sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.35.0.tgz",
+      "integrity": "sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==",
       "cpu": [
         "s390x"
       ],
@@ -5025,9 +4986,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
-      "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.35.0.tgz",
+      "integrity": "sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==",
       "cpu": [
         "x64"
       ],
@@ -5038,9 +4999,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.9.tgz",
-      "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.35.0.tgz",
+      "integrity": "sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==",
       "cpu": [
         "x64"
       ],
@@ -5052,9 +5013,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.9.tgz",
-      "integrity": "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.35.0.tgz",
+      "integrity": "sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==",
       "cpu": [
         "arm64"
       ],
@@ -5066,9 +5027,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.9.tgz",
-      "integrity": "sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.35.0.tgz",
+      "integrity": "sha512-2/lsgejMrtwQe44glq7AFFHLfJBPafpsTa6JvP2NGef/ifOa4KBoglVf7AKN7EV9o32evBPRqfg96fEHzWo5kw==",
       "cpu": [
         "ia32"
       ],
@@ -5080,9 +5041,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz",
-      "integrity": "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.35.0.tgz",
+      "integrity": "sha512-PIQeY5XDkrOysbQblSW7v3l1MDZzkTEzAfTPkj5VAu3FW8fS4ynyLg2sINp0fp3SjZ8xkRYpLqoKcYqAkhU1dw==",
       "cpu": [
         "x64"
       ],
@@ -6405,9 +6366,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
-      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6491,9 +6452,9 @@
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
-      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6679,15 +6640,15 @@
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.7.0.tgz",
-      "integrity": "sha512-jtK5B7YjZXmkGNHjviyGO4s3ZtEhbzSgrbX+s5o+Lr8i2nYqNyHuPVOeTdM1/hZ5Tkxg/KktAuAVDDiHMraMVA==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "12.7.0",
-        "@vueuse/shared": "12.7.0",
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
         "vue": "^3.5.13"
       },
       "funding": {
@@ -6695,14 +6656,14 @@
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.7.0.tgz",
-      "integrity": "sha512-IEq7K4bCl7mn3uKJaWtNXnd1CAPaHLUMuyj5K1/k/pVcItt0VONZW8xiGxdIovJcQjkzOHjImhX5t6gija+0/g==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vueuse/core": "12.7.0",
-        "@vueuse/shared": "12.7.0",
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
         "vue": "^3.5.13"
       },
       "funding": {
@@ -6762,9 +6723,9 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.7.0.tgz",
-      "integrity": "sha512-4VvTH9mrjXqFN5LYa5YfqHVRI6j7R00Vy4995Rw7PQxyCL3z0Lli86iN4UemWqixxEvYfRjG+hF9wL8oLOn+3g==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6772,9 +6733,9 @@
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.7.0.tgz",
-      "integrity": "sha512-coLlUw2HHKsm7rPN6WqHJQr18WymN4wkA/3ThFaJ4v4gWGWAQQGK+MJxLuJTBs4mojQiazlVWAKNJNpUWGRkNw==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6881,9 +6842,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6939,6 +6900,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/aggregate-error/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -6957,25 +6927,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.20.3.tgz",
-      "integrity": "sha512-iNC6BGvipaalFfDfDnXUje8GUlW5asj0cTMsZJwO/0rhsyLx1L7GZFAY8wW+eQ6AM4Yge2p5GSE5hrBlfSD90Q==",
+      "version": "5.20.4",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.20.4.tgz",
+      "integrity": "sha512-wjfzqruxovJyDqga8M6Xk5XtfuVg3igrWjhjgkRya87+WwfEa1kg+IluujBLzgAiMSd6rO6jqRb7czjgeeSYgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-abtesting": "5.20.3",
-        "@algolia/client-analytics": "5.20.3",
-        "@algolia/client-common": "5.20.3",
-        "@algolia/client-insights": "5.20.3",
-        "@algolia/client-personalization": "5.20.3",
-        "@algolia/client-query-suggestions": "5.20.3",
-        "@algolia/client-search": "5.20.3",
-        "@algolia/ingestion": "1.20.3",
-        "@algolia/monitoring": "1.20.3",
-        "@algolia/recommend": "5.20.3",
-        "@algolia/requester-browser-xhr": "5.20.3",
-        "@algolia/requester-fetch": "5.20.3",
-        "@algolia/requester-node-http": "5.20.3"
+        "@algolia/client-abtesting": "5.20.4",
+        "@algolia/client-analytics": "5.20.4",
+        "@algolia/client-common": "5.20.4",
+        "@algolia/client-insights": "5.20.4",
+        "@algolia/client-personalization": "5.20.4",
+        "@algolia/client-query-suggestions": "5.20.4",
+        "@algolia/client-search": "5.20.4",
+        "@algolia/ingestion": "1.20.4",
+        "@algolia/monitoring": "1.20.4",
+        "@algolia/recommend": "5.20.4",
+        "@algolia/requester-browser-xhr": "5.20.4",
+        "@algolia/requester-fetch": "5.20.4",
+        "@algolia/requester-node-http": "5.20.4"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -7358,9 +7328,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -7819,14 +7789,14 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.8.tgz",
-      "integrity": "sha512-OE1/jlarWxROUIpd0qGBSKFLkNsotY8pt4GeiVErUYh/NUeTNrT+SBksUgllQv4m6a0W/VZsLuiHb88maavqEw==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.9.tgz",
+      "integrity": "sha512-FicwAUyWnrtnd4QqYAoRlNs44/a1jTL7XDKqm5gJ90wz1DQPlC7U2Rd1Tydpv+E7WAr4sQHuw8Q8M3nZMAyecQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.7.0",
-        "keyv": "^5.2.3"
+        "hookified": "^1.7.1",
+        "keyv": "^5.3.1"
       }
     },
     "node_modules/call-bind": {
@@ -7862,13 +7832,13 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7936,9 +7906,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001701",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
-      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
+      "version": "1.0.30001702",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
+      "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
       "dev": true,
       "funding": [
         {
@@ -8452,18 +8422,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/clone-deep/node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cmd-shim": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-6.0.3.tgz",
@@ -8834,15 +8792,16 @@
       }
     },
     "node_modules/conventional-changelog-core/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/conventional-changelog-core/node_modules/git-raw-commits": {
@@ -8887,16 +8846,15 @@
       }
     },
     "node_modules/conventional-changelog-core/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "license": "MIT",
       "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^4.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/conventional-changelog-core/node_modules/lru-cache": {
@@ -8936,81 +8894,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/conventional-changelog-core/node_modules/meow/node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "license": "ISC"
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/conventional-changelog-core/node_modules/meow/node_modules/read-pkg": {
       "version": "5.2.0",
@@ -9099,49 +8987,39 @@
       }
     },
     "node_modules/conventional-changelog-core/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "dependencies": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/conventional-changelog-core/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.2.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/conventional-changelog-core/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "license": "MIT",
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/conventional-changelog-core/node_modules/split2": {
@@ -9213,6 +9091,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/conventional-changelog-writer/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/conventional-changelog-writer/node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -9223,6 +9114,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/lru-cache": {
@@ -9275,6 +9178,119 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "license": "ISC"
+    },
+    "node_modules/conventional-changelog-writer/node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/type-fest": {
@@ -9378,6 +9394,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/conventional-recommended-bump/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/conventional-recommended-bump/node_modules/git-raw-commits": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-3.0.0.tgz",
@@ -9417,6 +9446,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/conventional-recommended-bump/node_modules/lru-cache": {
@@ -9469,6 +9510,119 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "license": "ISC"
+    },
+    "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/conventional-recommended-bump/node_modules/split2": {
@@ -10332,9 +10486,9 @@
       "license": "MIT"
     },
     "node_modules/easymde": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.19.0.tgz",
-      "integrity": "sha512-4F1aNImqse+9xIjLh9ttfpOVenecjFPxUmKbl1tGp72Z+OyIqLZPE/SgNyy88c/xU0mOy0WC3+tfbZDQ5PDWhg==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.20.0.tgz",
+      "integrity": "sha512-V1Z5f92TfR42Na852OWnIZMbM7zotWQYTddNaLYZFVKj7APBbyZ3FYJ27gBw2grMW3R6Qdv9J8n5Ij7XRSIgXQ==",
       "license": "MIT",
       "dependencies": {
         "@types/codemirror": "^5.60.10",
@@ -10375,9 +10529,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.109",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.109.tgz",
-      "integrity": "sha512-AidaH9JETVRr9DIPGfp1kAarm/W6hRJTPuCnkF+2MqhF4KaAgRIcBc8nvjk+YMXZhwfISof/7WG29eS4iGxQLQ==",
+      "version": "1.5.113",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.113.tgz",
+      "integrity": "sha512-wjT2O4hX+wdWPJ76gWSkMhcHAV2PTMX+QetUCPYEdCIe+cxmgzzSSiGRCKW8nuh4mwKZlpv0xvoW7OF2X+wmHg==",
       "dev": true,
       "license": "ISC"
     },
@@ -10658,42 +10812,43 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
       }
     },
     "node_modules/escalade": {
@@ -10784,13 +10939,13 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.2.tgz",
-      "integrity": "sha512-1105/17ZIMjmCOJOPNfVdbXafLCLj3hPmkmB7dLgt7XsQ/zkxSuDerE/xgO3RxoHysR1N1whmquY0lSn2O0VLg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
+      "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "eslint-config-prettier": "build/bin/cli.js"
+        "eslint-config-prettier": "bin/cli.js"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -10987,35 +11142,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-plugin-unicorn/node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/strip-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/eslint-plugin-wc": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-wc/-/eslint-plugin-wc-2.2.1.tgz",
@@ -11031,9 +11157,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -11749,46 +11875,38 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.0.0.tgz",
-      "integrity": "sha512-MX6Zo2adDViYh+GcxxB1dpO43eypOGUOL12rLCOTMQv/DfIbpSJUy4oQIIZhVZkH9e+bZWKMon0XHFEju16tkQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
+        "ms": "^2.1.3"
+      },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
@@ -12480,6 +12598,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/git-semver-tags/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/git-semver-tags/node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -12490,6 +12621,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/git-semver-tags/node_modules/lru-cache": {
@@ -12542,6 +12685,119 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "license": "ISC"
+    },
+    "node_modules/git-semver-tags/node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/git-semver-tags/node_modules/type-fest": {
@@ -13394,12 +13650,16 @@
       }
     },
     "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/index-to-position": {
@@ -13979,10 +14239,13 @@
       }
     },
     "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14683,9 +14946,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.0.tgz",
-      "integrity": "sha512-XMBcWGBqH1j04AzjzdIulcsAKr5MaGlYC/N2PLyxdwTrEqVhQnuEIP5h1TPpa5UUcPOH1yVJ+xvhYJ2QAEv94w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.1.tgz",
+      "integrity": "sha512-13hQT2q2VIwOoaJdJa7nY3J8UVbYtMTJFHnwm9LI+SaQRfUiM6Em9KZeOVTCKbMnGcRIL3NSUFpAdjZCq24nLQ==",
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.0.3"
@@ -14726,18 +14989,18 @@
       }
     },
     "node_modules/lerna": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.2.0.tgz",
-      "integrity": "sha512-SLXPPUqU1V6m8pGVNYp8CpqGX92U2fp6XFWQsQMY36VTCGVP/5dGtri4hd2sgk2hcBuFPnxycgEnJecT2MQUsg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.2.1.tgz",
+      "integrity": "sha512-Xwjv9/4ixp7fpBWhtvp7dz4NoQT8DEf7hzibHKCgu/8kmZUHeXsTn+TKspHqhI+p4YDmdkDnkg8xmymz73kVOg==",
       "license": "MIT",
       "dependencies": {
-        "@lerna/create": "8.2.0",
+        "@lerna/create": "8.2.1",
         "@npmcli/arborist": "7.5.4",
         "@npmcli/package-json": "5.2.0",
         "@npmcli/run-script": "8.1.0",
         "@nx/devkit": ">=17.1.2 < 21",
         "@octokit/plugin-enterprise-rest": "6.0.1",
-        "@octokit/rest": "19.0.11",
+        "@octokit/rest": "20.1.2",
         "aproba": "2.0.0",
         "byte-size": "8.1.1",
         "chalk": "4.1.0",
@@ -14915,12 +15178,12 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
-      "integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
+      "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "detect-libc": "^1.0.3"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -14930,22 +15193,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.29.1",
-        "lightningcss-darwin-x64": "1.29.1",
-        "lightningcss-freebsd-x64": "1.29.1",
-        "lightningcss-linux-arm-gnueabihf": "1.29.1",
-        "lightningcss-linux-arm64-gnu": "1.29.1",
-        "lightningcss-linux-arm64-musl": "1.29.1",
-        "lightningcss-linux-x64-gnu": "1.29.1",
-        "lightningcss-linux-x64-musl": "1.29.1",
-        "lightningcss-win32-arm64-msvc": "1.29.1",
-        "lightningcss-win32-x64-msvc": "1.29.1"
+        "lightningcss-darwin-arm64": "1.29.2",
+        "lightningcss-darwin-x64": "1.29.2",
+        "lightningcss-freebsd-x64": "1.29.2",
+        "lightningcss-linux-arm-gnueabihf": "1.29.2",
+        "lightningcss-linux-arm64-gnu": "1.29.2",
+        "lightningcss-linux-arm64-musl": "1.29.2",
+        "lightningcss-linux-x64-gnu": "1.29.2",
+        "lightningcss-linux-x64-musl": "1.29.2",
+        "lightningcss-win32-arm64-msvc": "1.29.2",
+        "lightningcss-win32-x64-msvc": "1.29.2"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
-      "integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
+      "integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
       "cpu": [
         "arm64"
       ],
@@ -14963,9 +15226,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.1.tgz",
-      "integrity": "sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
+      "integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
       "cpu": [
         "x64"
       ],
@@ -14983,9 +15246,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.1.tgz",
-      "integrity": "sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
+      "integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
       "cpu": [
         "x64"
       ],
@@ -15003,9 +15266,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.1.tgz",
-      "integrity": "sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
+      "integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
       "cpu": [
         "arm"
       ],
@@ -15023,9 +15286,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
-      "integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
+      "integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
       "cpu": [
         "arm64"
       ],
@@ -15043,9 +15306,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.1.tgz",
-      "integrity": "sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
+      "integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
       "cpu": [
         "arm64"
       ],
@@ -15063,9 +15326,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
-      "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
+      "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
       "cpu": [
         "x64"
       ],
@@ -15083,9 +15346,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.1.tgz",
-      "integrity": "sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
+      "integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
       "cpu": [
         "x64"
       ],
@@ -15103,9 +15366,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.1.tgz",
-      "integrity": "sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
+      "integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
       "cpu": [
         "arm64"
       ],
@@ -15123,9 +15386,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.1.tgz",
-      "integrity": "sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
+      "integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
       "cpu": [
         "x64"
       ],
@@ -15140,18 +15403,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/lilconfig": {
@@ -16729,9 +16980,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.14.0.tgz",
-      "integrity": "sha512-AlM6alTx98vcnk/jMMmoYuBrm4qpe1/VrbwvL2SXEHjdtJ1ZbVZmrpyjUx9mqS94e9HcemzpLn+CxzhmT7b0uw==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.14.2.tgz",
+      "integrity": "sha512-kMEHNo0F3P6QKDq17zcDuPeaywK/YaJVCEQRzPF3TOM/Bl9MFg64YE5Tu7ifj37qZJMhwU1tl2Ioivws5gRG5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
@@ -16895,9 +17146,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
+      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
       "funding": [
         {
           "type": "github",
@@ -17343,16 +17594,16 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
-      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.18.tgz",
+      "integrity": "sha512-p1TRH/edngVEHVbwqWnxUViEmq5znDvyB+Sik5cmuLpGOIfDf/39zLiq3swPF8Vakqn+gvNiOQAZu8djYlQILA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nx": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.4.6.tgz",
-      "integrity": "sha512-gXRw3urAq4glK6B1+jxHjzXRyuNrFFI7L3ggNg34UmQ46AyT7a6FgjZp2OZ779urwnoQSTvxNfBuD4+RrB31MQ==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-20.5.0.tgz",
+      "integrity": "sha512-KuAzhTj1NHu3iOVsTBrzu7cboO69UgwzUMoAb8KfszV5FwQD5dARrkR7Ew4NZzFdB+arUr2rvo1ik9f1O19keg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17396,16 +17647,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.4.6",
-        "@nx/nx-darwin-x64": "20.4.6",
-        "@nx/nx-freebsd-x64": "20.4.6",
-        "@nx/nx-linux-arm-gnueabihf": "20.4.6",
-        "@nx/nx-linux-arm64-gnu": "20.4.6",
-        "@nx/nx-linux-arm64-musl": "20.4.6",
-        "@nx/nx-linux-x64-gnu": "20.4.6",
-        "@nx/nx-linux-x64-musl": "20.4.6",
-        "@nx/nx-win32-arm64-msvc": "20.4.6",
-        "@nx/nx-win32-x64-msvc": "20.4.6"
+        "@nx/nx-darwin-arm64": "20.5.0",
+        "@nx/nx-darwin-x64": "20.5.0",
+        "@nx/nx-freebsd-x64": "20.5.0",
+        "@nx/nx-linux-arm-gnueabihf": "20.5.0",
+        "@nx/nx-linux-arm64-gnu": "20.5.0",
+        "@nx/nx-linux-arm64-musl": "20.5.0",
+        "@nx/nx-linux-x64-gnu": "20.5.0",
+        "@nx/nx-linux-x64-musl": "20.5.0",
+        "@nx/nx-win32-arm64-msvc": "20.5.0",
+        "@nx/nx-win32-x64-msvc": "20.5.0"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -17965,12 +18216,12 @@
       }
     },
     "node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/p-waterfall": {
@@ -18412,15 +18663,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-dir/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pkg-dir/node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -18596,9 +18838,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
-      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -18973,9 +19215,9 @@
       }
     },
     "node_modules/read-package-up/node_modules/type-fest": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.36.0.tgz",
-      "integrity": "sha512-3T/PUdKTCnkUmhQU6FFJEHsLwadsRegktX3TNHk+2JJB9HlA8gp1/VXblXVDI93kSnXF2rdPx0GMbHtJIV2LPg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
+      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -19000,150 +19242,83 @@
       }
     },
     "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
       "license": "MIT",
       "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
+        "locate-path": "^2.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
-    },
-    "node_modules/read-pkg-up/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
     },
     "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "license": "MIT",
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "node": ">=4"
       }
     },
     "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "license": "MIT",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "p-try": "^1.0.0"
       },
       "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^1.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/read-pkg-up/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=4"
       }
     },
     "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/read-pkg/node_modules/hosted-git-info": {
@@ -19275,6 +19450,27 @@
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -19565,9 +19761,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.9.tgz",
-      "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.35.0.tgz",
+      "integrity": "sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19581,25 +19777,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.34.9",
-        "@rollup/rollup-android-arm64": "4.34.9",
-        "@rollup/rollup-darwin-arm64": "4.34.9",
-        "@rollup/rollup-darwin-x64": "4.34.9",
-        "@rollup/rollup-freebsd-arm64": "4.34.9",
-        "@rollup/rollup-freebsd-x64": "4.34.9",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.34.9",
-        "@rollup/rollup-linux-arm-musleabihf": "4.34.9",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.9",
-        "@rollup/rollup-linux-arm64-musl": "4.34.9",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.34.9",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.9",
-        "@rollup/rollup-linux-riscv64-gnu": "4.34.9",
-        "@rollup/rollup-linux-s390x-gnu": "4.34.9",
-        "@rollup/rollup-linux-x64-gnu": "4.34.9",
-        "@rollup/rollup-linux-x64-musl": "4.34.9",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.9",
-        "@rollup/rollup-win32-ia32-msvc": "4.34.9",
-        "@rollup/rollup-win32-x64-msvc": "4.34.9",
+        "@rollup/rollup-android-arm-eabi": "4.35.0",
+        "@rollup/rollup-android-arm64": "4.35.0",
+        "@rollup/rollup-darwin-arm64": "4.35.0",
+        "@rollup/rollup-darwin-x64": "4.35.0",
+        "@rollup/rollup-freebsd-arm64": "4.35.0",
+        "@rollup/rollup-freebsd-x64": "4.35.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.35.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.35.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.35.0",
+        "@rollup/rollup-linux-arm64-musl": "4.35.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.35.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.35.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.35.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.35.0",
+        "@rollup/rollup-linux-x64-gnu": "4.35.0",
+        "@rollup/rollup-linux-x64-musl": "4.35.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.35.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.35.0",
+        "@rollup/rollup-win32-x64-msvc": "4.35.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -19776,6 +19972,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/saxes": {
@@ -20286,9 +20491,9 @@
       }
     },
     "node_modules/snakecase-keys/node_modules/type-fest": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.36.0.tgz",
-      "integrity": "sha512-3T/PUdKTCnkUmhQU6FFJEHsLwadsRegktX3TNHk+2JJB9HlA8gp1/VXblXVDI93kSnXF2rdPx0GMbHtJIV2LPg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
+      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -20530,9 +20735,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
-      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
+      "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
       "license": "MIT"
     },
     "node_modules/streamsearch": {
@@ -20748,15 +20953,19 @@
       }
     },
     "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "min-indent": "^1.0.0"
+        "min-indent": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -20967,25 +21176,25 @@
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.6.tgz",
-      "integrity": "sha512-0wvv16mVo9nN0Md3k7DMjgAPKG/TY4F/gYMBVb/wMThFRJvzrpaqBFqF6km9wf8QfYTN+mNg5aeaBLfy8k35uA==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.7.tgz",
+      "integrity": "sha512-txsf5fu3anp2ff3+gOJJzRImtrtm/oa9tYLN0iTuINZ++EyVR/nRrg2fKYwvG/pXDofcrvvb0scEbX3NyW/COw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.6"
+        "flat-cache": "^6.1.7"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.6.tgz",
-      "integrity": "sha512-F+CKgSwp0pzLx67u+Zy1aCueVWFAHWbXepvXlZ+bWVTaASbm5SyCnSJ80Fp1ePEmS57wU+Bf6cx6525qtMZ4lQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.7.tgz",
+      "integrity": "sha512-qwZ4xf1v1m7Rc9XiORly31YaChvKt6oNVHuqqZcoED/7O+ToyNVGobKsIAopY9ODcWpEDKEBAbrSOCBHtNQvew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.8.8",
-        "flatted": "^3.3.2",
-        "hookified": "^1.7.0"
+        "cacheable": "^1.8.9",
+        "flatted": "^3.3.3",
+        "hookified": "^1.7.1"
       }
     },
     "node_modules/stylelint/node_modules/ignore": {
@@ -20996,6 +21205,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/stylelint/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/stylelint/node_modules/meow": {
@@ -21449,22 +21668,22 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "6.1.82",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.82.tgz",
-      "integrity": "sha512-KCTjNL9F7j8MzxgfTgjT+v21oYH38OidFty7dH00maWANAI2IsLw2AnThtTJi9HKALHZKQQWnNebYheadacD+g==",
+      "version": "6.1.83",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.83.tgz",
+      "integrity": "sha512-FHxxNJJ0WNsEBPHyC1oesQb3rRoxpuho/z2g3zIIAhw1WHJeQsUzK1jYK8TI1/iClaa4fS3Z2TCA9mtxXsENSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.82"
+        "tldts-core": "^6.1.83"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.82",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.82.tgz",
-      "integrity": "sha512-Jabl32m21tt/d/PbDO88R43F8aY98Piiz6BVH9ShUlOAiiAELhEqwrAmBocjAqnCfoUeIsRU+h3IEzZd318F3w==",
+      "version": "6.1.83",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.83.tgz",
+      "integrity": "sha512-I2wb9OJc6rXyh9d4aInhSNWChNI+ra6qDnFEGEwe9OoA68lE4Temw29bOkf1Uvwt8VZS079t1BFZdXVBmmB4dw==",
       "dev": true,
       "license": "MIT"
     },
@@ -22379,6 +22598,436 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/vitepress": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.3.tgz",
@@ -22976,9 +23625,9 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.0.tgz",
+      "integrity": "sha512-KHBC7z61OJeaMGnF3wqNZj+GGNXOyypZviiKpQeiHirG5Ib1ImwcLBH70rbMSkKfSmUNBsdf2PwaEJtKvgmkNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23559,374 +24208,6 @@
         "node": ">=20"
       }
     },
-    "packages/frontend/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
-      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/android-arm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
-      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
-      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/android-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
-      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
-      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
-      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
-      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
-      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
-      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
-      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
-      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
-      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
-      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
-      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
-      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
-      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
-      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
-      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
-      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
-      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
-      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
-      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
-      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "packages/frontend/node_modules/color": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.0.tgz",
@@ -23971,46 +24252,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/esbuild": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
-      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.0",
-        "@esbuild/android-arm": "0.25.0",
-        "@esbuild/android-arm64": "0.25.0",
-        "@esbuild/android-x64": "0.25.0",
-        "@esbuild/darwin-arm64": "0.25.0",
-        "@esbuild/darwin-x64": "0.25.0",
-        "@esbuild/freebsd-arm64": "0.25.0",
-        "@esbuild/freebsd-x64": "0.25.0",
-        "@esbuild/linux-arm": "0.25.0",
-        "@esbuild/linux-arm64": "0.25.0",
-        "@esbuild/linux-ia32": "0.25.0",
-        "@esbuild/linux-loong64": "0.25.0",
-        "@esbuild/linux-mips64el": "0.25.0",
-        "@esbuild/linux-ppc64": "0.25.0",
-        "@esbuild/linux-riscv64": "0.25.0",
-        "@esbuild/linux-s390x": "0.25.0",
-        "@esbuild/linux-x64": "0.25.0",
-        "@esbuild/netbsd-arm64": "0.25.0",
-        "@esbuild/netbsd-x64": "0.25.0",
-        "@esbuild/openbsd-arm64": "0.25.0",
-        "@esbuild/openbsd-x64": "0.25.0",
-        "@esbuild/sunos-x64": "0.25.0",
-        "@esbuild/win32-arm64": "0.25.0",
-        "@esbuild/win32-ia32": "0.25.0",
-        "@esbuild/win32-x64": "0.25.0"
       }
     },
     "packages/indiekit": {
@@ -24266,9 +24507,9 @@
       }
     },
     "packages/preset-eleventy/node_modules/type-fest": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.36.0.tgz",
-      "integrity": "sha512-3T/PUdKTCnkUmhQU6FFJEHsLwadsRegktX3TNHk+2JJB9HlA8gp1/VXblXVDI93kSnXF2rdPx0GMbHtJIV2LPg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
+      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -24346,9 +24587,9 @@
       }
     },
     "packages/preset-hugo/node_modules/type-fest": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.36.0.tgz",
-      "integrity": "sha512-3T/PUdKTCnkUmhQU6FFJEHsLwadsRegktX3TNHk+2JJB9HlA8gp1/VXblXVDI93kSnXF2rdPx0GMbHtJIV2LPg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
+      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3018,6 +3018,10 @@
       "resolved": "packages/indiekit",
       "link": true
     },
+    "node_modules/@indiekit/plugin": {
+      "resolved": "packages/plugin",
+      "link": true
+    },
     "node_modules/@indiekit/post-type-article": {
       "resolved": "packages/post-type-article",
       "link": true
@@ -24300,6 +24304,38 @@
       }
     },
     "packages/indiekit/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "packages/plugin": {
+      "name": "@indiekit/plugin",
+      "version": "1.0.0-beta.19",
+      "license": "MIT",
+      "dependencies": {
+        "@indiekit/error": "^1.0.0-beta.15",
+        "debug": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@indiekit/indiekit": "^1.0.0-beta.19"
+      }
+    },
+    "packages/plugin/node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "cookie-session": "^2.0.0",
     "create-indiekit": "*",
     "date-fns": "^4.0.0",
-    "eslint": "9.21.0",
+    "eslint": "^9.21.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsdoc": "^50.0.0",

--- a/packages/create-indiekit/lib/utils.js
+++ b/packages/create-indiekit/lib/utils.js
@@ -6,23 +6,23 @@ import prompts from "prompts";
 
 /**
  * Add plug-in to Indiekit configuration
- * @param {string} pluginName - Name of selected plug-in
+ * @param {string} packageName - Plug-in package name
  * @param {object} config - Indiekit configuration
  * @returns {Promise<object>} Updated configuration
  */
-export const addPluginConfig = async (pluginName, config) => {
-  const plugin = await getPlugin(pluginName);
+export const addPluginConfig = async (packageName, config) => {
+  const plugin = await getPlugin(packageName);
   const { info } = console;
 
   info(`${chalk.green(">")} ${chalk.white(`Configuring ${plugin.name}…`)}`);
 
   // Add plug-in to list of installed plug-ins
-  config.plugins.push(pluginName);
+  config.plugins.push(packageName);
 
   // Add any plug-in configuration values
   const pluginConfig = await prompts(plugin.prompts);
   if (Object.keys(pluginConfig).length > 0) {
-    config[pluginName] = pluginConfig;
+    config[packageName] = pluginConfig;
   }
 
   return config;
@@ -48,11 +48,11 @@ export const checkNodeVersion = (currentVersion, minimumMajorVersion) => {
 
 /**
  * Get question prompts specified by plug-in
- * @param {string} pluginName - Plug-in name
+ * @param {string} packageName - Plug-in package name
  * @returns {Promise<object>} Plug-in
  */
-export const getPlugin = async (pluginName) => {
-  const { default: IndiekitPlugin } = await import(pluginName);
+export const getPlugin = async (packageName) => {
+  const { default: IndiekitPlugin } = await import(packageName);
   const plugin = new IndiekitPlugin();
 
   return plugin;

--- a/packages/endpoint-auth/package.json
+++ b/packages/endpoint-auth/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19",
     "bcrypt": "^5.1.0",
-    "express": "^5.0.0",
     "express-validator": "^7.0.0",
     "jsonwebtoken": "^9.0.0",
     "microformats-parser": "^2.0.0"

--- a/packages/endpoint-files/package.json
+++ b/packages/endpoint-files/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
-    "express": "^5.0.0",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "express-validator": "^7.0.0"
   },
   "publishConfig": {

--- a/packages/endpoint-image/README.md
+++ b/packages/endpoint-image/README.md
@@ -23,8 +23,6 @@ To customise the behaviour of this plug-in, add `@indiekit/endpoint-image` to yo
 
 ## Options
 
-| Option      | Type       | Description                                                        |
-| :---------- | :--------- | :----------------------------------------------------------------- |
-| `cache`     | `Function` | [Keyv store](https://github.com/lukechilds/keyv).                  |
-| `me`        | `string`   | Publication URL. Used as prefix to image paths.                    |
-| `mountPath` | `string`   | Path to image resizing endpoint. _Optional_, defaults to `/image`. |
+| Option      | Type     | Description                                                        |
+| :---------- | :------- | :----------------------------------------------------------------- |
+| `mountPath` | `string` | Path to image resizing endpoint. _Optional_, defaults to `/image`. |

--- a/packages/endpoint-image/package.json
+++ b/packages/endpoint-image/package.json
@@ -35,7 +35,7 @@
     "directory": "packages/endpoint-image"
   },
   "dependencies": {
-    "express": "^5.0.0",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "ipx": "^3.0.0"
   },
   "publishConfig": {

--- a/packages/endpoint-json-feed/package.json
+++ b/packages/endpoint-json-feed/package.json
@@ -34,7 +34,7 @@
     "directory": "packages/endpoint-json-feed"
   },
   "dependencies": {
-    "express": "^5.0.0",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "mime-types": "^2.1.35"
   },
   "publishConfig": {

--- a/packages/endpoint-media/package.json
+++ b/packages/endpoint-media/package.json
@@ -34,10 +34,10 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19",
     "debug": "^4.3.2",
     "deepmerge": "^4.3.1",
-    "express": "^5.0.0",
     "file-type": "^20.0.0",
     "newbase60": "^1.3.1",
     "sharp": "^0.33.2"

--- a/packages/endpoint-micropub/index.js
+++ b/packages/endpoint-micropub/index.js
@@ -1,32 +1,42 @@
-import express from "express";
+import { IndiekitEndpointPlugin } from "@indiekit/plugin";
 
 import { actionController } from "./lib/controllers/action.js";
 import { queryController } from "./lib/controllers/query.js";
 
-const defaults = { mountPath: "/micropub" };
-const router = express.Router();
+const defaults = {
+  mountPath: "/micropub",
+};
 
-export default class MicropubEndpoint {
+export default class MicropubEndpointPlugin extends IndiekitEndpointPlugin {
+  collection = "posts";
+
+  name = "Micropub endpoint";
+
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.mountPath] - Path to endpoint
+   */
   constructor(options = {}) {
-    this.name = "Micropub endpoint";
+    super(options);
+
     this.options = { ...defaults, ...options };
+
     this.mountPath = this.options.mountPath;
   }
 
   get routes() {
-    router.get("/", queryController);
-    router.post("/", actionController);
+    this.router.get("/", queryController);
+    this.router.post("/", actionController);
 
-    return router;
+    return this.router;
   }
 
-  init(Indiekit) {
-    Indiekit.addCollection("posts");
-    Indiekit.addEndpoint(this);
+  async init() {
+    await super.init();
 
     // Only mount if micropub endpoint not already configured
-    if (!Indiekit.config.application.micropubEndpoint) {
-      Indiekit.config.application.micropubEndpoint = this.mountPath;
+    if (!this.indiekit.config.application.micropubEndpoint) {
+      this.indiekit.config.application.micropubEndpoint = this.mountPath;
     }
   }
 }

--- a/packages/endpoint-micropub/package.json
+++ b/packages/endpoint-micropub/package.json
@@ -34,10 +34,10 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19",
     "@paulrobertlloyd/mf2tojf2": "^2.1.0",
     "debug": "^4.3.2",
-    "express": "^5.0.0",
     "lodash": "^4.17.21",
     "markdown-it": "^14.0.0",
     "newbase60": "^1.3.1",

--- a/packages/endpoint-posts/index.js
+++ b/packages/endpoint-posts/index.js
@@ -1,8 +1,8 @@
 import path from "node:path";
 
 import { tagInputSanitizer } from "@indiekit/frontend";
+import { IndiekitEndpointPlugin } from "@indiekit/plugin";
 import { ISO_6709_RE, isRequired } from "@indiekit/util";
-import express from "express";
 
 import { deleteController } from "./lib/controllers/delete.js";
 import { formController } from "./lib/controllers/form.js";
@@ -12,27 +12,69 @@ import { postsController } from "./lib/controllers/posts.js";
 import { postData } from "./lib/middleware/post-data.js";
 import { validate } from "./lib/middleware/validation.js";
 
-const defaults = { mountPath: "/posts" };
-const router = express.Router();
+const defaults = {
+  mountPath: "/posts",
+};
 
-export default class PostsEndpoint {
+export default class PostsEndpointPlugin extends IndiekitEndpointPlugin {
+  name = "Post management endpoint";
+
+  validationSchemas = {
+    category: {
+      exists: { if: (value, { req }) => req.body?.category },
+      tagInput: tagInputSanitizer,
+      isArray: true,
+    },
+    content: {
+      errorMessage: (value, { req }) => req.__("posts.error.content.empty"),
+      exists: { if: (value, { req }) => isRequired(req, "content") },
+      notEmpty: true,
+    },
+    "featured.url": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.media.empty`, "/photos/image.jpg"),
+      exists: { if: (value, { req }) => isRequired(req, "featured") },
+      notEmpty: true,
+    },
+    "featured.alt": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.featured-alt.empty`),
+      exists: { if: (value, { req }) => req.body?.featured.url },
+      notEmpty: true,
+    },
+    geo: {
+      errorMessage: (value, { req }) => req.__(`posts.error.geo.invalid`),
+      exists: { if: (value, { req }) => req.body?.geo },
+      custom: {
+        options: (value) => value.match(ISO_6709_RE),
+      },
+    },
+    name: {
+      errorMessage: (value, { req }) => req.__("posts.error.name.empty"),
+      exists: { if: (value, { req }) => isRequired(req, "name") },
+      notEmpty: true,
+    },
+  };
+
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.mountPath] - Path to endpoint
+   */
   constructor(options = {}) {
-    this.name = "Post management endpoint";
-    this.options = { ...defaults, ...options };
-    this.mountPath = this.options.mountPath;
-  }
+    super(options);
 
-  get navigationItems() {
-    return {
-      href: this.options.mountPath,
+    this.options = { ...defaults, ...options };
+
+    this.mountPath = this.options.mountPath;
+
+    this.navigationItems = {
+      href: this.mountPath,
       text: "posts.title",
       requiresDatabase: true,
     };
-  }
 
-  get shortcutItems() {
-    return {
-      url: path.join(this.options.mountPath, "new"),
+    this.shortcutItems = {
+      url: path.join(this.mountPath, "new"),
       name: "posts.create.action",
       iconName: "createPost",
       requiresDatabase: true,
@@ -40,68 +82,34 @@ export default class PostsEndpoint {
   }
 
   get routes() {
-    router.get("/", postsController);
+    this.router.get("/", postsController);
 
-    router.get("/new", newController.get);
-    router.post("/new", validate.new, newController.post);
+    this.router.get("/new", newController.get);
+    this.router.post("/new", validate.new, newController.post);
 
-    router.get("/create", postData.create, formController.get);
-    router.post("/create", postData.create, validate.form, formController.post);
+    this.router.get("/create", postData.create, formController.get);
+    this.router.post(
+      "/create",
+      postData.create,
+      validate.form,
+      formController.post,
+    );
 
-    router.use("/:uid{/:action}", postData.read);
-    router.get("/:uid", postController);
+    this.router.use("/:uid{/:action}", postData.read);
+    this.router.get("/:uid", postController);
 
-    router.get("/:uid/update", formController.get);
-    router.post("/:uid/update", validate.form, formController.post);
+    this.router.get("/:uid/update", formController.get);
+    this.router.post("/:uid/update", validate.form, formController.post);
 
-    router.get(["/:uid/delete", "/:uid/undelete"], deleteController.get);
-    router.post(["/:uid/delete", "/:uid/undelete"], deleteController.post);
+    this.router.get(["/:uid/delete", "/:uid/undelete"], deleteController.get);
+    this.router.post(["/:uid/delete", "/:uid/undelete"], deleteController.post);
 
-    return router;
+    return this.router;
   }
 
-  get validationSchemas() {
-    return {
-      category: {
-        exists: { if: (value, { req }) => req.body?.category },
-        tagInput: tagInputSanitizer,
-        isArray: true,
-      },
-      content: {
-        errorMessage: (value, { req }) => req.__("posts.error.content.empty"),
-        exists: { if: (value, { req }) => isRequired(req, "content") },
-        notEmpty: true,
-      },
-      "featured.url": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.media.empty`, "/photos/image.jpg"),
-        exists: { if: (value, { req }) => isRequired(req, "featured") },
-        notEmpty: true,
-      },
-      "featured.alt": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.featured-alt.empty`),
-        exists: { if: (value, { req }) => req.body?.featured.url },
-        notEmpty: true,
-      },
-      geo: {
-        errorMessage: (value, { req }) => req.__(`posts.error.geo.invalid`),
-        exists: { if: (value, { req }) => req.body?.geo },
-        custom: {
-          options: (value) => value.match(ISO_6709_RE),
-        },
-      },
-      name: {
-        errorMessage: (value, { req }) => req.__("posts.error.name.empty"),
-        exists: { if: (value, { req }) => isRequired(req, "name") },
-        notEmpty: true,
-      },
-    };
-  }
+  async init() {
+    await super.init();
 
-  init(Indiekit) {
-    Indiekit.addEndpoint(this);
-    Indiekit.addPostType(false, this);
-    Indiekit.config.application.postsEndpoint = this.mountPath;
+    this.indiekit.config.application.postsEndpoint = this.mountPath;
   }
 }

--- a/packages/endpoint-posts/package.json
+++ b/packages/endpoint-posts/package.json
@@ -38,9 +38,9 @@
     "@indiekit/endpoint-micropub": "^1.0.0-beta.19",
     "@indiekit/error": "^1.0.0-beta.15",
     "@indiekit/frontend": "^1.0.0-beta.19",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19",
     "@paulrobertlloyd/mf2tojf2": "^2.1.0",
-    "express": "^5.0.0",
     "express-validator": "^7.0.0",
     "formatcoords": "^1.1.3"
   },

--- a/packages/endpoint-share/index.js
+++ b/packages/endpoint-share/index.js
@@ -1,27 +1,37 @@
-import express from "express";
+import { IndiekitEndpointPlugin } from "@indiekit/plugin";
 
 import { shareController } from "./lib/controllers/share.js";
 import { validate } from "./lib/middleware/validation.js";
 
-const defaults = { mountPath: "/share" };
-const router = express.Router();
+const defaults = {
+  mountPath: "/share",
+};
 
-export default class ShareEndpoint {
+export default class ShareEndpointPlugin extends IndiekitEndpointPlugin {
+  name = "Share endpoint";
+
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.mountPath] - Path to endpoint
+   */
   constructor(options = {}) {
-    this.name = "Share endpoint";
+    super(options);
+
     this.options = { ...defaults, ...options };
+
     this.mountPath = this.options.mountPath;
   }
 
   get routes() {
-    router.get("/{:path}", shareController.get);
-    router.post("/{:path}", validate, shareController.post);
+    this.router.get("/{:path}", shareController.get);
+    this.router.post("/{:path}", validate, shareController.post);
 
-    return router;
+    return this.router;
   }
 
-  init(Indiekit) {
-    Indiekit.addEndpoint(this);
-    Indiekit.config.application.shareEndpoint = this.options.mountPath;
+  async init() {
+    await super.init();
+
+    this.indiekit.config.application.shareEndpoint = this.mountPath;
   }
 }

--- a/packages/endpoint-share/package.json
+++ b/packages/endpoint-share/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
-    "express": "^5.0.0",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "express-validator": "^7.0.0"
   },
   "publishConfig": {

--- a/packages/endpoint-syndicate/index.js
+++ b/packages/endpoint-syndicate/index.js
@@ -1,28 +1,36 @@
-import express from "express";
+import { IndiekitEndpointPlugin } from "@indiekit/plugin";
 
 import { syndicateController } from "./lib/controllers/syndicate.js";
 
-const defaults = { mountPath: "/syndicate" };
-const router = express.Router();
+const defaults = {
+  mountPath: "/syndicate",
+};
 
-export default class SyndicateEndpoint {
+export default class SyndicateEndpointPlugin extends IndiekitEndpointPlugin {
+  name = "Syndication endpoint";
+
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.mountPath] - Path to endpoint
+   */
   constructor(options = {}) {
-    this.name = "Syndication endpoint";
+    super(options);
+
     this.options = { ...defaults, ...options };
+
     this.mountPath = this.options.mountPath;
   }
 
   get routesPublic() {
-    router.post("/", syndicateController.post);
+    this.router.post("/", syndicateController.post);
 
-    return router;
+    return this.router;
   }
 
-  init(Indiekit) {
-    Indiekit.addEndpoint(this);
+  async init() {
+    await super.init();
 
     // Use private value to register syndication endpoint path
-    Indiekit.config.application._syndicationEndpointPath =
-      this.options.mountPath;
+    this.indiekit.config.application._syndicationEndpointPath = this.mountPath;
   }
 }

--- a/packages/endpoint-syndicate/package.json
+++ b/packages/endpoint-syndicate/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
-    "express": "^5.0.0",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "jsonwebtoken": "^9.0.0"
   },
   "publishConfig": {

--- a/packages/endpoint-webmention-io/index.js
+++ b/packages/endpoint-webmention-io/index.js
@@ -1,4 +1,6 @@
-import express from "express";
+import process from "node:process";
+
+import { IndiekitEndpointPlugin } from "@indiekit/plugin";
 
 import { webmentionsController } from "./lib/controllers/webmentions.js";
 
@@ -6,34 +8,31 @@ const defaults = {
   mountPath: "/webmentions",
   token: process.env.WEBMENTION_IO_TOKEN,
 };
-const router = express.Router();
 
-export default class WebmentionEndpoint {
+export default class WebmentionEndpointPlugin extends IndiekitEndpointPlugin {
+  name = "Webmention.io endpoint";
+
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.mountPath] - Path to endpoint
+   * @param {string} [options.token] - Webmention.io API token
+   */
   constructor(options = {}) {
-    this.name = "Webmention.io endpoint";
-    this.options = { ...defaults, ...options };
-    this.mountPath = this.options.mountPath;
-  }
+    super(options);
 
-  get navigationItems() {
-    return {
-      href: this.options.mountPath,
+    this.options = { ...defaults, ...options };
+
+    this.mountPath = this.options.mountPath;
+
+    this.navigationItems = {
+      href: this.mountPath,
       text: "webmention-io.title",
     };
   }
 
   get routes() {
-    router.get(
-      "/",
-      webmentionsController({
-        token: this.options.token,
-      }),
-    );
+    this.router.get("/", webmentionsController({ token: this.options.token }));
 
-    return router;
-  }
-
-  init(Indiekit) {
-    Indiekit.addEndpoint(this);
+    return this.router;
   }
 }

--- a/packages/endpoint-webmention-io/package.json
+++ b/packages/endpoint-webmention-io/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
-    "express": "^4.17.1",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "sanitize-html": "^2.14.0"
   },
   "publishConfig": {

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -51,11 +51,6 @@ export const Indiekit = class {
     this.validationSchemas = new Map();
   }
 
-  addEndpoint(endpoint) {
-    this.endpoints.add(endpoint);
-    debug(`Added endpoint: ${endpoint.name}`);
-  }
-
   addPreset(preset) {
     this.publication.preset = preset;
     debug(`Added publication preset: ${preset.name}`);

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -51,11 +51,6 @@ export const Indiekit = class {
     this.validationSchemas = new Map();
   }
 
-  addPreset(preset) {
-    this.publication.preset = preset;
-    debug(`Added publication preset: ${preset.name}`);
-  }
-
   addStore(store) {
     this.stores.add(store);
     debug(`Added content store: ${store.name}`);

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -51,11 +51,6 @@ export const Indiekit = class {
     this.validationSchemas = new Map();
   }
 
-  addStore(store) {
-    this.stores.add(store);
-    debug(`Added content store: ${store.name}`);
-  }
-
   async connectMongodbClient() {
     const mongodbClientOrError = await getMongodbClient(this.mongodbUrl);
 

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -56,18 +56,6 @@ export const Indiekit = class {
     debug(`Added content store: ${store.name}`);
   }
 
-  addSyndicator(syndicator) {
-    syndicator = Array.isArray(syndicator) ? syndicator : [syndicator];
-    this.publication.syndicationTargets = [
-      ...this.publication.syndicationTargets,
-      ...syndicator,
-    ];
-    const names = this.publication.syndicationTargets.map(
-      (target) => target.name,
-    );
-    debug(`Added ${names.length} syndication target/s: ${names.join(", ")}`);
-  }
-
   async connectMongodbClient() {
     const mongodbClientOrError = await getMongodbClient(this.mongodbUrl);
 

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -65,23 +65,6 @@ export const Indiekit = class {
     debug(`Added endpoint: ${endpoint.name}`);
   }
 
-  addPostType(type, postType) {
-    if (postType.config) {
-      this.postTypes.set(type, {
-        ...this.postTypes.get(type),
-        ...postType.config,
-      });
-    }
-
-    if (postType.validationSchemas) {
-      for (const [field, schema] of Object.entries(
-        postType.validationSchemas,
-      )) {
-        this.validationSchemas.set(field, schema);
-      }
-    }
-  }
-
   addPreset(preset) {
     this.publication.preset = preset;
     debug(`Added publication preset: ${preset.name}`);

--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -51,15 +51,6 @@ export const Indiekit = class {
     this.validationSchemas = new Map();
   }
 
-  addCollection(name) {
-    if (this.collections.has(name)) {
-      console.warn(`Collection ‘${name}’ already added`);
-    } else if (this.database) {
-      this.collections.set(name, this.database.collection(name));
-      debug(`Added database collection: ${name}`);
-    }
-  }
-
   addEndpoint(endpoint) {
     this.endpoints.add(endpoint);
     debug(`Added endpoint: ${endpoint.name}`);

--- a/packages/indiekit/lib/plugins.js
+++ b/packages/indiekit/lib/plugins.js
@@ -1,26 +1,12 @@
-import { createRequire } from "node:module";
-import path from "node:path";
-const require = createRequire(import.meta.url);
-
 /**
  * Add plug-ins to application configuration
  * @param {object} Indiekit - Indiekit instance
  */
 export async function getInstalledPlugins(Indiekit) {
-  for await (const pluginName of Indiekit.config.plugins) {
-    const { default: IndiekitPlugin } = await import(pluginName);
-    const plugin = new IndiekitPlugin(Indiekit.config[pluginName]);
-
-    // Add plug-in file path
-    plugin.filePath = path.dirname(require.resolve(pluginName));
-
-    // Add plug-in ID
-    plugin.id = getPluginId(pluginName);
-
-    // Register plug-in functions
-    if (plugin.init) {
-      await plugin.init(Indiekit);
-      Indiekit.installedPlugins.add(plugin);
+  for await (const packageName of Indiekit.config.plugins) {
+    const { default: IndiekitPlugin } = await import(packageName);
+    if (IndiekitPlugin.register) {
+      await IndiekitPlugin.register(Indiekit, packageName);
     }
   }
 }
@@ -28,20 +14,11 @@ export async function getInstalledPlugins(Indiekit) {
 /**
  * Get installed plug-in
  * @param {Set} installedPlugins - Installed plug-ins
- * @param {string} pluginName - Plug-in Name
+ * @param {string} packageName - Plug-in package name
  * @returns {string} Plug-in ID
  */
-export const getInstalledPlugin = (installedPlugins, pluginName) => {
+export const getInstalledPlugin = (installedPlugins, packageName) => {
   return [...installedPlugins].find(
-    (plugin) => plugin.id === getPluginId(pluginName),
+    (plugin) => plugin.packageName === packageName,
   );
-};
-
-/**
- * Get normalised plug-in ID
- * @param {string} pluginName - Plug-in Name
- * @returns {string} Plug-in ID
- */
-export const getPluginId = (pluginName) => {
-  return pluginName.replace("/", "-");
 };

--- a/packages/indiekit/lib/routes.js
+++ b/packages/indiekit/lib/routes.js
@@ -89,13 +89,6 @@ export const routes = (Indiekit) => {
 
   // Public and .well-known endpoints
   for (const endpoint of endpoints) {
-    // Internal routing
-    // Currently used for endpoint-image which requires configuration values
-    // to be passed on to express-sharp middleware
-    if (endpoint.mountPath && endpoint._routes) {
-      router.use(endpoint.mountPath, limit, endpoint._routes(Indiekit));
-    }
-
     if (endpoint.mountPath && endpoint.routesPublic) {
       router.use(endpoint.mountPath, limit, endpoint.routesPublic);
     }

--- a/packages/indiekit/test/index.js
+++ b/packages/indiekit/test/index.js
@@ -24,23 +24,6 @@ describe("indiekit", async () => {
     indiekit.closeMongodbClient();
   });
 
-  it("Adds publication preset", () => {
-    const TestPreset = class {
-      constructor() {
-        this.name = "Test preset";
-      }
-
-      get info() {
-        return { name: "Test" };
-      }
-    };
-
-    const testPreset = new TestPreset();
-    indiekit.addPreset(testPreset);
-
-    assert.equal(indiekit.publication.preset.info.name, "Test");
-  });
-
   it("Adds content store", () => {
     const testStore = new TestStore();
     indiekit.addStore(testStore);

--- a/packages/indiekit/test/index.js
+++ b/packages/indiekit/test/index.js
@@ -24,21 +24,6 @@ describe("indiekit", async () => {
     indiekit.closeMongodbClient();
   });
 
-  it("Adds database collection", async () => {
-    indiekit.addCollection("test");
-
-    assert.equal(indiekit.collections.has("test"), true);
-  });
-
-  it("Doesn’t allow duplicate database collections", async () => {
-    mock.method(console, "warn", () => {});
-
-    indiekit.addCollection("test");
-    const result = console.warn.mock.calls[0].arguments[0];
-
-    assert.equal(result.includes(`Collection ‘test’ already added`), true);
-  });
-
   it("Adds endpoint", () => {
     const TestEndpoint = class {
       constructor() {

--- a/packages/indiekit/test/index.js
+++ b/packages/indiekit/test/index.js
@@ -1,9 +1,7 @@
-import { strict as assert } from "node:assert";
-import { after, before, describe, it, mock } from "node:test";
+import { after, before, describe, mock } from "node:test";
 
 import { testConfig } from "@indiekit-test/config";
 import { testDatabase } from "@indiekit-test/database";
-import TestStore from "@indiekit-test/store";
 
 import { Indiekit } from "../index.js";
 
@@ -22,12 +20,5 @@ describe("indiekit", async () => {
     await client.close();
     await mongoServer.stop();
     indiekit.closeMongodbClient();
-  });
-
-  it("Adds content store", () => {
-    const testStore = new TestStore();
-    indiekit.addStore(testStore);
-
-    assert.equal([...indiekit.stores][0].info.name, "Test store");
   });
 });

--- a/packages/indiekit/test/index.js
+++ b/packages/indiekit/test/index.js
@@ -24,19 +24,6 @@ describe("indiekit", async () => {
     indiekit.closeMongodbClient();
   });
 
-  it("Adds endpoint", () => {
-    const TestEndpoint = class {
-      constructor() {
-        this.name = "Test endpoint";
-      }
-    };
-
-    const testEndpoint = new TestEndpoint();
-    indiekit.addEndpoint(testEndpoint);
-
-    assert.equal([...indiekit.endpoints].at(-1).name, "Test endpoint");
-  });
-
   it("Adds publication preset", () => {
     const TestPreset = class {
       constructor() {

--- a/packages/indiekit/test/unit/plugins.js
+++ b/packages/indiekit/test/unit/plugins.js
@@ -1,7 +1,7 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { getInstalledPlugin, getPluginId } from "../../lib/plugins.js";
+import { getInstalledPlugin } from "../../lib/plugins.js";
 
 describe("indiekit/lib/plugins", async () => {
   it("Gets installed plug-in", () => {
@@ -17,9 +17,5 @@ describe("indiekit/lib/plugins", async () => {
         id: "@scope-package-name",
       },
     );
-  });
-
-  it("Gets normalised plug-in ID", () => {
-    assert.equal(getPluginId("@scope/package-name"), "@scope-package-name");
   });
 });

--- a/packages/indiekit/views/plugins/view.njk
+++ b/packages/indiekit/views/plugins/view.njk
@@ -22,7 +22,7 @@
     }) }}
   {% endcall %}
 
-  {% if plugin.options %}
+  {% if plugin.options | length %}
     {% call section({ title: __("plugin.options") }) %}
       {{ summary({
         rows: summaryRows(plugin.options)

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,0 +1,7 @@
+# @indiekit/plugin
+
+Plug-in API for Indiekit.
+
+## Installation
+
+`npm install @indiekit/plugin`

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -2,3 +2,4 @@ export { IndiekitPlugin } from "./lib/base.js";
 export { IndiekitEndpointPlugin } from "./lib/endpoint.js";
 export { IndiekitPostTypePlugin } from "./lib/post-type.js";
 export { IndiekitPresetPlugin } from "./lib/preset.js";
+export { IndiekitSyndicatorPlugin } from "./lib/syndicator.js";

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -1,0 +1,1 @@
+export { IndiekitPlugin } from "./lib/base.js";

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -2,4 +2,5 @@ export { IndiekitPlugin } from "./lib/base.js";
 export { IndiekitEndpointPlugin } from "./lib/endpoint.js";
 export { IndiekitPostTypePlugin } from "./lib/post-type.js";
 export { IndiekitPresetPlugin } from "./lib/preset.js";
+export { IndiekitStorePlugin } from "./lib/store.js";
 export { IndiekitSyndicatorPlugin } from "./lib/syndicator.js";

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -1,1 +1,2 @@
 export { IndiekitPlugin } from "./lib/base.js";
+export { IndiekitPostTypePlugin } from "./lib/post-type.js";

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -1,3 +1,4 @@
 export { IndiekitPlugin } from "./lib/base.js";
 export { IndiekitEndpointPlugin } from "./lib/endpoint.js";
 export { IndiekitPostTypePlugin } from "./lib/post-type.js";
+export { IndiekitPresetPlugin } from "./lib/preset.js";

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -1,2 +1,3 @@
 export { IndiekitPlugin } from "./lib/base.js";
+export { IndiekitEndpointPlugin } from "./lib/endpoint.js";
 export { IndiekitPostTypePlugin } from "./lib/post-type.js";

--- a/packages/plugin/lib/base.js
+++ b/packages/plugin/lib/base.js
@@ -57,6 +57,12 @@ export class IndiekitPlugin {
   prompts = undefined;
 
   /**
+   * Get validation schemas for form validation
+   * @type {import('express-validator').Schema} Form validation
+   */
+  validationSchemas = undefined;
+
+  /**
    * NPM package name
    * @type {string}
    */
@@ -101,6 +107,19 @@ export class IndiekitPlugin {
   }
 
   /**
+   * Add validation schemas
+   */
+  #addValidationSchemas() {
+    const validationSchemas = this.validationSchemas;
+    if (validationSchemas) {
+      for (const [field, schema] of Object.entries(validationSchemas)) {
+        debug("Adding validation schemas for", field);
+        this.indiekit.validationSchemas.set(field, schema);
+      }
+    }
+  }
+
+  /**
    * Initialize plug-in
    *
    * This method should be overridden by plug-in implementations to add
@@ -110,5 +129,6 @@ export class IndiekitPlugin {
    */
   async init() {
     debug(`Initiating ${this.#packageName}`);
+    this.#addValidationSchemas();
   }
 }

--- a/packages/plugin/lib/base.js
+++ b/packages/plugin/lib/base.js
@@ -1,0 +1,114 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { IndiekitError } from "@indiekit/error";
+import makeDebug from "debug";
+
+const debug = makeDebug(`indiekit:plugin`);
+
+/**
+ * Base class for Indiekit plug-ins
+ *
+ * Plug-in registration, initialization, and utility methods.
+ * @class
+ */
+export class IndiekitPlugin {
+  /**
+   * Register plug-in with Indiekit
+   * @param {object} Indiekit - Indiekit instance
+   * @param {string} packageName - Name of the plug-in package
+   * @returns {Promise<IndiekitPlugin>} Registered plug-in instance
+   * @static
+   * @async
+   */
+  static async register(Indiekit, packageName) {
+    debug(`Registering ${packageName}`);
+
+    const plugin = new this(Indiekit.config[packageName]);
+    plugin.indiekit = Indiekit;
+    plugin.name = plugin.name || packageName;
+    plugin.#packageName = packageName;
+
+    // Initiate plug-in features
+    await plugin.init();
+
+    // Add plug-in to Indiekit
+    Indiekit.installedPlugins.add(plugin);
+
+    return plugin;
+  }
+
+  /**
+   * Environment variables (used when configuring Docker)
+   * @type {string[]}
+   */
+  environment = undefined;
+
+  /**
+   * Human-readable name for the plug-in
+   * @type {string}
+   */
+  name = undefined;
+
+  /**
+   * Questions to ask when creating a new configuration file
+   * @type {import("prompts").PromptObject[]}
+   */
+  prompts = undefined;
+
+  /**
+   * NPM package name
+   * @type {string}
+   */
+  #packageName = undefined;
+
+  /**
+   * Create new plug-in instance
+   * @param {object} options - Plug-in options
+   */
+  constructor(options) {
+    this.indiekit = undefined;
+    this.options = options;
+  }
+
+  /**
+   * Get file path to plug-in package directory
+   * @returns {string} Absolute path to plug-in package directory
+   * @throws {IndiekitError} Plug-in package cannot be resolved
+   */
+  get filePath() {
+    const require = createRequire(import.meta.url);
+
+    try {
+      return path.dirname(require.resolve(`${this.#packageName}/package.json`));
+    } catch (error) {
+      throw new IndiekitError(
+        `Could not resolve path for ${this.#packageName}`,
+        {
+          cause: error,
+          plugin: this.#packageName,
+        },
+      );
+    }
+  }
+
+  /**
+   * Get unique identifier for plug-in
+   * @returns {string} Plug-in identifier derived from package name
+   */
+  get id() {
+    return this.#packageName.replace("/", "-");
+  }
+
+  /**
+   * Initialize plug-in
+   *
+   * This method should be overridden by plug-in implementations to add
+   * specific functionality.
+   * @returns {Promise<void>} Promise that resolves when initialization complete
+   * @async
+   */
+  async init() {
+    debug(`Initiating ${this.#packageName}`);
+  }
+}

--- a/packages/plugin/lib/base.js
+++ b/packages/plugin/lib/base.js
@@ -39,6 +39,12 @@ export class IndiekitPlugin {
   }
 
   /**
+   * Database collection used by the plug-in
+   * @type {string}
+   */
+  collection = undefined;
+
+  /**
    * Environment variables (used when configuring Docker)
    * @type {string[]}
    */
@@ -107,6 +113,25 @@ export class IndiekitPlugin {
   }
 
   /**
+   * Add database collection
+   */
+  #addCollection() {
+    if (!this.collection) {
+      return;
+    }
+
+    if (this.indiekit.collections.has(this.collection)) {
+      console.warn(`Collection ‘${this.collection}’ already added`);
+    } else if (this.indiekit.database) {
+      this.indiekit.collections.set(
+        this.collection,
+        this.indiekit.database.collection(this.collection),
+      );
+      debug(`Added database collection: ${this.collection}`);
+    }
+  }
+
+  /**
    * Add validation schemas
    */
   #addValidationSchemas() {
@@ -129,6 +154,7 @@ export class IndiekitPlugin {
    */
   async init() {
     debug(`Initiating ${this.#packageName}`);
+    this.#addCollection();
     this.#addValidationSchemas();
   }
 }

--- a/packages/plugin/lib/base.js
+++ b/packages/plugin/lib/base.js
@@ -64,7 +64,7 @@ export class IndiekitPlugin {
 
   /**
    * Get validation schemas for form validation
-   * @type {import('express-validator').Schema} Form validation
+   * @type {import("express-validator").Schema} Form validation
    */
   validationSchemas = undefined;
 

--- a/packages/plugin/lib/endpoint.js
+++ b/packages/plugin/lib/endpoint.js
@@ -1,0 +1,63 @@
+import makeDebug from "debug";
+import express from "express";
+
+import { IndiekitPlugin } from "./base.js";
+
+const debug = makeDebug(`indiekit:plugin`);
+
+/**
+ * @typedef NavigationItem
+ * @property {string} href - Navigation path
+ * @property {string} text - Text shown in the navigation item
+ * @property {boolean} [requiresDatabase] - Points to feature requiring database
+ */
+
+/**
+ * @typedef ShortcutItem
+ * @property {string} url - Shortcut URL
+ * @property {string} name - Text shown in shortcut item
+ * @property {string} [iconName] - Icon to use for shortcut item
+ * @property {boolean} [requiresDatabase] - Points to feature requiring database
+ */
+
+/**
+ * Endpoint plugin
+ * @class
+ * @augments {IndiekitPlugin}
+ */
+export class IndiekitEndpointPlugin extends IndiekitPlugin {
+  /**
+   * Path to mount plug-in routes onto
+   * @type {string}
+   */
+  mountPath = undefined;
+
+  /**
+   * Navigation item(s) to show in application navigation menu
+   * @type {Array<NavigationItem>|NavigationItem}
+   */
+  navigationItems = undefined;
+
+  /**
+   * Express router
+   * @type {import("express").Router}
+   */
+  router = express.Router({ caseSensitive: true, mergeParams: true });
+
+  /**
+   * Shortcut item(s) to add to application’s manifest
+   * @type {Array<ShortcutItem>|ShortcutItem}
+   */
+  shortcutItems = undefined;
+
+  #addEndpoint() {
+    debug("Adding endpoint at", this.mountPath);
+    this.indiekit.endpoints.add(this);
+  }
+
+  async init() {
+    await super.init();
+
+    this.#addEndpoint();
+  }
+}

--- a/packages/plugin/lib/post-type.js
+++ b/packages/plugin/lib/post-type.js
@@ -1,0 +1,73 @@
+import makeDebug from "debug";
+
+import { IndiekitPlugin } from "./base.js";
+
+const debug = makeDebug(`indiekit:plugin`);
+
+/**
+ * @typedef {string} MicroformatsVocabulary
+ * A string representing a Microformats vocabulary. Expected values are:
+ * - "adr": Structured location
+ * - "card": Person or organisation
+ * - "entry": Syndicated content
+ * - "event": Event
+ * - "feed": Stream of entries
+ * - "geo": WGS84 geographic coordinates
+ * - "item": Arbitrary item
+ * - "listing": Product listing
+ * - "product": Product data
+ * - "recipe": Recipe
+ * @see {@link https://microformats.org/wiki/microformats2#v2_vocabularies}
+ */
+
+/**
+ * @typedef {object} FieldType
+ * @property {boolean} [required] - Indicates if field is required
+ */
+
+/**
+ * @typedef PostTypeConfiguration
+ * @property {string} name - Post type name
+ * @property {MicroformatsVocabulary} [h] - Microformats vocabulary
+ * @property {{[key: string]: FieldType}} fields - Input fields
+ * @property {string} [discovery] - Property to identify Micropub request
+ */
+
+/**
+ * Post type plug-in
+ * @class
+ * @augments {IndiekitPlugin}
+ */
+export class IndiekitPostTypePlugin extends IndiekitPlugin {
+  /**
+   * Post type configuration
+   * @type {PostTypeConfiguration}
+   */
+  config = undefined;
+
+  /**
+   * Post type identifier
+   * @type {string}
+   * @see {@link https://indieweb.org/Category:PostType}
+   */
+  postType = undefined;
+
+  #addPostType() {
+    // Override post type configuration with user options
+    const postTypeConfig = { ...this.config, ...this.options };
+
+    if (postTypeConfig) {
+      debug("Adding post type configuration for", this.postType);
+      this.indiekit.postTypes.set(this.postType, {
+        ...this.indiekit.postTypes.get(this.postType),
+        ...postTypeConfig,
+      });
+    }
+  }
+
+  async init() {
+    await super.init();
+
+    this.#addPostType();
+  }
+}

--- a/packages/plugin/lib/preset.js
+++ b/packages/plugin/lib/preset.js
@@ -1,0 +1,62 @@
+import makeDebug from "debug";
+
+import { IndiekitPlugin } from "./base.js";
+
+const debug = makeDebug(`indiekit:plugin`);
+
+/**
+ * @typedef PostTypeConfiguration
+ * @property {string} name - Post type name
+ * @property {object} [post] - Post paths
+ * @property {string} [post.path] - File location for post in content store
+ * @property {string} [post.url] - Public post permalink URL
+ * @property {object} [media] - Media paths
+ * @property {string} [media.path] - File location for media in content store
+ * @property {string} [media.url] - Public media permalink URL
+ */
+
+/**
+ * @typedef PresetInformation
+ * @property {string} name - Name of publishing software
+ */
+
+/**
+ * Publication preset plug-in
+ * @class
+ * @augments {IndiekitPlugin}
+ */
+export class IndiekitPresetPlugin extends IndiekitPlugin {
+  /**
+   * Present information
+   * @type {PresetInformation}
+   */
+  info = undefined;
+
+  /**
+   * Post types
+   * @type {{[key: string]: PostTypeConfiguration}}
+   */
+  get postTypes() {
+    return {};
+  }
+
+  /**
+   * Post template
+   * @param {object} properties - JF2 properties
+   * @returns {string} Post template
+   */
+  postTemplate(properties) {
+    return JSON.stringify(properties);
+  }
+
+  #addPreset() {
+    debug(`Adding publication preset: ${this.name}`);
+    this.indiekit.publication.preset = this;
+  }
+
+  async init() {
+    await super.init();
+
+    this.#addPreset();
+  }
+}

--- a/packages/plugin/lib/store.js
+++ b/packages/plugin/lib/store.js
@@ -1,0 +1,87 @@
+import makeDebug from "debug";
+
+import { IndiekitPlugin } from "./base.js";
+
+const debug = makeDebug(`indiekit:plugin`);
+
+/**
+ * @typedef StoreInformation
+ * @property {string} name - Name of content store
+ * @property {string} uid - Unique identifier
+ */
+
+/**
+ * Content store plug-in
+ * @class
+ * @augments {IndiekitPlugin}
+ */
+export class IndiekitStorePlugin extends IndiekitPlugin {
+  /**
+   * Content store information
+   * @type {StoreInformation}
+   */
+  info = undefined;
+
+  #addStore() {
+    debug(`Adding content store: ${this.name}`);
+    this.indiekit.stores.add(this);
+  }
+
+  /**
+   * Create file
+   * @param {string} filePath - Path to file
+   * @param {string} content - File content
+   * @param {object} [options] - Options
+   * @param {string} [options.message] - Commit message
+   * @returns {Promise<string>} Created file URL
+   */
+  // eslint-disable-next-line no-unused-vars
+  async createFile(filePath, content, options) {
+    debug(`Creating ${filePath} to ${this.name}`);
+    return;
+  }
+
+  /**
+   * Read file
+   * @param {string} filePath - Path to file
+   * @returns {Promise<string>} File content
+   */
+  async readFile(filePath) {
+    debug(`Reading ${filePath} at ${this.name}`);
+    return;
+  }
+
+  /**
+   * Update file
+   * @param {string} filePath - Path to file
+   * @param {string} content - File content
+   * @param {object} [options] - Options
+   * @param {string} [options.message] - Commit message
+   * @param {string} [options.newPath] - New path to file
+   * @returns {Promise<string>} Updated file URL
+   */
+  // eslint-disable-next-line no-unused-vars
+  async updateFile(filePath, content, options) {
+    debug(`Updating ${filePath} at ${this.name}`);
+    return;
+  }
+
+  /**
+   * Delete file
+   * @param {string} filePath - Path to file
+   * @param {object} [options] - Options
+   * @param {string} [options.message] - Commit message
+   * @returns {Promise<boolean>} File deleted
+   */
+  // eslint-disable-next-line no-unused-vars
+  async deleteFile(filePath, options) {
+    debug(`Creating ${filePath} to ${this.name}`);
+    return;
+  }
+
+  async init() {
+    await super.init();
+
+    this.#addStore();
+  }
+}

--- a/packages/plugin/lib/syndicator.js
+++ b/packages/plugin/lib/syndicator.js
@@ -1,0 +1,61 @@
+import makeDebug from "debug";
+
+import { IndiekitPlugin } from "./base.js";
+
+const debug = makeDebug(`indiekit:plugin`);
+
+/**
+ * @typedef SyndicationTarget
+ * @property {string} name - Name of syndication target
+ * @property {string} uid - Unique identifier
+ * @property {boolean} [checked] - Use syndication target by default
+ * @property {object} [service] - Service information
+ * @property {string} [service.name] - Service name
+ * @property {string} [service.url] - Service URL
+ * @property {string} [service.photo] - Service logo
+ * @property {object} [user] - User information
+ * @property {string} [user.name] - User name
+ * @property {string} [user.url] - User URL
+ * @property {string} [user.photo] - User photo
+ * @see {@link https://micropub.spec.indieweb.org/#syndication-targets}
+ */
+
+/**
+ * Syndicator plug-in
+ * @class
+ * @augments {IndiekitPlugin}
+ */
+export class IndiekitSyndicatorPlugin extends IndiekitPlugin {
+  /**
+   * Syndication target information
+   * @type {SyndicationTarget}
+   */
+  info = undefined;
+
+  /**
+   * Syndicate post
+   * @param {object} properties - JF2 properties
+   * @returns {Promise<string|boolean>} URL of syndicated status
+   */
+  async syndicate(properties) {
+    debug(`Syndicating ${properties.url} to ${this.name}`);
+    return;
+  }
+
+  #addSyndicator() {
+    const syndicationTargets = new Set(
+      this.indiekit.publication.syndicationTargets,
+    );
+
+    debug(`Adding syndication target: ${this.name}`);
+    syndicationTargets.add(this);
+
+    this.indiekit.publication.syndicationTargets = [...syndicationTargets];
+  }
+
+  async init() {
+    await super.init();
+
+    this.#addSyndicator();
+  }
+}

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@indiekit/plugin",
+  "version": "1.0.0-beta.19",
+  "description": "Plug-in API for Indiekit",
+  "keywords": [
+    "indiekit",
+    "indieweb"
+  ],
+  "homepage": "https://getindiekit.com",
+  "author": {
+    "name": "Paul Robert Lloyd",
+    "url": "https://paulrobertlloyd.com"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "main": "index.js",
+  "files": [
+    "lib",
+    "index.js"
+  ],
+  "bugs": {
+    "url": "https://github.com/getindiekit/indiekit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getindiekit/indiekit.git",
+    "directory": "packages/plugin"
+  },
+  "dependencies": {
+    "@indiekit/error": "^1.0.0-beta.15",
+    "debug": "^4.3.2"
+  },
+  "peerDependencies": {
+    "@indiekit/indiekit": "^1.0.0-beta.19"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
-    "debug": "^4.3.2"
+    "debug": "^4.3.2",
+    "express": "^5.0.0"
   },
   "peerDependencies": {
     "@indiekit/indiekit": "^1.0.0-beta.19"

--- a/packages/post-type-article/index.js
+++ b/packages/post-type-article/index.js
@@ -1,32 +1,22 @@
-const defaults = {
-  name: "Article",
-  fields: {
-    name: { required: true },
-    summary: {},
-    content: { required: true },
-    category: {},
-    geo: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 
-export default class ArticlePostType {
-  constructor(options = {}) {
-    this.name = "Article post type";
-    this.options = { ...defaults, ...options };
-  }
+export default class ArticlePostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Article post type";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  postType = "article";
 
-  init(Indiekit) {
-    Indiekit.addPostType("article", this);
-  }
+  config = {
+    name: "Article",
+    h: "entry",
+    fields: {
+      name: { required: true },
+      summary: {},
+      content: { required: true },
+      category: {},
+      geo: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 }

--- a/packages/post-type-article/package.json
+++ b/packages/post-type-article/package.json
@@ -32,6 +32,9 @@
     "url": "https://github.com/getindiekit/indiekit.git",
     "directory": "packages/post-type-article"
   },
+  "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/post-type-audio/index.js
+++ b/packages/post-type-audio/index.js
@@ -1,45 +1,32 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Audio",
-  fields: {
-    audio: { required: true },
-    content: {},
-    category: {},
-    geo: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class AudioPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Audio post type";
 
-export default class AudioPostType {
-  constructor(options = {}) {
-    this.name = "Audio post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "audio";
 
-  get config() {
-    return {
-      name: this.options.name,
-      discovery: "audio",
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Audio",
+    discovery: "audio",
+    h: "entry",
+    fields: {
+      audio: { required: true },
+      content: {},
+      category: {},
+      geo: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      "audio.*": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.media.empty`, "/music/audio.mp3"),
-        exists: { if: (value, { req }) => isRequired(req, "audio") },
-        notEmpty: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("audio", this);
-  }
+  validationSchemas = {
+    "audio.*": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.media.empty`, "/music/audio.mp3"),
+      exists: { if: (value, { req }) => isRequired(req, "audio") },
+      notEmpty: true,
+    },
+  };
 }

--- a/packages/post-type-audio/package.json
+++ b/packages/post-type-audio/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-audio"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/post-type-bookmark/index.js
+++ b/packages/post-type-bookmark/index.js
@@ -1,45 +1,32 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Bookmark",
-  fields: {
-    "bookmark-of": { required: true },
-    name: {},
-    content: {},
-    category: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class BookmarkPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Bookmark post type";
 
-export default class BookmarkPostType {
-  constructor(options = {}) {
-    this.name = "Bookmark post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "bookmark";
 
-  get config() {
-    return {
-      name: this.options.name,
-      discovery: "bookmark-of",
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Bookmark",
+    discovery: "bookmark-of",
+    h: "entry",
+    fields: {
+      "bookmark-of": { required: true },
+      name: {},
+      content: {},
+      category: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      "bookmark-of": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.url.empty`, "https://example.org"),
-        exists: { if: (value, { req }) => isRequired(req, "bookmark-of") },
-        isURL: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("bookmark", this);
-  }
+  validationSchemas = {
+    "bookmark-of": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.url.empty`, "https://example.org"),
+      exists: { if: (value, { req }) => isRequired(req, "bookmark-of") },
+      isURL: true,
+    },
+  };
 }

--- a/packages/post-type-bookmark/package.json
+++ b/packages/post-type-bookmark/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-bookmark"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/post-type-event/index.js
+++ b/packages/post-type-event/index.js
@@ -1,46 +1,33 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Event",
-  fields: {
-    name: { required: true },
-    start: { required: true },
-    end: {},
-    url: {},
-    location: {},
-    content: {},
-    category: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class EventPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Event post type";
 
-export default class EventPostType {
-  constructor(options = {}) {
-    this.name = "Event post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "event";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "event",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Event",
+    h: "event",
+    fields: {
+      name: { required: true },
+      start: { required: true },
+      end: {},
+      url: {},
+      location: {},
+      content: {},
+      category: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      start: {
-        errorMessage: (value, { req }) => req.__("posts.error.start.empty"),
-        exists: { if: (value, { req }) => isRequired(req, "start") },
-        notEmpty: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("event", this);
-  }
+  validationSchemas = {
+    start: {
+      errorMessage: (value, { req }) => req.__("posts.error.start.empty"),
+      exists: { if: (value, { req }) => isRequired(req, "start") },
+      notEmpty: true,
+    },
+  };
 }

--- a/packages/post-type-event/package.json
+++ b/packages/post-type-event/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-event"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/post-type-jam/index.js
+++ b/packages/post-type-jam/index.js
@@ -1,56 +1,42 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Jam",
-  fields: {
-    "jam-of": { required: true },
-    content: {},
-    "post-status": {},
-    published: { required: true },
-  },
-};
+export default class JamPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Jam post type";
 
-export default class JamPostType {
-  constructor(options = {}) {
-    this.name = "Jam post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "jam";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      discovery: "jam-of",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Jam",
+    h: "entry",
+    discovery: "jam-of",
+    fields: {
+      "jam-of": { required: true },
+      content: {},
+      "post-status": {},
+      published: { required: true },
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      "jam-of.url": {
-        errorMessage: (value, { req }) =>
-          req.__(
-            `posts.error.url.empty`,
-            "https://www.youtube.com/watch?v=g5nzLQ63c9E",
-          ),
-        exists: { if: (value, { req }) => isRequired(req, "jam-of") },
-        isURL: true,
-      },
-      "jam-of.name": {
-        errorMessage: (value, { req }) => req.__(`posts.error.jam.name.empty`),
-        exists: { if: (value, { req }) => isRequired(req, "jam-of") },
-        notEmpty: true,
-      },
-      "jam-of.author": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.jam.author.empty`),
-        exists: { if: (value, { req }) => isRequired(req, "jam-of") },
-        notEmpty: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("jam", this);
-  }
+  validationSchemas = {
+    "jam-of.url": {
+      errorMessage: (value, { req }) =>
+        req.__(
+          `posts.error.url.empty`,
+          "https://www.youtube.com/watch?v=g5nzLQ63c9E",
+        ),
+      exists: { if: (value, { req }) => isRequired(req, "jam-of") },
+      isURL: true,
+    },
+    "jam-of.name": {
+      errorMessage: (value, { req }) => req.__(`posts.error.jam.name.empty`),
+      exists: { if: (value, { req }) => isRequired(req, "jam-of") },
+      notEmpty: true,
+    },
+    "jam-of.author": {
+      errorMessage: (value, { req }) => req.__(`posts.error.jam.author.empty`),
+      exists: { if: (value, { req }) => isRequired(req, "jam-of") },
+      notEmpty: true,
+    },
+  };
 }

--- a/packages/post-type-jam/package.json
+++ b/packages/post-type-jam/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-jam"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/post-type-like/index.js
+++ b/packages/post-type-like/index.js
@@ -1,43 +1,30 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Like",
-  fields: {
-    "like-of": { required: true },
-    category: {},
-    content: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class LikePostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Like post type";
 
-export default class LikePostType {
-  constructor(options = {}) {
-    this.name = "Like post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "like";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Like",
+    h: "entry",
+    fields: {
+      "like-of": { required: true },
+      category: {},
+      content: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      "like-of": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.url.empty`, "https://example.org"),
-        exists: { if: (value, { req }) => isRequired(req, "like-of") },
-        isURL: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("like", this);
-  }
+  validationSchemas = {
+    "like-of": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.url.empty`, "https://example.org"),
+      exists: { if: (value, { req }) => isRequired(req, "like-of") },
+      isURL: true,
+    },
+  };
 }

--- a/packages/post-type-like/package.json
+++ b/packages/post-type-like/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-like"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/post-type-note/index.js
+++ b/packages/post-type-note/index.js
@@ -1,30 +1,20 @@
-const defaults = {
-  name: "Note",
-  fields: {
-    content: { required: true },
-    category: {},
-    geo: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 
-export default class NotePostType {
-  constructor(options = {}) {
-    this.name = "Note post type";
-    this.options = { ...defaults, ...options };
-  }
+export default class NotePostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Note post type";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  postType = "note";
 
-  init(Indiekit) {
-    Indiekit.addPostType("note", this);
-  }
+  config = {
+    name: "Note",
+    h: "entry",
+    fields: {
+      content: { required: true },
+      category: {},
+      geo: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 }

--- a/packages/post-type-note/package.json
+++ b/packages/post-type-note/package.json
@@ -32,6 +32,9 @@
     "url": "https://github.com/getindiekit/indiekit.git",
     "directory": "packages/post-type-note"
   },
+  "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/post-type-photo/index.js
+++ b/packages/post-type-photo/index.js
@@ -1,51 +1,38 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Photo",
-  fields: {
-    photo: { required: true },
-    content: {},
-    category: {},
-    geo: {},
-    "post-status": {},
-    "mp-photo-alt": { required: true },
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class PhotoPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Photo post type";
 
-export default class PhotoPostType {
-  constructor(options = {}) {
-    this.name = "Photo post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "photo";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Photo",
+    h: "entry",
+    fields: {
+      photo: { required: true },
+      content: {},
+      category: {},
+      geo: {},
+      "post-status": {},
+      "mp-photo-alt": { required: true },
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      "photo.*.url": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.media.empty`, "/photos/image.jpg"),
-        exists: { if: (value, { req }) => isRequired(req, "photo") },
-        notEmpty: true,
-      },
-      "photo.*.alt": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.mp-photo-alt.empty`),
-        exists: { if: (value, { req }) => isRequired(req, "mp-photo-alt") },
-        notEmpty: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("photo", this);
-  }
+  validationSchemas = {
+    "photo.*.url": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.media.empty`, "/photos/image.jpg"),
+      exists: { if: (value, { req }) => isRequired(req, "photo") },
+      notEmpty: true,
+    },
+    "photo.*.alt": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.mp-photo-alt.empty`),
+      exists: { if: (value, { req }) => isRequired(req, "mp-photo-alt") },
+      notEmpty: true,
+    },
+  };
 }

--- a/packages/post-type-photo/package.json
+++ b/packages/post-type-photo/package.json
@@ -34,6 +34,10 @@
     "url": "https://github.com/getindiekit/indiekit.git",
     "directory": "packages/post-type-photo"
   },
+  "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
+    "@indiekit/util": "^1.0.0-beta.19"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/post-type-reply/index.js
+++ b/packages/post-type-reply/index.js
@@ -1,43 +1,30 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Reply",
-  fields: {
-    "in-reply-to": { required: true },
-    content: { required: true },
-    category: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class ReplyPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Reply post type";
 
-export default class ReplyPostType {
-  constructor(options = {}) {
-    this.name = "Reply post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "reply";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Reply",
+    h: "entry",
+    fields: {
+      "in-reply-to": { required: true },
+      content: { required: true },
+      category: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      "in-reply-to": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.url.empty`, "https://example.org"),
-        exists: { if: (value, { req }) => isRequired(req, "in-reply-to") },
-        isURL: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("reply", this);
-  }
+  validationSchemas = {
+    "in-reply-to": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.url.empty`, "https://example.org"),
+      exists: { if: (value, { req }) => isRequired(req, "in-reply-to") },
+      isURL: true,
+    },
+  };
 }

--- a/packages/post-type-reply/package.json
+++ b/packages/post-type-reply/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-reply"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/post-type-repost/index.js
+++ b/packages/post-type-repost/index.js
@@ -1,43 +1,30 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Repost",
-  fields: {
-    "repost-of": { required: true },
-    content: {},
-    category: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class RepostPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Repost post type";
 
-export default class RepostPostType {
-  constructor(options = {}) {
-    this.name = "Repost post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "repost";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Repost",
+    h: "entry",
+    fields: {
+      "repost-of": { required: true },
+      content: {},
+      category: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      "repost-of": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.url.empty`, "https://example.org"),
-        exists: { if: (value, { req }) => isRequired(req, "repost-of") },
-        isURL: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("repost", this);
-  }
+  validationSchemas = {
+    "repost-of": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.url.empty`, "https://example.org"),
+      exists: { if: (value, { req }) => isRequired(req, "repost-of") },
+      isURL: true,
+    },
+  };
 }

--- a/packages/post-type-repost/package.json
+++ b/packages/post-type-repost/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-repost"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/post-type-rsvp/index.js
+++ b/packages/post-type-rsvp/index.js
@@ -1,43 +1,30 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "RSVP",
-  fields: {
-    "in-reply-to": { required: true },
-    rsvp: { required: true },
-    content: {},
-    category: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class RsvpPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "RSVP post type";
 
-export default class RsvpPostType {
-  constructor(options = {}) {
-    this.name = "RSVP post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "rsvp";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "RSVP",
+    h: "entry",
+    fields: {
+      "in-reply-to": { required: true },
+      rsvp: { required: true },
+      content: {},
+      category: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      rsvp: {
-        errorMessage: (value, { req }) => req.__("posts.error.rsvp.empty"),
-        exists: { if: (value, { req }) => isRequired(req, "rsvp") },
-        notEmpty: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("rsvp", this);
-  }
+  validationSchemas = {
+    rsvp: {
+      errorMessage: (value, { req }) => req.__("posts.error.rsvp.empty"),
+      exists: { if: (value, { req }) => isRequired(req, "rsvp") },
+      notEmpty: true,
+    },
+  };
 }

--- a/packages/post-type-rsvp/package.json
+++ b/packages/post-type-rsvp/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-rsvp"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/post-type-video/index.js
+++ b/packages/post-type-video/index.js
@@ -1,44 +1,31 @@
+import { IndiekitPostTypePlugin } from "@indiekit/plugin";
 import { isRequired } from "@indiekit/util";
 
-const defaults = {
-  name: "Video",
-  fields: {
-    video: { required: true },
-    content: {},
-    category: {},
-    geo: {},
-    "post-status": {},
-    published: { required: true },
-    visibility: {},
-  },
-};
+export default class VideoPostTypePlugin extends IndiekitPostTypePlugin {
+  name = "Video post type";
 
-export default class PhotoPostType {
-  constructor(options = {}) {
-    this.name = "Video post type";
-    this.options = { ...defaults, ...options };
-  }
+  postType = "video";
 
-  get config() {
-    return {
-      name: this.options.name,
-      h: "entry",
-      fields: this.options.fields,
-    };
-  }
+  config = {
+    name: "Video",
+    h: "entry",
+    fields: {
+      video: { required: true },
+      content: {},
+      category: {},
+      geo: {},
+      "post-status": {},
+      published: { required: true },
+      visibility: {},
+    },
+  };
 
-  get validationSchemas() {
-    return {
-      "video.*": {
-        errorMessage: (value, { req }) =>
-          req.__(`posts.error.media.empty`, "/movies/video.mp4"),
-        exists: { if: (value, { req }) => isRequired(req, "video") },
-        notEmpty: true,
-      },
-    };
-  }
-
-  init(Indiekit) {
-    Indiekit.addPostType("video", this);
-  }
+  validationSchemas = {
+    "video.*": {
+      errorMessage: (value, { req }) =>
+        req.__(`posts.error.media.empty`, "/movies/video.mp4"),
+      exists: { if: (value, { req }) => isRequired(req, "video") },
+      notEmpty: true,
+    },
+  };
 }

--- a/packages/post-type-video/package.json
+++ b/packages/post-type-video/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/post-type-video"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19"
   },
   "publishConfig": {

--- a/packages/preset-eleventy/index.js
+++ b/packages/preset-eleventy/index.js
@@ -1,24 +1,20 @@
+import { IndiekitPresetPlugin } from "@indiekit/plugin";
+
 import { getPostTemplate } from "./lib/post-template.js";
 import { getPostTypes } from "./lib/post-types.js";
 
-export default class EleventyPreset {
-  constructor() {
-    this.name = "Eleventy preset";
-  }
+export default class EleventyPresetPlugin extends IndiekitPresetPlugin {
+  info = {
+    name: "Eleventy",
+  };
 
-  get info() {
-    return {
-      name: "Eleventy",
-    };
+  name = "Eleventy preset";
+
+  get postTypes() {
+    return getPostTypes(this.indiekit.postTypes);
   }
 
   postTemplate(properties) {
     return getPostTemplate(properties);
-  }
-
-  init(Indiekit) {
-    this.postTypes = getPostTypes(Indiekit.postTypes);
-
-    Indiekit.addPreset(this);
   }
 }

--- a/packages/preset-eleventy/package.json
+++ b/packages/preset-eleventy/package.json
@@ -35,6 +35,7 @@
     "directory": "packages/preset-eleventy"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "camelcase-keys": "^9.0.0",
     "plur": "^5.1.0",
     "yaml": "^2.6.0"

--- a/packages/preset-eleventy/test/index.js
+++ b/packages/preset-eleventy/test/index.js
@@ -1,32 +1,10 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
-
-import EleventyPreset from "../index.js";
+import EleventyPresetPlugin from "../index.js";
 
 describe("preset-eleventy", async () => {
-  const eleventy = new EleventyPreset();
-  const indiekit = await Indiekit.initialize({
-    config: {
-      publication: {
-        me: "https://website.example",
-        postTypes: {
-          puppy: {
-            name: "Puppy posts",
-          },
-        },
-      },
-    },
-  });
-  await indiekit.installPlugins();
-  await indiekit.updatePublicationConfig();
-
-  eleventy.init(indiekit);
-
-  it("Initiates plug-in", async () => {
-    assert.equal(indiekit.publication.preset.info.name, "Eleventy");
-  });
+  const eleventy = new EleventyPresetPlugin();
 
   it("Gets plug-in info", () => {
     assert.equal(eleventy.name, "Eleventy preset");

--- a/packages/preset-eleventy/test/unit/post-template.js
+++ b/packages/preset-eleventy/test/unit/post-template.js
@@ -5,7 +5,7 @@ import { getFixture } from "@indiekit-test/fixtures";
 
 import { getPostTemplate } from "../../lib/post-template.js";
 
-describe("preset-jekyll/lib/post-template", async () => {
+describe("preset-eleventy/lib/post-template", async () => {
   const properties = JSON.parse(getFixture("jf2/post-template-properties.jf2"));
 
   it("Renders post template without content", () => {

--- a/packages/preset-eleventy/test/unit/post-types.js
+++ b/packages/preset-eleventy/test/unit/post-types.js
@@ -8,7 +8,7 @@ postTypes.set("article", { name: "Journal post" });
 postTypes.set("note", { name: "Micro post" });
 postTypes.set("puppy", { name: "Puppy post" });
 
-describe("preset-jekyll/lib/post-types", () => {
+describe("preset-eleventy/lib/post-types", () => {
   it("Gets paths and URLs for configured post types", () => {
     const result = getPostTypes(postTypes);
 

--- a/packages/preset-hugo/index.js
+++ b/packages/preset-hugo/index.js
@@ -1,3 +1,5 @@
+import { IndiekitPresetPlugin } from "@indiekit/plugin";
+
 import { getPostTemplate } from "./lib/post-template.js";
 import { getPostTypes } from "./lib/post-types.js";
 
@@ -5,50 +7,54 @@ const defaults = {
   frontMatterFormat: "yaml",
 };
 
-export default class HugoPreset {
+export default class HugoPresetPlugin extends IndiekitPresetPlugin {
+  info = {
+    name: "Hugo",
+  };
+
+  name = "Hugo preset";
+
+  /**
+   * @type {import('prompts').PromptObject[]}
+   */
+  prompts = [
+    {
+      type: "select",
+      name: "frontMatterFormat",
+      message: "Which front matter format are you using?",
+      choices: [
+        {
+          title: "JSON",
+          value: "json",
+        },
+        {
+          title: "TOML",
+          value: "toml",
+        },
+        {
+          title: "YAML",
+          value: "yaml",
+        },
+      ],
+      initial: 2,
+    },
+  ];
+
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.frontMatterFormat] - Front matter format
+   */
   constructor(options = {}) {
-    this.name = "Hugo preset";
+    super(options);
+
     this.options = { ...defaults, ...options };
   }
 
-  get info() {
-    return {
-      name: "Hugo",
-    };
-  }
-
-  get prompts() {
-    return [
-      {
-        type: "select",
-        name: "frontMatterFormat",
-        message: "Which front matter format are you using?",
-        choices: [
-          {
-            title: "JSON",
-            value: "json",
-          },
-          {
-            title: "TOML",
-            value: "toml",
-          },
-          {
-            title: "YAML",
-            value: "yaml",
-          },
-        ],
-        initial: 2,
-      },
-    ];
+  get postTypes() {
+    return getPostTypes(this.indiekit.postTypes);
   }
 
   postTemplate(properties) {
     return getPostTemplate(properties, this.options.frontMatterFormat);
-  }
-
-  init(Indiekit) {
-    this.postTypes = getPostTypes(Indiekit.postTypes);
-
-    Indiekit.addPreset(this);
   }
 }

--- a/packages/preset-hugo/package.json
+++ b/packages/preset-hugo/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "camelcase-keys": "^9.0.0",
     "plur": "^5.1.0",
     "yaml": "^2.6.0"

--- a/packages/preset-hugo/test/index.js
+++ b/packages/preset-hugo/test/index.js
@@ -3,30 +3,10 @@ import { describe, it } from "node:test";
 
 import { Indiekit } from "@indiekit/indiekit";
 
-import HugoPreset from "../index.js";
+import HugoPresetPlugin from "../index.js";
 
 describe("preset-hugo", async () => {
-  const hugo = new HugoPreset();
-  const indiekit = await Indiekit.initialize({
-    config: {
-      publication: {
-        me: "https://website.example",
-        postTypes: {
-          puppy: {
-            name: "Puppy posts",
-          },
-        },
-      },
-    },
-  });
-  await indiekit.installPlugins();
-  await indiekit.updatePublicationConfig();
-
-  hugo.init(indiekit);
-
-  it("Initiates plug-in", async () => {
-    assert.equal(indiekit.publication.preset.info.name, "Hugo");
-  });
+  const hugo = new HugoPresetPlugin();
 
   it("Gets plug-in info", () => {
     assert.equal(hugo.name, "Hugo preset");

--- a/packages/preset-jekyll/index.js
+++ b/packages/preset-jekyll/index.js
@@ -1,24 +1,20 @@
+import { IndiekitPresetPlugin } from "@indiekit/plugin";
+
 import { getPostTemplate } from "./lib/post-template.js";
 import { getPostTypes } from "./lib/post-types.js";
 
-export default class JekyllPreset {
-  constructor() {
-    this.name = "Jekyll preset";
-  }
+export default class JekyllPresetPlugin extends IndiekitPresetPlugin {
+  info = {
+    name: "Jekyll",
+  };
 
-  get info() {
-    return {
-      name: "Jekyll",
-    };
+  name = "Jekyll preset";
+
+  get postTypes() {
+    return getPostTypes(this.indiekit.postTypes);
   }
 
   postTemplate(properties) {
     return getPostTemplate(properties);
-  }
-
-  init(Indiekit) {
-    this.postTypes = getPostTypes(Indiekit.postTypes);
-
-    Indiekit.addPreset(this);
   }
 }

--- a/packages/preset-jekyll/package.json
+++ b/packages/preset-jekyll/package.json
@@ -37,6 +37,7 @@
     "directory": "packages/preset-jekyll"
   },
   "dependencies": {
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "plur": "^5.1.0",
     "snakecase-keys": "^8.0.0",
     "yaml": "^2.6.0"

--- a/packages/preset-jekyll/test/index.js
+++ b/packages/preset-jekyll/test/index.js
@@ -1,32 +1,10 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
-
-import JekyllPreset from "../index.js";
+import JekyllPresetPlugin from "../index.js";
 
 describe("preset-jekyll", async () => {
-  const jekyll = new JekyllPreset();
-  const indiekit = await Indiekit.initialize({
-    config: {
-      publication: {
-        me: "https://website.example",
-        postTypes: {
-          puppy: {
-            name: "Puppy posts",
-          },
-        },
-      },
-    },
-  });
-  await indiekit.installPlugins();
-  await indiekit.updatePublicationConfig();
-
-  jekyll.init(indiekit);
-
-  it("Initiates plug-in", async () => {
-    assert.equal(indiekit.publication.preset.info.name, "Jekyll");
-  });
+  const jekyll = new JekyllPresetPlugin();
 
   it("Gets plug-in info", () => {
     assert.equal(jekyll.name, "Jekyll preset");

--- a/packages/store-bitbucket/index.js
+++ b/packages/store-bitbucket/index.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import process from "node:process";
 
 import { IndiekitError } from "@indiekit/error";
+import { IndiekitStorePlugin } from "@indiekit/plugin";
 // eslint-disable-next-line import/default
 import bitbucket from "bitbucket";
 
@@ -13,7 +14,33 @@ const defaults = {
 /**
  * @typedef {import("bitbucket").APIClient} APIClient
  */
-export default class BitbucketStore {
+export default class BitbucketStorePlugin extends IndiekitStorePlugin {
+  environment = ["BITBUCKET_PASSWORD"];
+
+  name = "Bitbucket store";
+
+  /**
+   * @type {import('prompts').PromptObject[]}
+   */
+  prompts = [
+    {
+      type: "text",
+      name: "user",
+      message: "What is your Bitbucket username?",
+    },
+    {
+      type: "text",
+      name: "repo",
+      message: "Which repository is your publication stored on?",
+    },
+    {
+      type: "text",
+      name: "branch",
+      message: "Which branch are you publishing from?",
+      initial: defaults.branch,
+    },
+  ];
+
   /**
    * @param {object} [options] - Plug-in options
    * @param {string} [options.user] - Username
@@ -22,42 +49,14 @@ export default class BitbucketStore {
    * @param {string} [options.password] - Password
    */
   constructor(options = {}) {
-    this.name = "Bitbucket store";
+    super(options);
+
     this.options = { ...defaults, ...options };
-  }
 
-  get environment() {
-    return ["BITBUCKET_PASSWORD"];
-  }
-
-  get info() {
-    const { repo, user } = this.options;
-
-    return {
-      name: `${user}/${repo} on Bitbucket`,
-      uid: `https://bitbucket.org/${user}/${repo}`,
+    this.info = {
+      name: `${this.options.user}/${this.options.repo} on Bitbucket`,
+      uid: `https://bitbucket.org/${this.options.user}/${this.options.repo}`,
     };
-  }
-
-  get prompts() {
-    return [
-      {
-        type: "text",
-        name: "user",
-        message: "What is your Bitbucket username?",
-      },
-      {
-        type: "text",
-        name: "repo",
-        message: "Which repository is your publication stored on?",
-      },
-      {
-        type: "text",
-        name: "branch",
-        message: "Which branch are you publishing from?",
-        initial: defaults.branch,
-      },
-    ];
   }
 
   /**
@@ -227,9 +226,5 @@ export default class BitbucketStore {
         status: error.status,
       });
     }
-  }
-
-  init(Indiekit) {
-    Indiekit.addStore(this);
   }
 }

--- a/packages/store-bitbucket/package.json
+++ b/packages/store-bitbucket/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "bitbucket": "^2.6.2"
   },
   "publishConfig": {

--- a/packages/store-bitbucket/test/index.js
+++ b/packages/store-bitbucket/test/index.js
@@ -1,13 +1,12 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
 import nock from "nock";
 
-import BitbucketStore from "../index.js";
+import BitbucketStorePlugin from "../index.js";
 
 describe("store-bitbucket", () => {
-  const bitbucket = new BitbucketStore({
+  const bitbucket = new BitbucketStorePlugin({
     user: "username",
     password: "password",
     repo: "repo",
@@ -29,23 +28,6 @@ describe("store-bitbucket", () => {
     assert.equal(
       bitbucket.prompts[0].message,
       "What is your Bitbucket username?",
-    );
-  });
-
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({
-      config: {
-        plugins: ["@indiekit/store-bitbucket"],
-        publication: { me: "https://website.example" },
-        "@indiekit/store-bitbucket": { user: "user", repo: "repo" },
-      },
-    });
-    await indiekit.installPlugins();
-    await indiekit.updatePublicationConfig();
-
-    assert.equal(
-      indiekit.publication.store.info.name,
-      "user/repo on Bitbucket",
     );
   });
 

--- a/packages/store-file-system/index.js
+++ b/packages/store-file-system/index.js
@@ -4,6 +4,7 @@ import path from "node:path";
 import process from "node:process";
 
 import { IndiekitError } from "@indiekit/error";
+import { IndiekitStorePlugin } from "@indiekit/plugin";
 
 const defaults = {
   directory: process.cwd(),
@@ -13,29 +14,33 @@ const defaults = {
  * @typedef Response
  * @property {object} response - Response
  */
-export default class FileSystemStore {
+export default class FileSystemStorePlugin extends IndiekitStorePlugin {
+  name = "File system store";
+
+  /**
+   * @type {import('prompts').PromptObject[]}
+   */
+  prompts = [
+    {
+      type: "text",
+      name: "directory",
+      message: "Which directory do you want to save files in?",
+    },
+  ];
+
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.directory] - Directory to save files to
+   */
   constructor(options = {}) {
-    this.name = "File system store";
+    super(options);
+
     this.options = { ...defaults, ...options };
-  }
 
-  get info() {
-    const { directory } = this.options;
-
-    return {
-      name: directory,
-      uid: `file://${directory}`,
+    this.info = {
+      name: this.options.directory,
+      uid: `file://${this.options.directory}`,
     };
-  }
-
-  get prompts() {
-    return [
-      {
-        type: "text",
-        name: "directory",
-        message: "Which directory do you want to save files in?",
-      },
-    ];
   }
 
   /**
@@ -132,9 +137,5 @@ export default class FileSystemStore {
         status: error.status,
       });
     }
-  }
-
-  init(Indiekit) {
-    Indiekit.addStore(this);
   }
 }

--- a/packages/store-file-system/package.json
+++ b/packages/store-file-system/package.json
@@ -32,7 +32,8 @@
     "directory": "packages/store-file-system"
   },
   "dependencies": {
-    "@indiekit/error": "^1.0.0-beta.15"
+    "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/store-file-system/test/index.js
+++ b/packages/store-file-system/test/index.js
@@ -3,13 +3,12 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import { afterEach, describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
 import mockFs from "mock-fs";
 
-import FileSystemStore from "../index.js";
+import FileSystemStorePlugin from "../index.js";
 
 describe("store-file-system", () => {
-  const fileSystem = new FileSystemStore({
+  const fileSystem = new FileSystemStorePlugin({
     directory: "directory",
   });
 
@@ -28,20 +27,6 @@ describe("store-file-system", () => {
       fileSystem.prompts[0].message,
       "Which directory do you want to save files in?",
     );
-  });
-
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({
-      config: {
-        plugins: ["@indiekit/store-file-system"],
-        publication: { me: "https://website.example" },
-        "@indiekit/store-file-system": { directory: "directory" },
-      },
-    });
-    await indiekit.installPlugins();
-    await indiekit.updatePublicationConfig();
-
-    assert.equal(indiekit.publication.store.info.name, "directory");
   });
 
   it("Creates file", async () => {

--- a/packages/store-ftp/package.json
+++ b/packages/store-ftp/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "ssh2-sftp-client": "^11.0.0"
   },
   "publishConfig": {

--- a/packages/store-ftp/test/index.js
+++ b/packages/store-ftp/test/index.js
@@ -2,20 +2,19 @@
 import { strict as assert } from "node:assert";
 import { before, after, describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
 import { closeServer, createSftpMockServer } from "@micham/sftp-mock-server";
 
-import FtpStore from "../index.js";
+import FtpStorePlugin from "../index.js";
 
 describe("store-ftp", () => {
-  const ftp = new FtpStore({
+  const ftp = new FtpStorePlugin({
     host: "127.0.0.1",
     port: 9393,
     user: "username",
     password: "password",
   });
 
-  const unauthorizedFtp = new FtpStore({
+  const unauthorizedFtp = new FtpStorePlugin({
     host: "127.0.0.1",
     port: 9393,
     user: "foo",
@@ -48,20 +47,6 @@ describe("store-ftp", () => {
 
   it("Gets plug-in installation prompts", () => {
     assert.equal(ftp.prompts[0].message, "Where is your FTP server hosted?");
-  });
-
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({
-      config: {
-        plugins: ["@indiekit/store-ftp"],
-        publication: { me: "https://website.example" },
-        "@indiekit/store-ftp": { user: "username", host: "127.0.0.1" },
-      },
-    });
-    await indiekit.installPlugins();
-    await indiekit.updatePublicationConfig();
-
-    assert.equal(indiekit.publication.store.info.name, "username on 127.0.0.1");
   });
 
   it("Throws error connecting to FTP server", async () => {

--- a/packages/store-gitea/index.js
+++ b/packages/store-gitea/index.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import process from "node:process";
 
 import { IndiekitError } from "@indiekit/error";
+import { IndiekitStorePlugin } from "@indiekit/plugin";
 
 const defaults = {
   branch: "main",
@@ -10,7 +11,39 @@ const defaults = {
   token: process.env.GITEA_TOKEN,
 };
 
-export default class GiteaStore {
+export default class GiteaStorePlugin extends IndiekitStorePlugin {
+  environment = ["GITEA_TOKEN"];
+
+  name = "Gitea store";
+
+  /**
+   * @type {import('prompts').PromptObject[]}
+   */
+  prompts = [
+    {
+      type: "text",
+      name: "instance",
+      message: "Where is Gitea hosted?",
+      initial: defaults.instance,
+    },
+    {
+      type: "text",
+      name: "user",
+      message: "What is your Gitea username?",
+    },
+    {
+      type: "text",
+      name: "repo",
+      message: "Which repository is your publication stored on?",
+    },
+    {
+      type: "text",
+      name: "branch",
+      message: "Which branch are you publishing from?",
+      initial: defaults.branch,
+    },
+  ];
+
   /**
    * @param {object} [options] - Plug-in options
    * @param {string} [options.instance] - Instance URL
@@ -20,49 +53,14 @@ export default class GiteaStore {
    * @param {string} [options.token] - Access token
    */
   constructor(options = {}) {
-    this.name = "Gitea store";
+    super(options);
+
     this.options = { ...defaults, ...options };
-  }
 
-  get environment() {
-    return ["GITEA_TOKEN"];
-  }
-
-  get info() {
-    const { instance, repo, user } = this.options;
-
-    return {
-      name: `${user}/${repo} on Gitea`,
-      uid: `${instance}/${user}/${repo}`,
+    this.info = {
+      name: `${this.options.user}/${this.options.repo} on Gitea`,
+      uid: `${this.options.instance}/${this.options.user}/${this.options.repo}`,
     };
-  }
-
-  get prompts() {
-    return [
-      {
-        type: "text",
-        name: "instance",
-        message: "Where is Gitea hosted?",
-        description: "i.e. https://gitea.com",
-        initial: defaults.instance,
-      },
-      {
-        type: "text",
-        name: "user",
-        message: "What is your Gitea username?",
-      },
-      {
-        type: "text",
-        name: "repo",
-        message: "Which repository is your publication stored on?",
-      },
-      {
-        type: "text",
-        name: "branch",
-        message: "Which branch are you publishing from?",
-        initial: defaults.branch,
-      },
-    ];
   }
 
   /**
@@ -214,9 +212,5 @@ export default class GiteaStore {
     });
 
     return true;
-  }
-
-  init(Indiekit) {
-    Indiekit.addStore(this);
   }
 }

--- a/packages/store-gitea/package.json
+++ b/packages/store-gitea/package.json
@@ -33,7 +33,8 @@
     "directory": "packages/store-gitea"
   },
   "dependencies": {
-    "@indiekit/error": "^1.0.0-beta.15"
+    "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/store-gitea/test/index.js
+++ b/packages/store-gitea/test/index.js
@@ -1,21 +1,20 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
 import { mockAgent } from "@indiekit-test/mock-agent";
 
-import GiteaStore from "../index.js";
+import GiteaStorePlugin from "../index.js";
 
 await mockAgent("store-gitea");
 
 describe("store-github", async () => {
-  const gitea = new GiteaStore({
+  const gitea = new GiteaStorePlugin({
     token: "token",
     user: "username",
     repo: "repo",
   });
 
-  const giteaInstance = new GiteaStore({
+  const giteaInstance = new GiteaStorePlugin({
     instance: "https://gitea.instance",
     token: "token",
     user: "username",
@@ -34,20 +33,6 @@ describe("store-github", async () => {
 
   it("Gets plug-in installation prompts", () => {
     assert.equal(gitea.prompts[0].message, "Where is Gitea hosted?");
-  });
-
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({
-      config: {
-        plugins: ["@indiekit/store-gitea"],
-        publication: { me: "https://website.example" },
-        "@indiekit/store-gitea": { user: "user", repo: "repo" },
-      },
-    });
-    await indiekit.installPlugins();
-    await indiekit.updatePublicationConfig();
-
-    assert.equal(indiekit.publication.store.info.name, "user/repo on Gitea");
   });
 
   it("Checks if file exists", async () => {

--- a/packages/store-github/package.json
+++ b/packages/store-github/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "debug": "^4.3.2"
   },
   "publishConfig": {

--- a/packages/store-github/test/index.js
+++ b/packages/store-github/test/index.js
@@ -2,15 +2,14 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
 import { mockAgent } from "@indiekit-test/mock-agent";
 
-import GithubStore from "../index.js";
+import GithubStorePlugin from "../index.js";
 
 await mockAgent("store-github");
 
 describe("store-github", async () => {
-  const github = new GithubStore({
+  const github = new GithubStorePlugin({
     token: "abcd1234",
     user: "user",
     repo: "repo",
@@ -28,20 +27,6 @@ describe("store-github", async () => {
 
   it("Gets plug-in installation prompts", () => {
     assert.equal(github.prompts[0].message, "What is your GitHub username?");
-  });
-
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({
-      config: {
-        plugins: ["@indiekit/store-github"],
-        publication: { me: "https://website.example" },
-        "@indiekit/store-github": { user: "user", repo: "repo", token: "123" },
-      },
-    });
-    await indiekit.installPlugins();
-    await indiekit.updatePublicationConfig();
-
-    assert.equal(indiekit.publication.store.info.name, "user/repo on GitHub");
   });
 
   it("Checks if file exists", async () => {

--- a/packages/store-gitlab/package.json
+++ b/packages/store-gitlab/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "@gitbeaker/rest": "^42.0.0",
-    "@indiekit/error": "^1.0.0-beta.15"
+    "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/store-gitlab/test/index.js
+++ b/packages/store-gitlab/test/index.js
@@ -1,21 +1,20 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
 import { mockAgent } from "@indiekit-test/mock-agent";
 
-import GitlabStore from "../index.js";
+import GitlabStorePlugin from "../index.js";
 
 await mockAgent("store-gitlab");
 
 describe("store-gitlab", async () => {
-  const gitlab = new GitlabStore({
+  const gitlab = new GitlabStorePlugin({
     token: "token",
     user: "username",
     repo: "repo",
   });
 
-  const gitlabInstance = new GitlabStore({
+  const gitlabInstance = new GitlabStorePlugin({
     token: "token",
     projectId: "1234",
     instance: "https://gitlab.instance",
@@ -33,23 +32,6 @@ describe("store-gitlab", async () => {
 
   it("Gets plug-in installation prompts", () => {
     assert.equal(gitlab.prompts[0].message, "Where is GitLab hosted?");
-  });
-
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({
-      config: {
-        plugins: ["@indiekit/store-gitlab"],
-        publication: { me: "https://website.example" },
-        "@indiekit/store-gitlab": { user: "username", repo: "repo" },
-      },
-    });
-    await indiekit.installPlugins();
-    await indiekit.updatePublicationConfig();
-
-    assert.equal(
-      indiekit.publication.store.info.name,
-      "username/repo on GitLab",
-    );
   });
 
   it("Checks if file exists", async () => {

--- a/packages/store-s3/index.js
+++ b/packages/store-s3/index.js
@@ -9,6 +9,7 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import { IndiekitError } from "@indiekit/error";
+import { IndiekitStorePlugin } from "@indiekit/plugin";
 
 const defaults = {
   accessKey: process.env.S3_ACCESS_KEY,
@@ -18,7 +19,11 @@ const defaults = {
   bucket: "",
 };
 
-export default class S3Store {
+export default class S3StorePlugin extends IndiekitStorePlugin {
+  environment = ["S3_ACCESS_KEY", "S3_SECRET_KEY"];
+
+  name = "S3 store";
+
   /**
    * @param {object} [options] - Plug-in options
    * @param {string} [options.accessKey] - Access key
@@ -28,20 +33,13 @@ export default class S3Store {
    * @param {string} [options.bucket] - Bucket name
    */
   constructor(options = {}) {
-    this.name = "S3 store";
+    super(options);
+
     this.options = { ...defaults, ...options };
-  }
 
-  get environment() {
-    return ["S3_ACCESS_KEY", "S3_SECRET_KEY"];
-  }
-
-  get info() {
-    const { endpoint, bucket } = this.options;
-
-    return {
-      name: `${bucket} bucket`,
-      uid: `${endpoint}/${bucket}`,
+    this.info = {
+      name: `${this.options.bucket} bucket`,
+      uid: `${this.options.endpoint}/${this.options.bucket}`,
     };
   }
 
@@ -218,9 +216,5 @@ export default class S3Store {
         status: error.status,
       });
     }
-  }
-
-  init(Indiekit) {
-    Indiekit.addStore(this);
   }
 }

--- a/packages/store-s3/package.json
+++ b/packages/store-s3/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.540.0",
-    "@indiekit/error": "^1.0.0-beta.15"
+    "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/store-s3/test/index.js
+++ b/packages/store-s3/test/index.js
@@ -8,13 +8,12 @@ import {
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
-import { Indiekit } from "@indiekit/indiekit";
 import { mockClient } from "aws-sdk-client-mock";
 
-import S3Store from "../index.js";
+import S3StorePlugin from "../index.js";
 
 describe("store-s3", () => {
-  const s3 = new S3Store({
+  const s3 = new S3StorePlugin({
     region: "us-west",
     endpoint: "https://s3.example",
     bucket: "website",
@@ -29,20 +28,6 @@ describe("store-s3", () => {
     assert.equal(s3.name, "S3 store");
     assert.equal(s3.info.name, "website bucket");
     assert.equal(s3.info.uid, "https://s3.example/website");
-  });
-
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({
-      config: {
-        plugins: ["@indiekit/store-s3"],
-        publication: { me: "https://website.example" },
-        "@indiekit/store-s3": { bucket: "website" },
-      },
-    });
-    await indiekit.installPlugins();
-    await indiekit.updatePublicationConfig();
-
-    assert.equal(indiekit.publication.store.info.name, "website bucket");
   });
 
   it("Checks if file exists", async () => {

--- a/packages/syndicator-internet-archive/README.md
+++ b/packages/syndicator-internet-archive/README.md
@@ -33,5 +33,4 @@ Add `@indiekit/syndicator-internet-archive` to your list of plug-ins, specifying
 | `accessKey` | `string`  | Your S3 access key. _Required_, defaults to `process.env.INTERNET_ARCHIVE_ACCESS_KEY`.                                                                               |
 | `secretKey` | `string`  | Your S3 secret key. _Required_, defaults to `process.env.INTERNET_ARCHIVE_SECRET_KEY`.                                                                               |
 | `checked`   | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`.                                                        |
-| `name`      | `string`  | Name for this syndicator that may appear in a Micropub client’s publishing interface. _Optional_, defaults to `Internet Archive`.                                    |
 | `uid`       | `string`  | Value Micropub client will include when publishing a post to indicate that it should be sent to this syndicator. _Optional_, defaults to `https://web.archive.org/`. |

--- a/packages/syndicator-internet-archive/index.js
+++ b/packages/syndicator-internet-archive/index.js
@@ -1,6 +1,7 @@
 import process from "node:process";
 
 import { IndiekitError } from "@indiekit/error";
+import { IndiekitSyndicatorPlugin } from "@indiekit/plugin";
 
 import { internetArchive } from "./lib/internet-archive.js";
 
@@ -12,48 +13,25 @@ const defaults = {
   uid: "https://web.archive.org/",
 };
 
-export default class InternetArchiveSyndicator {
-  /**
-   * @param {object} [options] - Plug-in options
-   * @param {string} [options.accessKey] - S3 access key
-   * @param {string} [options.secretKey] - S3 secret key
-   * @param {boolean} [options.checked] - Check syndicator in UI
-   */
+export default class InternetArchiveSyndicatorPlugin extends IndiekitSyndicatorPlugin {
+  environment = ["INTERNET_ARCHIVE_ACCESS_KEY", "INTERNET_ARCHIVE_SECRET_KEY"];
+
+  name = "Internet Archive syndicator";
+
   constructor(options = {}) {
-    this.name = "Internet Archive syndicator";
+    super(options);
+
     this.options = { ...defaults, ...options };
-  }
 
-  get environment() {
-    return ["INTERNET_ARCHIVE_ACCESS_KEY", "INTERNET_ARCHIVE_SECRET_KEY"];
-  }
-
-  get info() {
-    const service = {
-      name: "Internet Archive",
-      url: "https://web.archive.org/",
-      photo: "/assets/@indiekit-syndicator-internet-archive/icon.svg",
-    };
-
-    if (!this.options?.accessKey) {
-      return {
-        error: "Access key required",
-        service,
-      };
-    }
-
-    if (!this.options?.secretKey) {
-      return {
-        error: "Secret key required",
-        service,
-      };
-    }
-
-    return {
+    this.info = {
       checked: this.options.checked,
-      name: this.options.name,
+      name: "Internet Archive",
       uid: this.options.uid,
-      service,
+      service: {
+        name: "Internet Archive",
+        photo: "/assets/@indiekit-syndicator-internet-archive/icon.svg",
+        url: "https://web.archive.org/",
+      },
     };
   }
 
@@ -67,9 +45,5 @@ export default class InternetArchiveSyndicator {
         status: error.status,
       });
     }
-  }
-
-  init(Indiekit) {
-    Indiekit.addSyndicator(this);
   }
 }

--- a/packages/syndicator-internet-archive/package.json
+++ b/packages/syndicator-internet-archive/package.json
@@ -34,7 +34,8 @@
     "directory": "packages/syndicator-internet-archive"
   },
   "dependencies": {
-    "@indiekit/error": "^1.0.0-beta.15"
+    "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/syndicator-internet-archive/test/index.js
+++ b/packages/syndicator-internet-archive/test/index.js
@@ -1,15 +1,14 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
 import { mockAgent } from "@indiekit-test/mock-agent";
 
-import InternetArchiveSyndicator from "../index.js";
+import InternetArchiveSyndicatorPlugin from "../index.js";
 
 await mockAgent("syndicator-internet-archive");
 
 describe("syndicator-internet-archive", () => {
-  const internetArchive = new InternetArchiveSyndicator({
+  const internetArchive = new InternetArchiveSyndicatorPlugin({
     accessKey: "token",
     secretKey: "secret",
   });
@@ -32,7 +31,7 @@ describe("syndicator-internet-archive", () => {
   });
 
   it("Returns error information if no secret key provided", async () => {
-    const result = new InternetArchiveSyndicator({
+    const result = new InternetArchiveSyndicatorPlugin({
       accessKey: "token",
     });
 
@@ -40,21 +39,11 @@ describe("syndicator-internet-archive", () => {
   });
 
   it("Returns error information if no access key provided", () => {
-    const result = new InternetArchiveSyndicator({
+    const result = new InternetArchiveSyndicatorPlugin({
       secretKey: "secret",
     });
 
     assert.equal(result.info.error, "Access key required");
-  });
-
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({ config: {} });
-    internetArchive.init(indiekit);
-
-    assert.equal(
-      indiekit.publication.syndicationTargets[0].info.name,
-      "Internet Archive",
-    );
   });
 
   it("Returns syndicated URL", async () => {
@@ -64,7 +53,7 @@ describe("syndicator-internet-archive", () => {
   });
 
   it("Throws error getting syndicated URL with no API keys", async () => {
-    const internetArchiveNoKeys = new InternetArchiveSyndicator({});
+    const internetArchiveNoKeys = new InternetArchiveSyndicatorPlugin({});
 
     await assert.rejects(internetArchiveNoKeys.syndicate({ url }), {
       code: "indiekit",

--- a/packages/syndicator-mastodon/README.md
+++ b/packages/syndicator-mastodon/README.md
@@ -44,7 +44,7 @@ When sharing content to Mastodon using this syndicator, any post visibility sett
 | Option             | Type      | Description                                                                                                   |
 | :----------------- | :-------- | :------------------------------------------------------------------------------------------------------------ |
 | `accessToken`      | `string`  | Your Mastodon access token. _Required_, defaults to `process.env.MASTODON_ACCESS_TOKEN`.                      |
-| `url`              | `string`  | Your Mastodon server, i.e. `https://mastodon.social`. _Required_.                                             |
+| `url`              | `string`  | Your Mastodon server. _Required_, defaults to `https://mastodon.social`. _Required_.                          |
 | `user`             | `string`  | Your Mastodon username (without the `@`). _Required_.                                                         |
 | `characterLimit`   | `number`  | Maximum number of characters before a post is truncated. _Optional_, defaults to `500`.                       |
 | `checked`          | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`. |

--- a/packages/syndicator-mastodon/index.js
+++ b/packages/syndicator-mastodon/index.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import process from "node:process";
 
 import { IndiekitError } from "@indiekit/error";
+import { IndiekitSyndicatorPlugin } from "@indiekit/plugin";
 
 import { mastodon } from "./lib/mastodon.js";
 
@@ -10,81 +11,52 @@ const defaults = {
   characterLimit: 500,
   checked: false,
   includePermalink: false,
+  url: "https://mastodon.social",
 };
 
-export default class MastodonSyndicator {
+export default class MastodonSyndicatorPlugin extends IndiekitSyndicatorPlugin {
+  environment = ["MASTODON_ACCESS_TOKEN"];
+
+  name = "Mastodon syndicator";
+
   /**
    * @param {object} [options] - Plug-in options
    * @param {string} [options.accessToken] - Access token
    * @param {number} [options.characterLimit] - Server character limit
+   * @param {boolean} [options.checked] - Check syndicator in UI
    * @param {boolean} [options.includePermalink] - Include permalink in status
    * @param {string} [options.url] - Server URL
    * @param {string} [options.user] - Username
-   * @param {boolean} [options.checked] - Check syndicator in UI
    */
   constructor(options = {}) {
-    this.name = "Mastodon syndicator";
+    super(options);
+
     this.options = { ...defaults, ...options };
-  }
 
-  get #url() {
-    return this.options?.url ? new URL(this.options.url) : false;
-  }
-
-  get #user() {
-    return this.options?.user
-      ? `@${this.options.user.replace("@", "")}`
-      : false;
-  }
-
-  get environment() {
-    return ["MASTODON_ACCESS_TOKEN"];
-  }
-
-  get info() {
-    const service = {
-      name: "Mastodon",
-      photo: "/assets/@indiekit-syndicator-mastodon/icon.svg",
-    };
-    const user = this.#user;
-    const url = this.#url;
-
-    if (!url) {
-      return {
-        error: "Server URL required",
-        service,
-      };
-    }
-
-    if (!user) {
-      return {
-        error: "User name required",
-        service,
-      };
-    }
-
-    const uid = `${url.protocol}//${path.join(url.hostname, user)}`;
-    service.url = url.href;
-
-    return {
+    this.info = {
       checked: this.options.checked,
-      name: `${user}@${url.hostname}`,
-      uid,
-      service,
+      name: `${this.#user}@${this.#url.hostname}`,
+      uid: this.#uid,
+      service: {
+        name: "Mastodon",
+        photo: "/assets/@indiekit-syndicator-mastodon/icon.svg",
+        url: this.#url.href,
+      },
       user: {
-        name: user,
-        url: uid,
+        name: this.#user,
+        url: this.#uid,
       },
     };
-  }
 
-  get prompts() {
-    return [
+    /**
+     * @type {import('prompts').PromptObject[]}
+     */
+    this.prompts = [
       {
         type: "text",
         name: "url",
         message: "What is the URL of your Mastodon server?",
-        description: "i.e. https://mastodon.social",
+        initial: this.#url.href,
       },
       {
         type: "text",
@@ -94,14 +66,38 @@ export default class MastodonSyndicator {
     ];
   }
 
-  async syndicate(properties, publication) {
+  /**
+   * Instance URL object
+   * @type {URL}
+   */
+  get #url() {
+    return new URL(this.options.url);
+  }
+
+  /**
+   * Ensure username is prefixed with `@`
+   * @type {string}
+   */
+  get #user() {
+    return this.options?.user ? `@${this.options.user.replace("@", "")}` : "";
+  }
+
+  /**
+   * Resolved UID
+   * @type {string}
+   */
+  get #uid() {
+    return `${this.#url.protocol}//${path.join(this.#url.hostname, this.#user)}`;
+  }
+
+  async syndicate(properties) {
     try {
       return await mastodon({
         accessToken: this.options.accessToken,
         characterLimit: this.options.characterLimit,
         includePermalink: this.options.includePermalink,
         serverUrl: `${this.#url.protocol}//${this.#url.hostname}`,
-      }).post(properties, publication.me);
+      }).post(properties, this.indiekit.publication.me);
     } catch (error) {
       throw new IndiekitError(error.message, {
         cause: error,
@@ -109,9 +105,5 @@ export default class MastodonSyndicator {
         status: error.statusCode,
       });
     }
-  }
-
-  init(Indiekit) {
-    Indiekit.addSyndicator(this);
   }
 }

--- a/packages/syndicator-mastodon/package.json
+++ b/packages/syndicator-mastodon/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@indiekit/error": "^1.0.0-beta.15",
+    "@indiekit/plugin": "^1.0.0-beta.19",
     "@indiekit/util": "^1.0.0-beta.19",
     "brevity": "^0.2.9",
     "html-to-text": "^9.0.0",

--- a/packages/syndicator-mastodon/test/index.js
+++ b/packages/syndicator-mastodon/test/index.js
@@ -1,16 +1,15 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { Indiekit } from "@indiekit/indiekit";
 import { getFixture } from "@indiekit-test/fixtures";
 import { mockAgent } from "@indiekit-test/mock-agent";
 
-import MastodonSyndicator from "../index.js";
+import MastodonSyndicatorPlugin from "../index.js";
 
 await mockAgent("syndicator-mastodon");
 
 describe("syndicator-mastodon", () => {
-  const mastodon = new MastodonSyndicator({
+  const mastodon = new MastodonSyndicatorPlugin({
     accessToken: "token",
     url: "https://mastodon.example",
     user: "username",
@@ -37,7 +36,7 @@ describe("syndicator-mastodon", () => {
   });
 
   it("Returns error information if no server URL provided", async () => {
-    const result = new MastodonSyndicator({
+    const result = new MastodonSyndicatorPlugin({
       accessToken: "token",
       user: "username",
     });
@@ -46,7 +45,7 @@ describe("syndicator-mastodon", () => {
   });
 
   it("Returns error information if no username provided", () => {
-    const result = new MastodonSyndicator({
+    const result = new MastodonSyndicatorPlugin({
       accessToken: "token",
       url: "https://mastodon.example",
     });
@@ -61,18 +60,8 @@ describe("syndicator-mastodon", () => {
     );
   });
 
-  it("Initiates plug-in", async () => {
-    const indiekit = await Indiekit.initialize({ config: {} });
-    mastodon.init(indiekit);
-
-    assert.equal(
-      indiekit.publication.syndicationTargets[0].info.name,
-      "@username@mastodon.example",
-    );
-  });
-
   it("Returns syndicated URL", async () => {
-    const result = await mastodon.syndicate(properties, publication);
+    const result = await mastodon.syndicate(properties);
 
     assert.equal(
       result,
@@ -81,13 +70,13 @@ describe("syndicator-mastodon", () => {
   });
 
   it("Throws error getting syndicated URL if access token invalid", async () => {
-    const mastodonNoToken = new MastodonSyndicator({
+    const mastodonNoToken = new MastodonSyndicatorPlugin({
       accessToken: "invalid",
       url: "https://mastodon.example",
       user: "username",
     });
 
-    await assert.rejects(mastodonNoToken.syndicate(properties, publication), {
+    await assert.rejects(mastodonNoToken.syndicate(properties), {
       message: "Mastodon syndicator: The access token is invalid",
     });
   });


### PR DESCRIPTION
By using class inheritance with a base `IndiekitPlugin` class with child classes for the different plug-in types, it becomes possible to orchestrate common functionality and centralise debugging and error handling.

This becomes even more important if we want to use an event-based model with hooks, to allow multiple plugins (and of certain types) to perform functions at given points in the publishing lifecycle. The goal is to strike a balance between giving plug-ins flexibility to determine behaviour, but have a plug-in system that works in a reliable and consistent way.

We should try to keep largely to the existing plug-in API, but at least one required changed would be to have a plug-in inherit from a parent plugin class to continue working.

### Todo

- [x] Initial proof of concept
- [x] Convert endpoint plug-ins
- [x] Convert post type plug-ins
- [x] Convert preset plug-ins
- [x] Convert store plug-ins
- [x] Convert syndicator plug-ins
- [ ] Add checks for required properties and methods
- [ ] Built-in error handling
- [ ] Update tests
- [ ] Add tests for base and type plug-ins
- [ ] Add ADR
- [ ] Update documentation

### Later PRs

- [ ] Automatic plug-in registration?
- [ ] Publication presets set post/media paths without directly modifying `postTypes` object 