### PR TITLE
Handle empty content syndicating a post to Bluesky

### DIFF
--- a/helpers/fixtures/jf2/photo-untitled.jf2
+++ b/helpers/fixtures/jf2/photo-untitled.jf2
@@ -1,0 +1,7 @@
+{
+  "type": "entry",
+  "photo": [
+    "https://foo.bar/qux.jpg"
+  ],
+  "url": "https://foo.bar/lunchtime"
+}

--- a/packages/syndicator-bluesky/lib/utils.js
+++ b/packages/syndicator-bluesky/lib/utils.js
@@ -56,7 +56,7 @@ export const uriToPostUrl = (profileUrl, uri) => {
  * @returns {string} Post text
  */
 export const getPostText = (properties, includePermalink) => {
-  let text;
+  let text = "";
 
   if (properties.name && properties.name !== "") {
     // Post has a non-empty title, show title with a link to post

--- a/packages/syndicator-bluesky/test/unit/utils.js
+++ b/packages/syndicator-bluesky/test/unit/utils.js
@@ -56,6 +56,14 @@ describe("syndicator-bluesky/lib/utils", () => {
     });
   });
 
+  it("Gets post text for post with no content", () => {
+    const result = getPostText(
+      JSON.parse(getFixture("jf2/photo-untitled.jf2")),
+    );
+
+    assert.equal(result, "");
+  });
+
   it("Gets post text with article post name and URL", () => {
     const result = getPostText(
       JSON.parse(getFixture("jf2/article-content-provided-html-text.jf2")),


### PR DESCRIPTION
Fixes #790.

Seems that `brevity` doesn’t handle no text being provided to its `shorten()` method.