### PR TITLE
fix(endpoint-micropub): don't assume mp-syndicate-to is an array

### DIFF
--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -301,13 +301,24 @@ export const getSyndicateToProperty = (properties, syndicationTargets) => {
     return;
   }
 
+  // Converting mf2 to JF2 leaves this property in one of three shapes: an
+  // array for several targets, a string for one, and an empty *object* for
+  // none. Calling `.includes` on it directly threw a TypeError and failed the
+  // whole post for any client sending `"mp-syndicate-to": []`, which is what
+  // an unticked syndication list produces.
+  const syndicateTo = properties["mp-syndicate-to"];
+  const requested = Array.isArray(syndicateTo)
+    ? syndicateTo
+    : typeof syndicateTo === "string"
+      ? [syndicateTo]
+      : [];
+
   const property = [];
 
   for (const target of syndicationTargets) {
     const { uid } = target.info;
-    const syndicateTo = properties["mp-syndicate-to"];
 
-    if (syndicateTo?.includes(uid)) {
+    if (requested.includes(uid)) {
       property.push(uid);
     }
   }

--- a/packages/endpoint-micropub/test/unit/jf2.js
+++ b/packages/endpoint-micropub/test/unit/jf2.js
@@ -387,6 +387,33 @@ describe("endpoint-micropub/lib/jf2", () => {
     assert.deepEqual(result, ["https://example.website/"]);
   });
 
+  it("Doesn’t throw when `mp-syndicate-to` is not an array", () => {
+    // Converting mf2 to JF2 turns an empty array into an empty object, so a
+    // client that sends `"mp-syndicate-to": []` — an unticked syndication
+    // list — arrives here with a value that has no `.includes`
+    const syndicationTargets = [{ info: { uid: "https://example.website/" } }];
+
+    for (const value of [{}, 1, true]) {
+      const result = getSyndicateToProperty(
+        { "mp-syndicate-to": value },
+        syndicationTargets,
+      );
+
+      assert.equal(result, undefined);
+    }
+  });
+
+  it("Adds syndication target given as a string", () => {
+    // A single target collapses to a string during mf2 to JF2 conversion
+    const syndicationTargets = [{ info: { uid: "https://example.website/" } }];
+    const result = getSyndicateToProperty(
+      { "mp-syndicate-to": "https://example.website/" },
+      syndicationTargets,
+    );
+
+    assert.deepEqual(result, ["https://example.website/"]);
+  });
+
   it("Doesn’t add unused syndication target", () => {
     const properties = {};
     const syndicationTargets = [


### PR DESCRIPTION
### Problem

Posting fails with

```
TypeError: syndicateTo?.includes is not a function
```

whenever a client sends `"mp-syndicate-to": []`.

`getSyndicateToProperty` reads the property straight off the JF2 object and
calls `.includes` on it, but converting mf2 to JF2 leaves it in one of three
shapes:

| client sends | after mf2 → JF2 | `.includes` |
| --- | --- | --- |
| `["a", "b"]` | `["a", "b"]` | array — fine |
| `["a"]` | `"a"` | string — fine |
| `[]` | `{}` | **object — throws** |

An empty array is what an unticked syndication list produces, so this is
reachable through ordinary use rather than a malformed request. The post type
makes no difference; the only other condition is that the publication has
syndication targets configured, since the function returns early when it has
none. That combination is why it presents as intermittent — selecting a single
target makes the same post succeed.

Found from a browser extension that sent the property unconditionally. The
client has been fixed too, but any client can trip this and the failure takes
down post creation entirely.

### Fix

Resolve the value to an array once, before the loop:

```js
const syndicateTo = properties["mp-syndicate-to"];
const requested = Array.isArray(syndicateTo)
  ? syndicateTo
  : typeof syndicateTo === "string"
    ? [syndicateTo]
    : [];
```

Anything that is neither an array nor a string is treated as no targets.

### Behaviour change worth noting

The single-target case is now an exact comparison. It was previously
`"https://example.website/".includes(uid)` — a substring test — which would
also match a uid that merely appeared inside the configured target string.
Exact matching seems clearly right here, but it is a change.

### Testing

- Two tests added to `packages/endpoint-micropub/test/unit/jf2.js`, covering
  the non-array shapes and the string shape. I verified the first fails with
  the original expression, reproducing the reported `TypeError` exactly.
- **118/118** unit tests pass in `endpoint-micropub`; `eslint` and `prettier`
  clean.
- The integration tests need MongoDB, which I do not have locally — they fail
  identically on an untouched `main`, so this changes nothing there.
