### PR TITLE
fix: ensure name is a string before calling replace in getError

### DIFF
--- a/packages/error/index.js
+++ b/packages/error/index.js
@@ -75,6 +75,10 @@ export class IndiekitError extends Error {
   }
 
   getError(name) {
+    // Ensure name is a string before calling replace
+    if (typeof name !== "string") {
+      name = String(name || "unknown");
+    }
     name = name.replace(" ", "_").toLowerCase();
 
     const error = errors[name];


### PR DESCRIPTION
## Summary
- Adds type checking to ensure `name` parameter is a string before calling `.replace()` in `getError` method
- Prevents "name.replace is not a function" error when code passed to IndiekitError is not a string

## Problem
When `response.statusText` is undefined in some edge cases, it could be passed to `IndiekitError` which then calls `getError(name)`. If `name` is not a string, the `.replace()` call throws an error.

## Solution
Convert `name` to string with a fallback to "unknown" if it's nullish.

## Test plan
- [x] Verified the fix handles undefined, null, and non-string values
- [x] Existing functionality unchanged for string inputs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)