### PR TITLE
Add option to specify remote domains for image resizing

### DIFF
--- a/packages/endpoint-image/README.md
+++ b/packages/endpoint-image/README.md
@@ -23,8 +23,9 @@ To customise the behaviour of this plug-in, add `@indiekit/endpoint-image` to yo
 
 ## Options
 
-| Option      | Type       | Description                                                        |
-| :---------- | :--------- | :----------------------------------------------------------------- |
-| `cache`     | `Function` | [Keyv store](https://github.com/lukechilds/keyv).                  |
-| `me`        | `string`   | Publication URL. Used as prefix to image paths.                    |
-| `mountPath` | `string`   | Path to image resizing endpoint. _Optional_, defaults to `/image`. |
+| Option      | Type       | Description                                                                                                                                                                  |
+| :---------- | :--------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cache`     | `Function` | [Keyv store](https://github.com/lukechilds/keyv).                                                                                                                            |
+| `domains`   | `Array`    | List of domains to allow remote image resizing for. _Optional_, defaults to the [value provided for `publication.me`.](https://getindiekit.com/configuration/publication#me) |
+| `me`        | `string`   | Publication URL. Used as prefix to image paths.                                                                                                                              |
+| `mountPath` | `string`   | Path to image resizing endpoint. _Optional_, defaults to `/image`.                                                                                                           |

--- a/packages/endpoint-image/index.js
+++ b/packages/endpoint-image/index.js
@@ -6,7 +6,7 @@ import {
   createIPXNodeServer,
 } from "ipx";
 
-const defaults = { mountPath: "/image" };
+const defaults = { domains: [], mountPath: "/image" };
 const router = express.Router();
 
 export default class ImageEndpoint {
@@ -14,6 +14,7 @@ export default class ImageEndpoint {
 
   constructor(options = {}) {
     this.options = { ...defaults, ...options };
+    this.domains = this.options.domains;
     this.mountPath = this.options.mountPath;
   }
 
@@ -23,9 +24,15 @@ export default class ImageEndpoint {
   }
 
   _routes(indiekitConfig) {
+    const domains = Array.isArray(this.domains) ? this.domains : [this.domains];
+
     const ipx = createIPX({
-      storage: ipxFSStorage({ dir: "./public" }),
-      httpStorage: ipxHttpStorage({ domains: indiekitConfig.publication.me }),
+      storage: ipxFSStorage({
+        dir: "./public",
+      }),
+      httpStorage: ipxHttpStorage({
+        domains: [indiekitConfig.publication.me, ...domains],
+      }),
     });
 
     router.use(createIPXNodeServer(ipx));


### PR DESCRIPTION
Fixes #814.

Currently the image resizing plugin only supports resizing remote images saved to the destination publication URL (`publication.me`). However, it’s possible to configure Indiekit such that files can be saved to other destinations, such as S3-compatible bucket storage.

This PR adds a `domains` option which gets passed to the same option on `ipxHttpStorage()` which controls which remote URLs image resizing is allowed for.

For example, if your website is at `https://website.example`, but media files are saved to `https://media.example`, you could use the following configuration options:

```js
{
  publication: {
    me: "https://website.example"
  },
  ["@indiekit/endpoint-image"]: {
    domains: ["https://media.example"]
  }
}