### PR TITLE
fix(endpoint-auth): return after passing secret error to next()

### DIFF
--- a/packages/endpoint-auth/lib/middleware/secret.js
+++ b/packages/endpoint-auth/lib/middleware/secret.js
@@ -12,7 +12,7 @@ export const hasSecret = (request, response, next) => {
       response.locals.__("NotImplementedError.secret"),
     );
 
-    next(error);
+    return next(error);
   }
 
   next();


### PR DESCRIPTION
### Problem

`hasSecret` passes an error to `next()` when `SECRET` is unset, but doesn't
return, so execution falls through to the unconditional `next()` on the
following line:

```js
if (!process.env.SECRET) {
  const error = IndiekitError.notImplemented(
    response.locals.__("NotImplementedError.secret"),
  );

  next(error);   // ← dispatches to the error handler
}

next();          // ← …and then continues down the normal stack
```

Express treats those as two separate dispatches: the first jumps to the
error-handling middleware, the second carries on through the normal stack.
Both run for the same request, so the misconfiguration is reported *and* the
route executes anyway — ending in a doubled response or
`ERR_HTTP_HEADERS_SENT`, depending on which finishes first.

### Fix

Return the error dispatch so the middleware stops there.

```diff
-    next(error);
+    return next(error);
```

### Notes

Only reachable when the server is started without `SECRET`, so it doesn't
affect a correctly configured instance — but it turns a clear "secret not
set" message into a confusing double-handled request, which is exactly the
wrong experience for someone in the middle of setting Indiekit up.

Found while working on the `endpoint-auth` package for a separate
`redirect_uri` fix; kept as its own commit since the two are unrelated.
