### PR TITLE
Correctly format dates with specified time zone

### DIFF
--- a/packages/endpoint-media/lib/utils.js
+++ b/packages/endpoint-media/lib/utils.js
@@ -33,7 +33,7 @@ export const renderPath = async (path, properties, application) => {
   // Add date tokens
   for (const dateToken of dateTokens) {
     tokens[dateToken] = formatDate(properties.published, dateToken, {
-      locale: application.locals,
+      locale: application.locale,
       timeZone:
         application.timeZone === "server" ? timeZone : application.timeZone,
       useAdditionalDayOfYearTokens: true,

--- a/packages/util/lib/date.js
+++ b/packages/util/lib/date.js
@@ -40,10 +40,10 @@ export const dateTokens = [
 export const formatDate = (string, tokens, options = {}) => {
   const formattedLocale = String(options.locale || "en").replace("-", "");
 
-  // Convert options object to options expected for `FormatOptionsWithTZ`
   const formatOptions = {
-    ...options,
     ...(options.locale && { locale: locales[formattedLocale] }),
+    ...(options.timeZone && { in: tz(options.timeZone) }),
+    useAdditionalDayOfYearTokens: options.useAdditionalDayOfYearTokens,
   };
 
   const date = string === "now" ? new Date() : parseISO(string);


### PR DESCRIPTION
Fixes #861.

Plain `date-fns` v4's `format()` doesn't recognise a `timeZone` option, it only respects time zones via the `in: tz(timeZone)` option from `@date-fns/tz`.

The regression was introduced in commit 0d972ee3. This updated `formatDateToLocal` and `getDate` to use the new `in: tz()` pattern, but missed `formatDate`.

This PR also fixes a typo where `locale` was being passed from a non-existent `application.locals` option.