### PR TITLE
feat(syndicator-bluesky): add categories to post as hashtags

### DIFF
--- a/packages/syndicator-bluesky/README.md
+++ b/packages/syndicator-bluesky/README.md
@@ -27,13 +27,24 @@ Add `@indiekit/syndicator-bluesky` to your list of plug-ins, specifying options 
 }
 ```
 
+Enabling the `includeCategories` option adds a post’s categories to the end of the post as hashtags, which Bluesky turns into tag facets:
+
+```text
+I ate a cheese sandwich, which was nice.
+
+#lunch #cheesesandwiches
+```
+
+Characters Bluesky doesn’t recognise as part of a tag are removed, and only the last segment of a hierarchical category is used, so `holidays/family trips` becomes `#familytrips`. Any hashtag already written into the post content is not repeated.
+
 ## Options
 
-| Option             | Type      | Description                                                                                                                 |
-| :----------------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------- |
-| `handle`           | `string`  | Your Bluesky handle (without the `@`). _Required_.                                                                          |
-| `password`         | `string`  | A Bluesky app password. _Required_, defaults to `process.env.BLUESKY_PASSWORD`.                                             |
-| `profileUrl`       | `string`  | Bluesky profile URL prefix. Used in the URL returned in syndicated URLs. _Optional_, defaults to `https://bsky.app/profile` |
-| `serviceUrl`       | `string`  | Bluesky service URL. Used to connect to a Bluesky service API. _Optional_, defaults to `https://bsky.social`                |
-| `checked`          | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`.               |
-| `includePermalink` | `boolean` | Always include a link to the original post. _Optional_, defaults to `false`.                                                |
+| Option              | Type      | Description                                                                                                                 |
+| :------------------ | :-------- | :-------------------------------------------------------------------------------------------------------------------------- |
+| `handle`            | `string`  | Your Bluesky handle (without the `@`). _Required_.                                                                          |
+| `password`          | `string`  | A Bluesky app password. _Required_, defaults to `process.env.BLUESKY_PASSWORD`.                                             |
+| `profileUrl`        | `string`  | Bluesky profile URL prefix. Used in the URL returned in syndicated URLs. _Optional_, defaults to `https://bsky.app/profile` |
+| `serviceUrl`        | `string`  | Bluesky service URL. Used to connect to a Bluesky service API. _Optional_, defaults to `https://bsky.social`                |
+| `checked`           | `boolean` | Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`.               |
+| `includeCategories` | `boolean` | Add a post’s categories to the end of the post as hashtags. _Optional_, defaults to `false`.                                |
+| `includePermalink`  | `boolean` | Always include a link to the original post. _Optional_, defaults to `false`.                                                |

--- a/packages/syndicator-bluesky/index.js
+++ b/packages/syndicator-bluesky/index.js
@@ -9,6 +9,7 @@ const defaults = {
   password: process.env.BLUESKY_PASSWORD,
   profileUrl: "https://bsky.app/profile",
   serviceUrl: "https://bsky.social",
+  includeCategories: false,
   includePermalink: false,
   checked: false,
 };
@@ -22,6 +23,7 @@ export default class BlueskySyndicator {
    * @param {string} [options.serviceUrl] - Service URL
    * @param {string} [options.handle] - Handle
    * @param {string} [options.password] - Password
+   * @param {boolean} [options.includeCategories] - Add categories as hashtags
    * @param {boolean} [options.includePermalink] - Include permalink in status
    * @param {boolean} [options.checked] - Check syndicator in UI
    */
@@ -90,6 +92,7 @@ export default class BlueskySyndicator {
         password: this.options?.password,
         profileUrl: this.#profileUrl,
         serviceUrl: this.#serviceUrl,
+        includeCategories: this.options.includeCategories,
         includePermalink: this.options.includePermalink,
       });
 

--- a/packages/syndicator-bluesky/lib/bluesky.js
+++ b/packages/syndicator-bluesky/lib/bluesky.js
@@ -17,6 +17,7 @@ export class Bluesky {
    * @param {string} options.password - Password
    * @param {string} options.profileUrl - Profile URL
    * @param {string} options.serviceUrl - Service URL
+   * @param {boolean} [options.includeCategories] - Add categories as hashtags
    * @param {boolean} [options.includePermalink] - Include permalink in status
    */
   constructor(options) {
@@ -24,6 +25,7 @@ export class Bluesky {
     this.password = options.password;
     this.profileUrl = options.profileUrl;
     this.serviceUrl = options.serviceUrl;
+    this.includeCategories = options.includeCategories || false;
     this.includePermalink = options.includePermalink || false;
   }
 
@@ -249,7 +251,11 @@ export class Bluesky {
       if (repostUrl) {
         // Syndicate repost of Bluesky URL with content as a quote post
         if (isSameOrigin(repostUrl, this.profileUrl) && properties.content) {
-          const text = getPostText(properties, this.includePermalink);
+          const text = getPostText(
+            properties,
+            this.includePermalink,
+            this.includeCategories,
+          );
           const richText = await createRichText(client, text);
 
           return this.postQuotePost(repostUrl, richText, images);
@@ -275,7 +281,11 @@ export class Bluesky {
         return;
       }
 
-      const text = getPostText(properties, this.includePermalink);
+      const text = getPostText(
+        properties,
+        this.includePermalink,
+        this.includeCategories,
+      );
       const richText = await createRichText(client, text);
 
       return this.postPost(richText, images);

--- a/packages/syndicator-bluesky/lib/utils.js
+++ b/packages/syndicator-bluesky/lib/utils.js
@@ -51,12 +51,54 @@ export const uriToPostUrl = (profileUrl, uri) => {
 };
 
 /**
+ * Get hashtags for given categories
+ *
+ * Uses the last segment of a hierarchical category, and removes any characters
+ * Bluesky doesn’t recognise as part of a tag, so that `holidays/family trips`
+ * becomes `#familytrips`. Tags longer than 64 characters are dropped, as
+ * `detectFacets` ignores them.
+ * @param {Array|string} [category] - JF2 `category` property
+ * @returns {Array} Hashtags
+ */
+export const createHashtags = (category) => {
+  if (!category) {
+    return [];
+  }
+
+  const categories = Array.isArray(category) ? category : [category];
+  const hashtags = [];
+
+  for (const item of categories) {
+    if (typeof item !== "string") {
+      continue;
+    }
+
+    const name = item
+      .split("/")
+      .at(-1)
+      .replaceAll(/[^\p{L}\p{N}_]/gu, "");
+    const hashtag = `#${name}`;
+
+    if (name && name.length <= 64 && !hashtags.includes(hashtag)) {
+      hashtags.push(hashtag);
+    }
+  }
+
+  return hashtags;
+};
+
+/**
  * Get post test from given JF2 properties
  * @param {object} properties - JF2 properties
  * @param {boolean} [includePermalink] - Include permalink in post
+ * @param {boolean} [includeCategories] - Add categories as hashtags
  * @returns {string} Post text
  */
-export const getPostText = (properties, includePermalink) => {
+export const getPostText = (
+  properties,
+  includePermalink,
+  includeCategories,
+) => {
   let text = "";
 
   if (properties.name && properties.name !== "") {
@@ -66,7 +108,18 @@ export const getPostText = (properties, includePermalink) => {
     text = htmlToStatusText(properties.content.html);
   }
 
-  // Truncate status if longer than 300 characters
+  // Show hashtags at the end of a post, where Bluesky links them. Skip any
+  // already written into the post content. `createRichText` runs
+  // `detectFacets`, which turns them into tag facets.
+  const hashtags = includeCategories
+    ? createHashtags(properties.category).filter(
+        (hashtag) =>
+          !new RegExp(String.raw`${hashtag}(?![\p{L}\p{N}_])`, "iu").test(text),
+      )
+    : [];
+  const suffix = hashtags.length > 0 ? `\n\n${hashtags.join(" ")}` : "";
+
+  // Truncate status if longer than 300 characters, leaving room for hashtags
   text = brevity.shorten(
     text,
     properties.url,
@@ -74,13 +127,13 @@ export const getPostText = (properties, includePermalink) => {
       ? properties.url
       : false,
     false, // https://indieweb.org/permashortcitation
-    300,
+    300 - suffix.length,
   );
 
   // Show permalink below status, not within brackets
   text = text.replace(`(${properties.url})`, `\n\n${properties.url}`);
 
-  return text;
+  return text + suffix;
 };
 
 /**

--- a/packages/syndicator-bluesky/test/unit/utils.js
+++ b/packages/syndicator-bluesky/test/unit/utils.js
@@ -6,6 +6,7 @@ import { getFixture } from "@indiekit-test/fixtures";
 import sharp from "sharp";
 
 import {
+  createHashtags,
   createRichText,
   constrainImage,
   getPostImage,
@@ -126,6 +127,79 @@ describe("syndicator-bluesky/lib/utils", async () => {
     );
 
     assert.equal(result, "What I had for lunch https://foo.bar/lunchtime");
+  });
+
+  it("Gets post text with categories added as hashtags", () => {
+    const result = getPostText(
+      JSON.parse(getFixture("jf2/note-category-provided.jf2")),
+      false,
+      true,
+    );
+
+    assert.equal(
+      result,
+      "I ate a cheese sandwich, which was nice.\n\n#lunch #cheesesandwiches",
+    );
+  });
+
+  it("Gets post text without hashtags if categories not included", () => {
+    const result = getPostText(
+      JSON.parse(getFixture("jf2/note-category-provided.jf2")),
+    );
+
+    assert.equal(result, "I ate a cheese sandwich, which was nice.");
+  });
+
+  it("Gets post text without repeating hashtags already in content", () => {
+    const result = getPostText(
+      {
+        content: { html: "<p>I ate a cheese sandwich. #lunch</p>" },
+        category: ["lunch", "food"],
+      },
+      false,
+      true,
+    );
+
+    assert.equal(result, "I ate a cheese sandwich. #lunch\n\n#food");
+  });
+
+  it("Gets post text with hashtags within the character limit", () => {
+    const result = getPostText(
+      {
+        content: { html: `<p>${"cheese ".repeat(60).trim()}</p>` },
+        category: ["lunch"],
+      },
+      false,
+      true,
+    );
+
+    assert.ok(result.length <= 300);
+    assert.ok(result.endsWith("\n\n#lunch"));
+  });
+
+  it("Gets hashtags from categories", () => {
+    assert.deepEqual(createHashtags(["lunch", "food"]), ["#lunch", "#food"]);
+  });
+
+  it("Gets hashtag from last segment of a hierarchical category", () => {
+    assert.deepEqual(createHashtags(["holidays/family trips"]), [
+      "#familytrips",
+    ]);
+  });
+
+  it("Gets hashtags without characters Bluesky doesn\u{2019}t recognise", () => {
+    assert.deepEqual(createHashtags(["cheese sandwiches", "web-design"]), [
+      "#cheesesandwiches",
+      "#webdesign",
+    ]);
+  });
+
+  it("Gets no hashtag for a category longer than 64 characters", () => {
+    assert.deepEqual(createHashtags(["a".repeat(65)]), []);
+  });
+
+  it("Gets no hashtags if no categories given", () => {
+    assert.deepEqual(createHashtags(), []);
   });
 
   it("Gets post text with HTML content", () => {


### PR DESCRIPTION
Companion to #875, adding the same `includeCategories` option to the Bluesky syndicator.

When enabled, a post’s categories are appended to the end of the post text:

```text
I ate a cheese sandwich, which was nice.

#lunch #cheesesandwiches
```

## No facets are built by hand

`createRichText` already calls `detectFacets`, which recognises `#hashtag` in the text and emits `app.bsky.richtext.facet#tag` entries, so appending plain text is enough to get real tags rather than literal characters. That keeps this close to the Mastodon implementation rather than needing a separate mechanism.

Two Bluesky-specific details are handled:

- tags longer than 64 characters are dropped, since `detectFacets` ignores them
- the hashtags are counted towards the 300 character limit, and the content is truncated to leave room, rather than the post overrunning

Normalisation otherwise matches the Mastodon version: characters outside letters, numbers and `_` are removed (`cheese sandwiches` → `#cheesesandwiches`, `web-design` → `#webdesign`), only the last segment of a hierarchical category is used (`holidays/family trips` → `#familytrips`), and duplicates are dropped. Hashtags already written into the post content aren’t repeated.

## Default

Defaulted to `false`, as in #875, so nobody’s syndicated posts change unless they opt in.

## Tests

Nine tests added to `test/unit/utils.js`, covering the option on and off, normalisation, hierarchical categories, the 64 character tag limit, not repeating hashtags already in content, and staying within the character limit. The existing tests are unchanged and still pass. Reuses the `jf2/note-category-provided.jf2` fixture added in #875.

## One thing worth deciding

`createHashtags` is now implemented separately in both syndicators. The two copies are identical apart from the Bluesky tag length check. If you’d rather it lived in `@indiekit/util` alongside the other shared helpers, I’m happy to do that as a follow-up — I didn’t want to move something into a core package as a side effect of this PR.
