### PR TITLE
fix(endpoint-auth): restrict client discovery to domain names

### DIFF
--- a/helpers/mock-agent/endpoint-auth.js
+++ b/helpers/mock-agent/endpoint-auth.js
@@ -49,6 +49,22 @@ export const mockClient = () => {
   // Client information (Not Found)
   agent.get(origin).intercept({ path: "/404" }).reply(404);
 
+  // Client information (body that is neither metadata nor parseable HTML)
+  agent
+    .get(origin)
+    .intercept({ path: "/json" })
+    .reply(200, '{"foo":"bar"}')
+    .persist();
+
+  // An internal address that client discovery must refuse to fetch. Serves the
+  // same markup as a valid client, so a regression shows up as this client's
+  // name replacing the fallback derived from `client_id`.
+  agent
+    .get("https://169.254.169.254")
+    .intercept({ path: "/" })
+    .reply(200, getFixture("html/client.html"))
+    .persist();
+
   // Declared `redirect_uri` (HTML `<link>` tag)
   agent
     .get(origin)

--- a/packages/endpoint-auth/lib/client.js
+++ b/packages/endpoint-auth/lib/client.js
@@ -1,4 +1,54 @@
+import net from "node:net";
+
 import { mf2 } from "microformats-parser";
+
+const FETCH_TIMEOUT = 5000;
+
+/**
+ * Check whether a URL may be fetched when discovering client information
+ *
+ * A client identifier's host name must be a domain name: IP addresses are not
+ * permitted except loopback, and the authorization endpoint is told not to
+ * fetch those. So no IP literal is worth fetching, which is why this refuses
+ * them outright rather than sorting internal ranges from public ones.
+ * @param {URL} url - URL to check
+ * @returns {boolean} URL is safe to fetch
+ * @see {@link https://indieauth.spec.indieweb.org/#client-identifier}
+ * @see {@link https://indieauth.spec.indieweb.org/#client-information-discovery}
+ */
+const isFetchableOrigin = (url) => {
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return false;
+  }
+
+  const hostname = url.hostname.replaceAll(/^\[|]$/g, "").toLowerCase();
+
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
+    return false;
+  }
+
+  // Any IP literal, loopback or not: none are valid client identifiers
+  if (net.isIP(hostname) !== 0) {
+    return false;
+  }
+
+  // Decimal, hexadecimal and octal encodings of an address (`2130706433`,
+  // `0x7f000001`, `0177.0.0.1`) are resolved by the system resolver but are
+  // not recognised by `net.isIP`, so they would otherwise pass as domain names
+  if (
+    /^\d+$/.test(hostname) ||
+    /^0x[\da-f]+$/.test(hostname) ||
+    /^[\d.]+$/.test(hostname)
+  ) {
+    return false;
+  }
+
+  // A domain name is trusted without resolving it, so one pointing at an
+  // internal address still passes. The specification suggests resolving first
+  // and rejecting the loopback range; doing that safely also means connecting
+  // to the address that was checked, which needs a custom dispatcher.
+  return true;
+};
 
 /**
  * Get client information from application Microformat
@@ -71,13 +121,33 @@ export const getClientMetadata = (body, client) => {
  * @see {@link https://indieauth.spec.indieweb.org/#client-information-discovery}
  */
 export const getClientInformation = async (clientId) => {
-  let client = {
+  let clientUrl;
+  try {
+    clientUrl = new URL(clientId);
+  } catch {
+    return { id: clientId, name: clientId, url: clientId };
+  }
+
+  const client = {
     id: clientId,
-    name: new URL(clientId).host,
-    url: new URL(clientId).href,
+    name: clientUrl.host,
+    url: clientUrl.href,
   };
 
-  const clientResponse = await fetch(clientId);
+  if (!isFetchableOrigin(clientUrl)) {
+    return client;
+  }
+
+  let clientResponse;
+  try {
+    clientResponse = await fetch(clientId, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+    });
+  } catch {
+    // Unreachable, refused, TLS failure or timed out
+    return client;
+  }
+
   if (!clientResponse.ok) {
     // Use information derived from clientId
     return client;
@@ -89,7 +159,14 @@ export const getClientInformation = async (clientId) => {
     // Use information from client JSON metadata
     return getClientMetadata(body, client);
   } catch {
-    // Use information from client HTML microformats (deprecated)
-    return getApplicationInformation(body, client);
+    try {
+      // Use information from client HTML microformats (deprecated)
+      return getApplicationInformation(body, client);
+    } catch {
+      // Neither client metadata nor parseable HTML. `mf2()` throws on an empty
+      // or non-HTML body, which would otherwise fail the whole authorization
+      // request over a client that simply serves JSON
+      return client;
+    }
   }
 };

--- a/packages/endpoint-auth/test/unit/client.js
+++ b/packages/endpoint-auth/test/unit/client.js
@@ -78,3 +78,59 @@ describe("endpoint-auth/lib/client", () => {
     });
   });
 });
+
+describe("endpoint-auth/lib/client fetchable origins", () => {
+  it("Refuses to fetch an IP address", async () => {
+    // A client identifier's host name must be a domain name, and the mock
+    // agent serves valid client markup at this address — so a returned name of
+    // `169.254.169.254` shows no request was made
+    const result = await getClientInformation("https://169.254.169.254/");
+
+    assert.deepEqual(result, {
+      id: "https://169.254.169.254/",
+      name: "169.254.169.254",
+      url: "https://169.254.169.254/",
+    });
+  });
+
+  it("Refuses to fetch loopback, other IPs and non-HTTP schemes", async () => {
+    // Net connections are disabled, so were any of these fetched the request
+    // would throw rather than fall back to information derived from client_id
+    for (const clientId of [
+      "https://localhost:3000/",
+      "https://127.0.0.1/",
+      "https://[::1]/",
+      "https://8.8.8.8/",
+      "https://[2606:4700::1111]/",
+      // Numeric encodings the system resolver accepts but `net.isIP` does not
+      "https://2130706433/",
+      "https://0x7f000001/",
+      "https://0177.0.0.1/",
+      "file:///etc/passwd",
+    ]) {
+      const result = await getClientInformation(clientId);
+
+      assert.equal(result.id, clientId);
+    }
+  });
+
+  it("Returns client information (body is not metadata or HTML)", async () => {
+    // `mf2()` throws on an empty or non-HTML body; a client serving JSON must
+    // not fail the whole authorization request
+    const result = await getClientInformation(
+      "https://auth-endpoint.example/json",
+    );
+
+    assert.equal(result.name, "auth-endpoint.example");
+  });
+
+  it("Returns client information (client unreachable)", async () => {
+    const result = await getClientInformation("https://unreachable.example/");
+
+    assert.deepEqual(result, {
+      id: "https://unreachable.example/",
+      name: "unreachable.example",
+      url: "https://unreachable.example/",
+    });
+  });
+});


### PR DESCRIPTION
Implements the `client_id` checks that [§4.2](https://indieauth.spec.indieweb.org/#client-information-discovery) recommends.

### Problem

`getClientInformation` fetches the `client_id` URL with no restriction on scheme or host:

```js
const clientResponse = await fetch(clientId);
```

That runs during `GET /auth` while the consent screen is built, before any authentication, so an unauthenticated caller chooses where the server sends a request — loopback services, private-range hosts, or a cloud metadata endpoint.

The specification anticipates exactly this. §4.2 says the endpoint **MUST NOT** fetch a loopback `client_id`, and adds:

> Note that the server may want to perform some additional checks on the `client_id` before fetching it **to avoid SSRF attacks**. In particular, the server may want to resolve the domain name first and avoid fetching the document if the IP address is within the loopback range defined by [RFC5735] or any other implementation-specific internal IP address.

There is also a limited reflection path, since `consent.njk` renders `client.name`. The test added here demonstrates it: with the origin check removed, discovering `https://169.254.169.254/` returns

```
name: 'Example client', logo: 'https://169.254.169.254/assets/icon.svg'
```

instead of the fallback — content from an internal response reaching client information, and from there the consent screen. It's narrow, since only `name`, `url` and `logo` are extracted and only from client-metadata JSON or an h-app microformat, so I'd treat the reflection as opportunistic and the outbound request as the reliable capability.

### Fix

Restrict discovery to domain names. [§3.3](https://indieauth.spec.indieweb.org/#client-identifier) requires it:

> host names **MUST** be domain names or a loopback interface and **MUST NOT** be IPv4 or IPv6 addresses except for IPv4 `127.0.0.1` or IPv6 `[::1]`

Since loopback is the only permitted IP form and §4.2 forbids fetching it, **no IP literal is worth fetching** — so all of them are refused. That's simpler than sorting internal ranges from public ones, and needs no address tables: `net.isIP` is only asked whether the host is an IP literal at all. Numeric host encodings (`2130706433`, `0x7f000001`, `0177.0.0.1`) are refused explicitly, since the system resolver accepts them while `net.isIP` does not recognise them, so they would otherwise pass as domain names. No new dependency — `node:net` is enough.

**Known limitation:** a domain name is still trusted without being resolved, so one pointing at an internal address passes. That's the other half of the §4.2 suggestion; doing it safely means connecting to the address that was checked, which needs a custom dispatcher and seemed like more than belongs here. Happy to look at it separately.

### Also fixed

Discovery threw on responses it could not use. `fetch` had no error handling, and `getApplicationInformation` calls `mf2()`, which throws on an empty or non-HTML body — so a client that was briefly unreachable, or that serves JSON, failed the **whole authorization request** rather than falling back to information derived from `client_id`, which the existing non-2xx branch already did. Fetches now time out after 5 seconds.

### Testing

- **28/28** unit and **38/38** integration tests pass in `endpoint-auth`; `eslint` and `prettier` clean.
- New tests use the existing `mockAgent("endpoint-auth")` fixtures. The internal-address fixture serves valid client markup, so the assertion is that internal content does **not** appear — I verified it fails when the check is removed, rather than passing vacuously.
- Covers IP literals (loopback, public, IPv6), numeric encodings, non-HTTP schemes, a JSON body, and an unreachable client.

### Background

Reported privately first and reviewed by @aciccarello, who suggested dropping IP support entirely — the specification turned out to support that, which is why the range tables are gone. The same change is running in a fork of this package.
