### PR TITLE
fix(endpoint-posts): use correct template variable for syndicate form `source_url`

### DIFF
--- a/packages/endpoint-posts/includes/@indiekit-endpoint-posts-syndicate.njk
+++ b/packages/endpoint-posts/includes/@indiekit-endpoint-posts-syndicate.njk
@@ -14,7 +14,7 @@
   {{ button({
     classes: "button--secondary button--small",
     name: "syndication[source_url]",
-    value: data.url,
+    value: properties.url,
     icon: "syndicate",
     text: __("posts.post.syndicate")
   }) | indent(2) }}


### PR DESCRIPTION
Re-submitting an original fix by @rmdes included as part of #828. 

The syndicate form button was using `data.url` for the source_url value, but `data` is never set in the template context. The post controller and middleware set `properties` (via response.locals.properties), not `data`.

This caused the syndicate form to submit with an undefined source_url, which made the syndicate endpoint fall back to finding "the most recently published post awaiting syndication" instead of syndicating the post the user was actually viewing.

The fix changes `data.url` to `properties.url` to correctly reference the post URL from the template context.