### PR TITLE
fix(preset-eleventy): add permalink to frontmatter from url property

### DIFF
--- a/packages/preset-eleventy/lib/post-template.js
+++ b/packages/preset-eleventy/lib/post-template.js
@@ -55,7 +55,14 @@ const getFrontMatter = (properties) => {
   delete properties.published; // Use `date`
   delete properties.slug; // use `page.fileSlug`
   delete properties.type; // Not required
-  delete properties.url; // Not required
+
+  // Convert url to Eleventy permalink so generated URL matches Indiekit's stored URL
+  // Add trailing slash to generate /path/index.html instead of /path.html
+  if (properties.url) {
+    const url = properties.url;
+    properties.permalink = url.endsWith("/") ? url : `${url}/`;
+  }
+  delete properties.url;
 
   const frontMatter = YAML.stringify(properties, { lineWidth: 0 });
   return `---\n${frontMatter}---\n`;

--- a/packages/preset-eleventy/test/unit/post-template.js
+++ b/packages/preset-eleventy/test/unit/post-template.js
@@ -104,9 +104,31 @@ repostOf: https://website.example
 inReplyTo: https://website.example
 visibility: private
 syndication: https://website.example/post/12345
+permalink: https://website.example/posts/cheese-sandwich/
 ---
 
 I ate a [cheese](https://en.wikipedia.org/wiki/Cheese) sandwich, which was nice.
+`,
+    );
+  });
+
+  it("Renders post template with permalink from url", () => {
+    const result = getPostTemplate({
+      published: "2020-02-02",
+      name: "Test Post",
+      url: "/posts/2020/02/02/test-post",
+      content: "Test content",
+    });
+
+    assert.equal(
+      result,
+      `---
+date: 2020-02-02
+title: Test Post
+permalink: /posts/2020/02/02/test-post/
+---
+
+Test content
 `,
     );
   });


### PR DESCRIPTION
## Summary

The preset was deleting the `url` property from frontmatter, leaving Eleventy to generate URLs from file paths. This caused a mismatch between Indiekit's stored URL and Eleventy's generated URL.

## Problem

When creating a post via Micropub, Indiekit generates a URL (e.g., `/notes/2026/01/30/hello`) and stores it. However, the Eleventy preset was removing this URL from the frontmatter, causing Eleventy to generate a different URL based on the file path. This broke syndication and other features that rely on the post URL being consistent.

## Solution

Convert the `url` property to an Eleventy `permalink` property (with trailing slash) so Eleventy generates the URL that Indiekit expects.

## Changes

- `packages/preset-eleventy/lib/post-template.js`: Convert `url` to `permalink` in frontmatter
- `packages/preset-eleventy/test/unit/post-template.js`: Added test for permalink generation

---