### PR TITLE
fix: ensure name is a string before calling replace in getError

### DIFF
--- a/packages/error/index.js
+++ b/packages/error/index.js
@@ -75,6 +75,10 @@ export class IndiekitError extends Error {
   }
 
   getError(name) {
+    // Ensure name is a string before calling replace
+    if (typeof name !== "string") {
+      name = String(name || "unknown");
+    }
     name = name.replace(" ", "_").toLowerCase();
 
     const error = errors[name];


### PR DESCRIPTION
## Summary

Prevents "name.replace is not a function" error when the code passed to `IndiekitError` is not a string (e.g., when `response.statusText` is undefined in some edge cases).

## Changes

- Added a type check to ensure `name` is a string before calling `.replace()` in `getError()`

## Test

This is a defensive fix - the error was encountered in production when certain HTTP responses had undefined statusText.

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>