### PR TITLE
Add photo to list of supported post fields

### DIFF
--- a/docs/api/add-post-type.md
+++ b/docs/api/add-post-type.md
@@ -148,6 +148,7 @@ Indiekit provides automatic support for the following field types:
 - `location`
 - `name`
 - `summary`
+- `photo`
 
 Installing other post type plug-ins will add to this list, and these fields can be shared by other post type plug-ins.
 


### PR DESCRIPTION
Discovered that `photo: {}` works in `"@indiekit/post-type-photo": {fields:` automatically; enabling multiple photos to be attached to a post (photo postType). An "add another photo" button will appear.