### PR TITLE
Use correct locale for error validation strings

### DIFF
--- a/packages/indiekit/lib/middleware/internationalisation.js
+++ b/packages/indiekit/lib/middleware/internationalisation.js
@@ -23,7 +23,7 @@ export const internationalisation = (Indiekit) =>
 
       // Override system locale with configured value
       if (locale) {
-        response.locals.setLocale(locale);
+        request.setLocale(locale);
       }
 
       next();


### PR DESCRIPTION
`setLocale()` should be used on `request`, not `response.locals`. Fixes #796.