### PR TITLE
feat(syndicator-mastodon): add categories to status as hashtags

### DIFF
--- a/helpers/fixtures/jf2/note-category-provided.jf2
+++ b/helpers/fixtures/jf2/note-category-provided.jf2
@@ -1,0 +1,7 @@
+{
+  "type": "entry",
+  "content": {
+    "html": "<p>I ate a cheese sandwich, which was nice.</p>"
+  },
+  "category": ["lunch", "cheese sandwiches"]
+}

--- a/packages/syndicator-mastodon/README.md
+++ b/packages/syndicator-mastodon/README.md
@@ -39,13 +39,24 @@ When sharing content to Mastodon using this syndicator, any post visibility sett
 | Unlisted                 | Unlisted                   |
 | Private                  | Followers only             |
 
+Enabling the `includeCategories` option adds a post’s categories to the end of the status as hashtags, where Mastodon displays them as links:
+
+```text
+I ate a cheese sandwich, which was nice.
+
+#lunch #cheesesandwiches
+```
+
+Characters Mastodon doesn’t recognise as part of a hashtag are removed, and only the last segment of a hierarchical category is used, so `holidays/family trips` becomes `#familytrips`. Any hashtag already written into the post content is not repeated.
+
 ## Options
 
-| Option             | Type      | Description                                                                                                   |
-| :----------------- | :-------- | :------------------------------------------------------------------------------------------------------------ |
-| `accessToken`      | `string`  | Your Mastodon access token. _Required_, defaults to `process.env.MASTODON_ACCESS_TOKEN`.                      |
-| `user`             | `string`  | Your Mastodon username (without the `@`). _Required_.                                                         |
-| `url`              | `string`  | Your Mastodon server. _Optional_, defaults to `https://mastodon.social`.                                      |
-| `characterLimit`   | `number`  | Maximum number of characters before a post is truncated. _Optional_, defaults to `500`.                       |
-| `checked`          | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`. |
-| `includePermalink` | `boolean` | Always include a link to the original post. _Optional_, defaults to `false`.                                  |
+| Option              | Type      | Description                                                                                                   |
+| :------------------ | :-------- | :------------------------------------------------------------------------------------------------------------ |
+| `accessToken`       | `string`  | Your Mastodon access token. _Required_, defaults to `process.env.MASTODON_ACCESS_TOKEN`.                      |
+| `user`              | `string`  | Your Mastodon username (without the `@`). _Required_.                                                         |
+| `url`               | `string`  | Your Mastodon server. _Optional_, defaults to `https://mastodon.social`.                                      |
+| `characterLimit`    | `number`  | Maximum number of characters before a post is truncated. _Optional_, defaults to `500`.                       |
+| `checked`           | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`. |
+| `includeCategories` | `boolean` | Add a post’s categories to the end of the status as hashtags. _Optional_, defaults to `false`.                |
+| `includePermalink`  | `boolean` | Always include a link to the original post. _Optional_, defaults to `false`.                                  |

--- a/packages/syndicator-mastodon/index.js
+++ b/packages/syndicator-mastodon/index.js
@@ -10,6 +10,7 @@ const defaults = {
   url: "https://mastodon.social",
   characterLimit: 500,
   checked: false,
+  includeCategories: false,
   includePermalink: false,
 };
 
@@ -20,6 +21,7 @@ export default class MastodonSyndicator {
    * @param {object} [options] - Plug-in options
    * @param {string} [options.accessToken] - Access token
    * @param {number} [options.characterLimit] - Server character limit
+   * @param {boolean} [options.includeCategories] - Add categories as hashtags
    * @param {boolean} [options.includePermalink] - Include permalink in status
    * @param {string} [options.url] - Server URL
    * @param {string} [options.user] - Username
@@ -92,6 +94,7 @@ export default class MastodonSyndicator {
       const mastodon = new Mastodon({
         accessToken: this.options.accessToken,
         characterLimit: this.options.characterLimit,
+        includeCategories: this.options.includeCategories,
         includePermalink: this.options.includePermalink,
         serverUrl: `${this.#url.protocol}//${this.#url.hostname}`,
       });

--- a/packages/syndicator-mastodon/lib/mastodon.js
+++ b/packages/syndicator-mastodon/lib/mastodon.js
@@ -10,12 +10,14 @@ export class Mastodon {
    * @param {string} options.accessToken - Access token
    * @param {string} options.serverUrl - Server URL
    * @param {number} options.characterLimit - Server character limit
+   * @param {boolean} [options.includeCategories] - Add categories as hashtags
    * @param {boolean} [options.includePermalink] - Include permalink in status
    */
   constructor(options) {
     this.accessToken = options.accessToken;
     this.characterLimit = options.characterLimit;
     this.serverUrl = options.serverUrl;
+    this.includeCategories = options.includeCategories || false;
     this.includePermalink = options.includePermalink || false;
   }
 
@@ -158,6 +160,7 @@ export class Mastodon {
 
     const status = createStatus(properties, {
       characterLimit: this.characterLimit,
+      includeCategories: this.includeCategories,
       includePermalink: this.includePermalink,
       mediaIds,
       serverUrl: this.serverUrl,

--- a/packages/syndicator-mastodon/lib/utils.js
+++ b/packages/syndicator-mastodon/lib/utils.js
@@ -9,13 +9,20 @@ import { htmlToText } from "html-to-text";
  * @param {object} properties - JF2 properties
  * @param {object} [options] - Options
  * @param {number} [options.characterLimit] - Character limit
+ * @param {boolean} [options.includeCategories] - Add categories as hashtags
  * @param {boolean} [options.includePermalink] - Include permalink in status
  * @param {Array} [options.mediaIds] - Mastodon media IDs
  * @param {string} [options.serverUrl] - Server URL
  * @returns {object} Status parameters
  */
 export const createStatus = (properties, options = {}) => {
-  const { characterLimit, includePermalink, mediaIds, serverUrl } = options;
+  const {
+    characterLimit,
+    includeCategories,
+    includePermalink,
+    mediaIds,
+    serverUrl,
+  } = options;
   const parameters = {};
 
   let status;
@@ -38,6 +45,18 @@ export const createStatus = (properties, options = {}) => {
 
   // Truncate status if longer than 500 characters
   if (status) {
+    // Show hashtags at the end of a status, where Mastodon displays them as
+    // links. Skip any already written into the post content.
+    const hashtags = includeCategories
+      ? createHashtags(properties.category).filter(
+          (hashtag) =>
+            !new RegExp(String.raw`${hashtag}(?![\p{L}\p{N}_])`, "iu").test(
+              status,
+            ),
+        )
+      : [];
+    const suffix = hashtags.length > 0 ? `\n\n${hashtags.join(" ")}` : "";
+
     const statusText = brevity.shorten(
       status,
       properties.url,
@@ -45,14 +64,14 @@ export const createStatus = (properties, options = {}) => {
         ? properties.url
         : false,
       false, // https://indieweb.org/permashortcitation
-      characterLimit,
+      // Leave room for the hashtags added below
+      characterLimit ? characterLimit - suffix.length : characterLimit,
     );
 
     // Show permalink below status, not within brackets
-    parameters.status = statusText.replace(
-      `(${properties.url})`,
-      `\n\n${properties.url}`,
-    );
+    parameters.status =
+      statusText.replace(`(${properties.url})`, `\n\n${properties.url}`) +
+      suffix;
   }
 
   // Add media IDs
@@ -81,6 +100,42 @@ export const createStatus = (properties, options = {}) => {
   }
 
   return parameters;
+};
+
+/**
+ * Get hashtags for given categories
+ *
+ * Uses the last segment of a hierarchical category, and removes any characters
+ * Mastodon doesn’t recognise as part of a hashtag, so that `holidays/family
+ * trips` becomes `#familytrips`.
+ * @param {Array|string} [category] - JF2 `category` property
+ * @returns {Array} Hashtags
+ */
+export const createHashtags = (category) => {
+  if (!category) {
+    return [];
+  }
+
+  const categories = Array.isArray(category) ? category : [category];
+  const hashtags = [];
+
+  for (const item of categories) {
+    if (typeof item !== "string") {
+      continue;
+    }
+
+    const name = item
+      .split("/")
+      .at(-1)
+      .replaceAll(/[^\p{L}\p{N}_]/gu, "");
+    const hashtag = `#${name}`;
+
+    if (name && !hashtags.includes(hashtag)) {
+      hashtags.push(hashtag);
+    }
+  }
+
+  return hashtags;
 };
 
 /**

--- a/packages/syndicator-mastodon/test/unit/utils.js
+++ b/packages/syndicator-mastodon/test/unit/utils.js
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import { getFixture } from "@indiekit-test/fixtures";
 
 import {
+  createHashtags,
   createStatus,
   getStatusIdFromUrl,
   htmlToStatusText,
@@ -129,6 +130,93 @@ describe("syndicator-mastodon/lib/utils", () => {
 
     assert.equal(result.status, "Here’s the cheese sandwich I ate.");
     assert.deepEqual(result.mediaIds, ["1", "2", "3", "4"]);
+  });
+
+  it("Creates a status with categories added as hashtags", () => {
+    const result = createStatus(
+      JSON.parse(getFixture("jf2/note-category-provided.jf2")),
+      {
+        includeCategories: true,
+        serverUrl: "https://mastodon.example",
+      },
+    );
+
+    assert.equal(
+      result.status,
+      "I ate a cheese sandwich, which was nice.\n\n#lunch #cheesesandwiches",
+    );
+  });
+
+  it("Creates a status without hashtags if categories not included", () => {
+    const result = createStatus(
+      JSON.parse(getFixture("jf2/note-category-provided.jf2")),
+      {
+        serverUrl: "https://mastodon.example",
+      },
+    );
+
+    assert.equal(result.status, "I ate a cheese sandwich, which was nice.");
+  });
+
+  it("Creates a status without repeating hashtags already in content", () => {
+    const result = createStatus(
+      {
+        content: { html: "<p>I ate a cheese sandwich. #lunch</p>" },
+        category: ["lunch", "food"],
+      },
+      {
+        includeCategories: true,
+        serverUrl: "https://mastodon.example",
+      },
+    );
+
+    assert.equal(result.status, "I ate a cheese sandwich. #lunch\n\n#food");
+  });
+
+  it("Creates a status with hashtags within the character limit", () => {
+    const result = createStatus(
+      {
+        content: { html: `<p>${"cheese ".repeat(20).trim()}</p>` },
+        category: ["lunch"],
+      },
+      {
+        characterLimit: 50,
+        includeCategories: true,
+        serverUrl: "https://mastodon.example",
+      },
+    );
+
+    assert.ok(result.status.length <= 50);
+    assert.ok(result.status.endsWith("\n\n#lunch"));
+  });
+
+  it("Gets hashtags from categories", () => {
+    assert.deepEqual(createHashtags(["lunch", "food"]), ["#lunch", "#food"]);
+  });
+
+  it("Gets hashtag from a category given as a string", () => {
+    assert.deepEqual(createHashtags("lunch"), ["#lunch"]);
+  });
+
+  it("Gets no hashtags if no categories given", () => {
+    assert.deepEqual(createHashtags(), []);
+  });
+
+  it("Gets hashtag from last segment of a hierarchical category", () => {
+    assert.deepEqual(createHashtags(["holidays/family trips"]), [
+      "#familytrips",
+    ]);
+  });
+
+  it("Gets hashtags without characters Mastodon doesn’t recognise", () => {
+    assert.deepEqual(createHashtags(["cheese sandwiches", "web-design"]), [
+      "#cheesesandwiches",
+      "#webdesign",
+    ]);
+  });
+
+  it("Gets hashtags without duplicates or empty values", () => {
+    assert.deepEqual(createHashtags(["lunch", "lunch", "!!!", ""]), ["#lunch"]);
   });
 
   it("Gets status ID from Mastodon permalink", () => {


### PR DESCRIPTION
Closes #832.

Adds an `includeCategories` option to the Mastodon syndicator. When enabled, a post’s categories are appended to the end of the status, where Mastodon renders them as hashtag links:

```text
I ate a cheese sandwich, which was nice.

#lunch #cheesesandwiches
```

Placing them at the end matters for the reason given in the issue: hashtags only get Mastodon’s link styling when they aren’t buried mid-sentence, which is why the reporter’s manual workaround didn’t quite work.

## Behaviour

Categories are normalised to something Mastodon will actually recognise as a hashtag:

- characters outside letters, numbers and `_` are removed, so `cheese sandwiches` becomes `#cheesesandwiches` and `web-design` becomes `#webdesign` (a hyphen would otherwise end the hashtag)
- only the last segment of a hierarchical category is used, so `holidays/family trips` becomes `#familytrips`
- duplicates and categories that normalise to nothing are dropped

Hashtags already written into the post content aren’t repeated, so anyone currently using the workaround in the issue won’t end up with them twice.

Where a character limit applies, the hashtags are counted towards it and the content is truncated to leave room, rather than the status overrunning.

## Default

I’ve defaulted this to `false`, following `includePermalink`, so nobody’s syndicated posts change unless they opt in. That said, the issue is phrased as an expectation rather than a feature request, so if you’d rather it default to `true` that’s a one-line change — happy to switch it.

## Tests

Nine tests added to `test/unit/utils.js` covering the option on and off, normalisation, hierarchical categories, deduplication, not repeating hashtags already in content, and staying within the character limit. The existing tests are unchanged and still pass.

## Notes

This only covers `syndicator-mastodon`. #832 is about Mastodon specifically, but the same thing presumably applies to other syndicators — I’ve not touched those here.
