### PR TITLE
feat(store-s3): add optional ACL option for uploads

### DIFF
--- a/packages/store-s3/index.js
+++ b/packages/store-s3/index.js
@@ -28,6 +28,7 @@ export default class S3Store {
    * @param {string} [options.region] - Region name
    * @param {string} [options.endpoint] - Endpoint URL
    * @param {string} [options.bucket] - Bucket name
+   * @param {string} [options.acl] - Access Control List (ACL) policy
    */
   constructor(options = {}) {
     this.options = { ...defaults, ...options };
@@ -115,11 +116,17 @@ export default class S3Store {
    * @returns {Promise<string>} File created
    */
   async createFile(filePath, content) {
-    const putCommand = new PutObjectCommand({
-      Bucket: this.options.bucket,
-      Key: filePath,
-      Body: content,
-    });
+    const params = {
+    Bucket: this.options.bucket,
+    Key: filePath,
+    Body: content,
+    };
+
+    if (this.options.acl) {
+      params.ACL = this.options.acl;
+    }
+
+    const putCommand = new PutObjectCommand(params);
 
     try {
       const fileExists = await this.fileExists(filePath);
@@ -181,11 +188,15 @@ export default class S3Store {
    * @returns {Promise<string>} Updated file URL
    */
   async updateFile(filePath, content, options) {
-    const putCommand = new PutObjectCommand({
+    const params = {
       Bucket: this.options.bucket,
       Key: filePath,
       Body: content,
-    });
+    };
+    if (this.options.acl) {
+      params.ACL = this.options.acl;
+    }
+    const putCommand = new PutObjectCommand(params);
 
     try {
       const { ETag } = await this.client().send(putCommand);


### PR DESCRIPTION
Re: #809 

Add an access control list (ACL) option for [@indiekit/store-s3](https://getindiekit.com/plugins/stores/s3#indiekit-store-s3) when uploading files to S3 storage.

This allows setting ACL (e.g. to public-read) for each object uploaded using S3 providers via Indiekit that doesn't [support global bucket policies](https://help.ovhcloud.com/csm/en-public-cloud-storage-s3-bucket-acl?id=kb_article_view&sysparm_article=KB0057089#resource-based) for Object Storage. (In my case, it's OVH S3 Object Storage.)

It will allow users to add the acl option to their Indiekit config:

```json
  "@indiekit/store-s3": {
    "region": "some-region",
    "bucket": "myBucket",
    ...
    "acl": "public-read" 
  }
```

The relevant store-s3 options for Indiekit usage:

- `"acl": "public-read"` - Photos accessible via direct URL
- Omit `acl` - Uses bucket default (if bucket already supports public-read)

---

I am new to npm projects, I don't know how to test my changes made to the forked project code on my own Indiekit server running on [Render](https://render.com/). I tried added the forked repo SSH url to the `package.json` on my server repo under `"dependencies": {"@indiekit/indiekit": "^1.0.0-beta.24"` like `{"@indiekit/indiekit":"git@github.com:eclecticpassions/indiekit.git"` but it doesn't work. I tried using commands like `npm link` but I don't know what I'm doing. 🥲

Can someone help review if the changes made to the `packages/store-s3/index.js` is valid and works? Thanks so much. If it does, I'll update the docs page for the store-s3 plugin with the new option.

Relevant links:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl