### PR TITLE
feat: improve markdown link handling

### DIFF
--- a/packages/frontend/components/textarea/index.js
+++ b/packages/frontend/components/textarea/index.js
@@ -103,6 +103,49 @@ export const TextareaFieldComponent = class extends HTMLElement {
       unorderedListStyle: "-",
     });
 
+    // Generate Markdown link syntax (without adding `https:`)
+    // Place cursor within empty brackets for easier URL pasting
+    document.addEventListener(
+      "click",
+      function (event) {
+        const linkButton = event.target?.closest(".link");
+        if (linkButton) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          const linkTemplate = `[${editor.codemirror.getSelection()}]()`;
+          editor.codemirror.replaceSelection(linkTemplate);
+          editor.codemirror.focus();
+
+          // Move cursor into the bracket for direct pasting
+          const cursorPosition = editor.codemirror.getCursor();
+          editor.codemirror.setSelection(
+            { line: cursorPosition.line, ch: cursorPosition.ch - 1 },
+            { line: cursorPosition.line, ch: cursorPosition.ch - 1 },
+          );
+        }
+      },
+      { capture: true },
+    );
+
+    // Auto convert clipboard URL to Markdown link syntax when pasting a URL
+    // with a text span highlighted
+    editor.codemirror.on("paste", function (_cm, event) {
+      const selectedText = editor.codemirror.getSelection();
+      if (!selectedText) {
+        return;
+      }
+
+      const pastedText = event.clipboardData?.getData("text/plain") || "";
+      const urlMatch = pastedText.match(/https?:\/\/[^\s]+/);
+
+      if (urlMatch) {
+        event.preventDefault();
+        const link = `[${selectedText}](${urlMatch[0]})`;
+        editor.codemirror.replaceSelection(link);
+      }
+    });
+
     // Restore label behaviour
     /** @type {HTMLTextAreaElement} */
     const $codeMirrorTextarea = this.querySelector(".CodeMirror textarea");


### PR DESCRIPTION
Hi,

I wanted these two features for a long time as I'm very used to pasting links directly into selected text in VS Codium and Obsidian. 

With some help from `qwen2.5-coder`, I figured how to add the two features into the `textarea/index.js` file. I tested it locally and it seems to be working! But I'd appreciate your feedback to see if it's worth adding to Indiekit `main` or if there's any errors/improvements.

My two additions:

- Improve how Markdown links are handled when the "link" button is pressed by removing the placeholder `https://` inside the `()`. Because, then I have to select the `https://` and then paste the link from my clipboard. The extra step is a bit cumbersome (to me).  Now, when the button is pressed, the cursor jumps to an empty `()` after the `[link text]` and ctrl+v will paste the link in, making it quicker and less fiddly.

- Added new feature of generating Markdown links automatically a link is pasted into highlighted text. This means it doesn't require using the mouse to press the link button in the editor toolbar (like in [GitHub](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#links)).

Thanks @paulrobertlloyd!

Edit: correct wrong link to GitHub example