### PR TITLE
feat: add `syndicator-indienews` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docs/.cache
 
 # Localisation keys
 localazy.keys.json
+.worktrees

--- a/packages/endpoint-micropub/lib/post-content.js
+++ b/packages/endpoint-micropub/lib/post-content.js
@@ -16,6 +16,30 @@ export const postContent = {
 
     const { postTemplate, store, storeMessageTemplate } = publication;
     const { path, properties } = postData;
+
+    // Call getSyndicationUrl on any targeted syndicator that implements it
+    const syndicationTargets = publication.syndicationTargets ?? [];
+    const requestedUids = [properties["mp-syndicate-to"] ?? []].flat();
+    for (const target of syndicationTargets) {
+      if (
+        typeof target.getSyndicationUrl === "function" &&
+        requestedUids.includes(target.info.uid)
+      ) {
+        try {
+          const urls = [await target.getSyndicationUrl(publication)]
+            .flat()
+            .filter(Boolean);
+          const existing = [properties.syndication ?? []].flat();
+          const newUrls = urls.filter((url) => !existing.includes(url));
+          if (newUrls.length > 0) {
+            properties.syndication = [...existing, ...newUrls];
+          }
+        } catch (error) {
+          debug(`getSyndicationUrl failed for ${target.info.uid}: %O`, error);
+        }
+      }
+    }
+
     const metadata = {
       action: "create",
       result: "created",

--- a/packages/endpoint-micropub/test/unit/post-content.js
+++ b/packages/endpoint-micropub/test/unit/post-content.js
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { deletedPostData, postData } from "@indiekit-test/post-data";
@@ -85,5 +85,62 @@ describe("endpoint-micropub/lib/post-content", () => {
     await assert.rejects(postContent.undelete(false, postData), {
       message: "postTemplate is not a function",
     });
+  });
+
+  it("Calls getSyndicationUrl on targeted syndicator and sets syndication property", async () => {
+    const getSyndicationUrl = mock.fn(async () => "https://news.indieweb.org/en/");
+    const syndicator = {
+      info: { uid: "https://news.indieweb.org/en/" },
+      getSyndicationUrl,
+    };
+    const pub = { ...publication, syndicationTargets: [syndicator] };
+    const data = {
+      path: "foo.md",
+      properties: {
+        ...postData.properties,
+        "mp-syndicate-to": ["https://news.indieweb.org/en/"],
+      },
+    };
+    await postContent.create(pub, data);
+    assert.equal(getSyndicationUrl.mock.calls.length, 1);
+  });
+
+  it("Does not call getSyndicationUrl on syndicator not in mp-syndicate-to", async () => {
+    const getSyndicationUrl = mock.fn(async () => "https://news.indieweb.org/en/");
+    const syndicator = {
+      info: { uid: "https://news.indieweb.org/en/" },
+      getSyndicationUrl,
+    };
+    const pub = { ...publication, syndicationTargets: [syndicator] };
+    const data = {
+      path: "foo.md",
+      properties: {
+        ...postData.properties,
+        "mp-syndicate-to": ["https://other.example/"],
+      },
+    };
+    await postContent.create(pub, data);
+    assert.equal(getSyndicationUrl.mock.calls.length, 0);
+  });
+
+  it("Appends to existing syndication without duplicates", async () => {
+    const getSyndicationUrl = mock.fn(async () => "https://news.indieweb.org/en/");
+    const syndicator = {
+      info: { uid: "https://news.indieweb.org/en/" },
+      getSyndicationUrl,
+    };
+    const pub = { ...publication, syndicationTargets: [syndicator] };
+    const data = {
+      path: "foo.md",
+      properties: {
+        ...postData.properties,
+        syndication: ["https://news.indieweb.org/en/"],
+        "mp-syndicate-to": ["https://news.indieweb.org/en/"],
+      },
+    };
+    await postContent.create(pub, data);
+    // getSyndicationUrl was called but returned a duplicate — syndication stays length 1
+    assert.equal(getSyndicationUrl.mock.calls.length, 1);
+    assert.deepEqual(data.properties.syndication, ["https://news.indieweb.org/en/"]);
   });
 });

--- a/packages/endpoint-micropub/test/unit/post-content.js
+++ b/packages/endpoint-micropub/test/unit/post-content.js
@@ -103,6 +103,7 @@ describe("endpoint-micropub/lib/post-content", () => {
     };
     await postContent.create(pub, data);
     assert.equal(getSyndicationUrl.mock.calls.length, 1);
+    assert.deepEqual(data.properties.syndication, ["https://news.indieweb.org/en/"]);
   });
 
   it("Does not call getSyndicationUrl on syndicator not in mp-syndicate-to", async () => {

--- a/packages/endpoint-micropub/test/unit/post-content.js
+++ b/packages/endpoint-micropub/test/unit/post-content.js
@@ -144,4 +144,21 @@ describe("endpoint-micropub/lib/post-content", () => {
     assert.equal(getSyndicationUrl.mock.calls.length, 1);
     assert.deepEqual(data.properties.syndication, ["https://news.indieweb.org/en/"]);
   });
+
+  it("Silently skips syndicator when getSyndicationUrl throws", async () => {
+    const syndicator = {
+      info: { uid: "https://news.indieweb.org/en/" },
+      getSyndicationUrl: async () => { throw new Error("network error"); },
+    };
+    const pub = { ...publication, syndicationTargets: [syndicator] };
+    const data = {
+      path: "foo.md",
+      properties: {
+        ...postData.properties,
+        "mp-syndicate-to": ["https://news.indieweb.org/en/"],
+      },
+    };
+    await assert.doesNotReject(() => postContent.create(pub, data));
+    assert.equal(data.properties.syndication, undefined);
+  });
 });

--- a/packages/endpoint-syndicate/lib/utils.js
+++ b/packages/endpoint-syndicate/lib/utils.js
@@ -79,6 +79,10 @@ export const syndicateToTargets = async (publication, properties) => {
     const alreadySyndicated = hasSyndicationUrl(syndicatedUrls, url);
 
     if (target && !alreadySyndicated) {
+      if (typeof target.syndicate !== "function") {
+        continue;
+      }
+
       try {
         const syndicatedUrl = await target.syndicate(properties, publication);
 

--- a/packages/endpoint-syndicate/test/unit/utils.js
+++ b/packages/endpoint-syndicate/test/unit/utils.js
@@ -7,6 +7,7 @@ import {
   getPostData,
   getSyndicationTarget,
   hasSyndicationUrl,
+  syndicateToTargets,
 } from "../../lib/utils.js";
 
 const { client, database, mongoServer } = await testDatabase();
@@ -86,5 +87,24 @@ describe("endpoint-syndicate/lib/token", () => {
       hasSyndicationUrl(syndication, "https://mastodon.foobar"),
       false,
     );
+  });
+
+  it("Skips syndicator target without syndicate method", async () => {
+    const targetWithoutSyndicate = {
+      info: { uid: "https://example.com/" },
+      // no syndicate method
+    };
+    const publication = {
+      syndicationTargets: [targetWithoutSyndicate],
+    };
+    const properties = {
+      "mp-syndicate-to": ["https://example.com/"],
+      url: "https://me.example/post/1",
+    };
+
+    const result = await syndicateToTargets(publication, properties);
+
+    assert.deepEqual(result.syndicatedUrls, []);
+    assert.equal(result.failedTargets, undefined);
   });
 });

--- a/packages/syndicator-indienews/README.md
+++ b/packages/syndicator-indienews/README.md
@@ -1,0 +1,53 @@
+# @indiekit/syndicator-indienews
+
+[IndieNews](https://news.indieweb.org) syndicator for Indiekit.
+
+IndieNews is a community aggregator for posts about the IndieWeb. Unlike API-based syndicators, IndieNews discovers content via [Webmention](https://indieweb.org/Webmention) — syndication is triggered when your post links to an IndieNews channel URL and sends a Webmention to it.
+
+This syndicator writes the IndieNews channel URL into the `syndication` property of your post at creation time, so that it appears in your post's markup and can be picked up by your Webmention sending setup.
+
+## Installation
+
+`npm install @indiekit/syndicator-indienews`
+
+## Usage
+
+Add `@indiekit/syndicator-indienews` to your list of plug-ins, specifying options as required:
+
+```json
+{
+  "plugins": ["@indiekit/syndicator-indienews"],
+  "@indiekit/syndicator-indienews": {
+    "language": "en"
+  }
+}
+```
+
+When you create a post with `mp-syndicate-to: https://news.indieweb.org/en/`, Indiekit will write `https://news.indieweb.org/en/` into the `syndication` property of your post. Your Webmention sender can then notify IndieNews.
+
+### Multiple languages
+
+To offer syndication to multiple IndieNews language channels, add the plugin once per language:
+
+```json
+{
+  "plugins": [
+    "@indiekit/syndicator-indienews",
+    "@indiekit/syndicator-indienews"
+  ],
+  "@indiekit/syndicator-indienews": [
+    { "language": "en" },
+    { "language": "es" }
+  ]
+}
+```
+
+Each instance appears as a separate syndication target in your Micropub client.
+
+## Options
+
+| Option     | Type     | Description                                                                                                    |
+| :--------- | :------- | :------------------------------------------------------------------------------------------------------------- |
+| `language` | `string` | IndieNews language channel to syndicate to. _Optional_, defaults to `"en"`. See [IndieNews](https://news.indieweb.org) for available languages. |
+| `checked`  | `boolean`| Tell a Micropub client whether this syndicator should be enabled by default. _Optional_, defaults to `false`.  |
+

--- a/packages/syndicator-indienews/README.md
+++ b/packages/syndicator-indienews/README.md
@@ -23,7 +23,7 @@ Add `@indiekit/syndicator-indienews` to your list of plug-ins, specifying option
 }
 ```
 
-When you create a post with `mp-syndicate-to: https://news.indieweb.org/en/`, Indiekit will write `https://news.indieweb.org/en/` into the `syndication` property of your post.
+When you create a post with `mp-syndicate-to: https://news.indieweb.org/en`, Indiekit will write `https://news.indieweb.org/en` into the `syndication` property of your post.
 
 For IndieNews to discover your post, two additional things must happen:
 

--- a/packages/syndicator-indienews/README.md
+++ b/packages/syndicator-indienews/README.md
@@ -23,7 +23,12 @@ Add `@indiekit/syndicator-indienews` to your list of plug-ins, specifying option
 }
 ```
 
-When you create a post with `mp-syndicate-to: https://news.indieweb.org/en/`, Indiekit will write `https://news.indieweb.org/en/` into the `syndication` property of your post. Your Webmention sender can then notify IndieNews.
+When you create a post with `mp-syndicate-to: https://news.indieweb.org/en/`, Indiekit will write `https://news.indieweb.org/en/` into the `syndication` property of your post.
+
+For IndieNews to discover your post, two additional things must happen:
+
+1. **Your post template must include the `syndication` value** as a `u-syndication` link in your post's HTML markup, so that the URL is visible to Webmention senders.
+2. **Your site must send a Webmention** to the IndieNews channel URL after publishing. This can be done with a Webmention sending service or tool such as [Telegraph](https://telegraph.p3k.io) or [webmention.app](https://webmention.app).
 
 ### Multiple languages
 

--- a/packages/syndicator-indienews/README.md
+++ b/packages/syndicator-indienews/README.md
@@ -25,7 +25,25 @@ Add `@indiekit/syndicator-indienews` to your list of plug-ins, specifying option
 
 When you create a post with `mp-syndicate-to: https://news.indieweb.org/en/`, Indiekit will write `https://news.indieweb.org/en/` into the `syndication` property of your post. Your Webmention sender can then notify IndieNews.
 
+### Multiple languages
+
+To offer syndication to multiple IndieNews language channels, pass an array of options:
+
+```json
+{
+  "plugins": ["@indiekit/syndicator-indienews"],
+  "@indiekit/syndicator-indienews": [
+    { "language": "en" },
+    { "language": "es" }
+  ]
+}
+```
+
+Each entry appears as a separate syndication target in your Micropub client.
+
 ## Options
+
+Each options object (or the single options object) supports:
 
 | Option     | Type     | Description                                                                                                    |
 | :--------- | :------- | :------------------------------------------------------------------------------------------------------------- |

--- a/packages/syndicator-indienews/README.md
+++ b/packages/syndicator-indienews/README.md
@@ -25,25 +25,6 @@ Add `@indiekit/syndicator-indienews` to your list of plug-ins, specifying option
 
 When you create a post with `mp-syndicate-to: https://news.indieweb.org/en/`, Indiekit will write `https://news.indieweb.org/en/` into the `syndication` property of your post. Your Webmention sender can then notify IndieNews.
 
-### Multiple languages
-
-To offer syndication to multiple IndieNews language channels, add the plugin once per language:
-
-```json
-{
-  "plugins": [
-    "@indiekit/syndicator-indienews",
-    "@indiekit/syndicator-indienews"
-  ],
-  "@indiekit/syndicator-indienews": [
-    { "language": "en" },
-    { "language": "es" }
-  ]
-}
-```
-
-Each instance appears as a separate syndication target in your Micropub client.
-
 ## Options
 
 | Option     | Type     | Description                                                                                                    |

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -7,12 +7,13 @@ export default class SyndicatorIndienews {
    */
   constructor(options = {}) {
     this.language = options.language ?? "en";
+    this.checked = options.checked ?? false;
   }
 
   get info() {
     const uid = `https://news.indieweb.org/${this.language}/`;
     return {
-      checked: false,
+      checked: this.checked,
       name: `IndieNews (${this.language})`,
       uid,
       service: {

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -1,12 +1,17 @@
 /**
- * @typedef {object} PluginOptions
+ * @import { Indiekit } from "@indiekit/indiekit";
+ */
+
+/**
+ * @typedef {object} IndieNewsPluginOptions
  * @property {string} [language] - IndieNews language code (default: "en")
  * @property {boolean} [checked] - Pre-check in Micropub clients (default: false)
  */
 
 /**
  * Create a single IndieNews syndicator target for a given language.
- * @param {PluginOptions} options
+ * @param {IndieNewsPluginOptions} options - Options object (per language)
+ * @returns {object} Syndicator target
  */
 function createTarget(options = {}) {
   const language = options.language ?? "en";
@@ -33,16 +38,19 @@ function createTarget(options = {}) {
   };
 }
 
-export default class SyndicatorIndienews {
-  name = "IndieNews syndicator";
+export default class SyndicatorIndieNews {
+  name = "IndieNews Syndicator";
 
   /**
-   * @param {PluginOptions | PluginOptions[]} [options] - Plug-in options, or array of options for multiple languages
+   * @param {IndieNewsPluginOptions | IndieNewsPluginOptions[]} [options] - Plug-in options, or array of options for multiple languages
    */
   constructor(options = {}) {
-    this.targets = [options].flat().map(createTarget);
+    this.targets = [options].flat().map((options) => createTarget(options));
   }
 
+  /**
+   * @param {Indiekit} Indiekit - Indiekit instance
+   */
   init(Indiekit) {
     Indiekit.addSyndicator(this.targets);
   }

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -19,6 +19,8 @@ function createTarget(options = {}) {
   const uid = `https://news.indieweb.org/${language}/`;
 
   return {
+    name: `IndieNews (${language})`,
+
     get info() {
       return {
         checked,
@@ -45,7 +47,7 @@ export default class SyndicatorIndieNews {
    * @param {IndieNewsPluginOptions | IndieNewsPluginOptions[]} [options] - Plug-in options, or array of options for multiple languages
    */
   constructor(options = {}) {
-    this.targets = [options].flat().map((options) => createTarget(options));
+    this.targets = [options].flat().map((targetOptions) => createTarget(targetOptions));
   }
 
   /**

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -16,7 +16,7 @@
 function createTarget(options = {}) {
   const language = options.language ?? "en";
   const checked = options.checked ?? false;
-  const uid = `https://news.indieweb.org/${language}/`;
+  const uid = `https://news.indieweb.org/${language}`;
 
   return {
     name: `IndieNews (${language})`,

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -1,34 +1,47 @@
+/**
+ * Create a single IndieNews syndicator target for a given language.
+ * @param {object} options
+ * @param {string} [options.language] - Language code (default: "en")
+ * @param {boolean} [options.checked] - Pre-check in Micropub clients (default: false)
+ */
+function createTarget(options = {}) {
+  const language = options.language ?? "en";
+  const checked = options.checked ?? false;
+  const uid = `https://news.indieweb.org/${language}/`;
+
+  return {
+    get info() {
+      return {
+        checked,
+        name: `IndieNews (${language})`,
+        uid,
+        service: {
+          name: "IndieNews",
+          photo: "https://news.indieweb.org/favicon.ico",
+          url: "https://news.indieweb.org",
+        },
+      };
+    },
+
+    async getSyndicationUrl() {
+      return uid;
+    },
+  };
+}
+
 export default class SyndicatorIndienews {
   name = "IndieNews syndicator";
 
   /**
-   * @param {object} [options] - Plug-in options
+   * @param {object | object[]} [options] - Plug-in options, or array of options for multiple languages
    * @param {string} [options.language] - Language code (default: "en")
+   * @param {boolean} [options.checked] - Pre-check in Micropub clients (default: false)
    */
   constructor(options = {}) {
-    this.language = options.language ?? "en";
-    this.checked = options.checked ?? false;
-  }
-
-  get info() {
-    const uid = `https://news.indieweb.org/${this.language}/`;
-    return {
-      checked: this.checked,
-      name: `IndieNews (${this.language})`,
-      uid,
-      service: {
-        name: "IndieNews",
-        photo: "https://news.indieweb.org/favicon.ico",
-        url: "https://news.indieweb.org",
-      },
-    };
-  }
-
-  async getSyndicationUrl() {
-    return this.info.uid;
+    this.targets = [options].flat().map(createTarget);
   }
 
   init(Indiekit) {
-    Indiekit.addSyndicator(this);
+    Indiekit.addSyndicator(this.targets);
   }
 }

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -1,8 +1,12 @@
 /**
+ * @typedef {object} PluginOptions
+ * @property {string} [language] - IndieNews language code (default: "en")
+ * @property {boolean} [checked] - Pre-check in Micropub clients (default: false)
+ */
+
+/**
  * Create a single IndieNews syndicator target for a given language.
- * @param {object} options
- * @param {string} [options.language] - Language code (default: "en")
- * @param {boolean} [options.checked] - Pre-check in Micropub clients (default: false)
+ * @param {PluginOptions} options
  */
 function createTarget(options = {}) {
   const language = options.language ?? "en";
@@ -33,9 +37,7 @@ export default class SyndicatorIndienews {
   name = "IndieNews syndicator";
 
   /**
-   * @param {object | object[]} [options] - Plug-in options, or array of options for multiple languages
-   * @param {string} [options.language] - Language code (default: "en")
-   * @param {boolean} [options.checked] - Pre-check in Micropub clients (default: false)
+   * @param {PluginOptions | PluginOptions[]} [options] - Plug-in options, or array of options for multiple languages
    */
   constructor(options = {}) {
     this.targets = [options].flat().map(createTarget);

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -16,11 +16,18 @@
  */
 function createTarget(options = {}, includeLanguage) {
   const language = options.language ?? "en";
-  const languageName = new Intl.DisplayNames([language], {
-    type: "language",
-  }).of(language);
+  let languageName = language;
+
+  try {
+    languageName = new Intl.DisplayNames([language], {
+      type: "language",
+    }).of(language) ?? language;
+  } catch {
+    // Use the configured code when it is not a valid language tag.
+  }
+
   const name = includeLanguage
-    ? `IndieNews (${languageName ?? language})`
+    ? `IndieNews (${languageName})`
     : "IndieNews";
   const checked = options.checked ?? false;
   const uid = `https://news.indieweb.org/${language}`;

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -11,20 +11,27 @@
 /**
  * Create a single IndieNews syndicator target for a given language.
  * @param {IndieNewsPluginOptions} options - Options object (per language)
+ * @param {boolean} includeLanguage - Whether to include the language in the target name
  * @returns {object} Syndicator target
  */
-function createTarget(options = {}) {
+function createTarget(options = {}, includeLanguage) {
   const language = options.language ?? "en";
+  const languageName = new Intl.DisplayNames([language], {
+    type: "language",
+  }).of(language);
+  const name = includeLanguage
+    ? `IndieNews (${languageName ?? language})`
+    : "IndieNews";
   const checked = options.checked ?? false;
   const uid = `https://news.indieweb.org/${language}`;
 
   return {
-    name: `IndieNews (${language})`,
+    name,
 
     get info() {
       return {
         checked,
-        name: `IndieNews (${language})`,
+        name,
         uid,
         service: {
           name: "IndieNews",
@@ -47,7 +54,10 @@ export default class SyndicatorIndieNews {
    * @param {IndieNewsPluginOptions | IndieNewsPluginOptions[]} [options] - Plug-in options, or array of options for multiple languages
    */
   constructor(options = {}) {
-    this.targets = [options].flat().map((targetOptions) => createTarget(targetOptions));
+    const targetOptions = [options].flat();
+    this.targets = targetOptions.map((options) =>
+      createTarget(options, targetOptions.length > 1),
+    );
   }
 
   /**

--- a/packages/syndicator-indienews/index.js
+++ b/packages/syndicator-indienews/index.js
@@ -1,0 +1,33 @@
+export default class SyndicatorIndienews {
+  name = "IndieNews syndicator";
+
+  /**
+   * @param {object} [options] - Plug-in options
+   * @param {string} [options.language] - Language code (default: "en")
+   */
+  constructor(options = {}) {
+    this.language = options.language ?? "en";
+  }
+
+  get info() {
+    const uid = `https://news.indieweb.org/${this.language}/`;
+    return {
+      checked: false,
+      name: `IndieNews (${this.language})`,
+      uid,
+      service: {
+        name: "IndieNews",
+        photo: "https://news.indieweb.org/favicon.ico",
+        url: "https://news.indieweb.org",
+      },
+    };
+  }
+
+  async getSyndicationUrl() {
+    return this.info.uid;
+  }
+
+  init(Indiekit) {
+    Indiekit.addSyndicator(this);
+  }
+}

--- a/packages/syndicator-indienews/package.json
+++ b/packages/syndicator-indienews/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@indiekit/syndicator-indienews",
+  "version": "1.0.0",
+  "description": "IndieNews syndicator for Indiekit",
+  "keywords": [
+    "indiekit",
+    "indiekit-plugin",
+    "indieweb",
+    "syndication",
+    "indienews"
+  ],
+  "homepage": "https://getindiekit.com",
+  "author": {
+    "name": "Paul Robert Lloyd",
+    "url": "https://paulrobertlloyd.com"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=24.17"
+  },
+  "type": "module",
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "bugs": {
+    "url": "https://github.com/getindiekit/indiekit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getindiekit/indiekit.git",
+    "directory": "packages/syndicator-indienews"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/syndicator-indienews/test/index.js
+++ b/packages/syndicator-indienews/test/index.js
@@ -11,7 +11,7 @@ describe("syndicator-indienews", () => {
     });
 
     it("target uid defaults to english", () => {
-      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/en/");
+      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/en");
     });
 
     it("target checked defaults to false", () => {
@@ -32,7 +32,7 @@ describe("syndicator-indienews", () => {
 
     it("creates one target with configured language", () => {
       assert.equal(syndicator.targets.length, 1);
-      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/es/");
+      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/es");
     });
 
     it("respects checked option", () => {
@@ -51,11 +51,11 @@ describe("syndicator-indienews", () => {
     });
 
     it("first target is english", () => {
-      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/en/");
+      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/en");
     });
 
     it("second target is spanish with checked", () => {
-      assert.equal(syndicator.targets[1].info.uid, "https://news.indieweb.org/es/");
+      assert.equal(syndicator.targets[1].info.uid, "https://news.indieweb.org/es");
       assert.equal(syndicator.targets[1].info.checked, true);
     });
   });
@@ -64,7 +64,7 @@ describe("syndicator-indienews", () => {
     it("returns the uid for the configured language", async () => {
       const syndicator = new SyndicatorIndieNews({ language: "en" });
       const result = await syndicator.targets[0].getSyndicationUrl();
-      assert.equal(result, "https://news.indieweb.org/en/");
+      assert.equal(result, "https://news.indieweb.org/en");
     });
 
     it("each target returns its own uid", async () => {
@@ -73,8 +73,8 @@ describe("syndicator-indienews", () => {
         { language: "es" },
       ]);
       const [en, es] = await Promise.all(syndicator.targets.map((t) => t.getSyndicationUrl()));
-      assert.equal(en, "https://news.indieweb.org/en/");
-      assert.equal(es, "https://news.indieweb.org/es/");
+      assert.equal(en, "https://news.indieweb.org/en");
+      assert.equal(es, "https://news.indieweb.org/es");
     });
   });
 

--- a/packages/syndicator-indienews/test/index.js
+++ b/packages/syndicator-indienews/test/index.js
@@ -19,6 +19,16 @@ describe("syndicator-indienews", () => {
       assert.equal(syndicator.info.service.name, "IndieNews");
       assert.equal(syndicator.info.service.url, "https://news.indieweb.org");
     });
+
+    it("defaults checked to false", () => {
+      const syndicator = new SyndicatorIndienews();
+      assert.equal(syndicator.info.checked, false);
+    });
+
+    it("respects checked option", () => {
+      const syndicator = new SyndicatorIndienews({ checked: true });
+      assert.equal(syndicator.info.checked, true);
+    });
   });
 
   describe("getSyndicationUrl", () => {

--- a/packages/syndicator-indienews/test/index.js
+++ b/packages/syndicator-indienews/test/index.js
@@ -3,56 +3,90 @@ import { describe, it } from "node:test";
 import SyndicatorIndienews from "../index.js";
 
 describe("syndicator-indienews", () => {
-  describe("info", () => {
-    it("returns uid with default language", () => {
-      const syndicator = new SyndicatorIndienews();
-      assert.equal(syndicator.info.uid, "https://news.indieweb.org/en/");
+  describe("single language (default)", () => {
+    const syndicator = new SyndicatorIndienews();
+
+    it("creates one target", () => {
+      assert.equal(syndicator.targets.length, 1);
     });
 
-    it("returns uid with configured language", () => {
-      const syndicator = new SyndicatorIndienews({ language: "es" });
-      assert.equal(syndicator.info.uid, "https://news.indieweb.org/es/");
+    it("target uid defaults to english", () => {
+      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/en/");
     });
 
-    it("includes service info", () => {
-      const syndicator = new SyndicatorIndienews();
-      assert.equal(syndicator.info.service.name, "IndieNews");
-      assert.equal(syndicator.info.service.url, "https://news.indieweb.org");
+    it("target checked defaults to false", () => {
+      assert.equal(syndicator.targets[0].info.checked, false);
     });
 
-    it("defaults checked to false", () => {
-      const syndicator = new SyndicatorIndienews();
-      assert.equal(syndicator.info.checked, false);
+    it("target includes service info", () => {
+      assert.equal(syndicator.targets[0].info.service.name, "IndieNews");
+      assert.equal(syndicator.targets[0].info.service.url, "https://news.indieweb.org");
+    });
+  });
+
+  describe("single language (configured)", () => {
+    const syndicator = new SyndicatorIndienews({ language: "es", checked: true });
+
+    it("creates one target with configured language", () => {
+      assert.equal(syndicator.targets.length, 1);
+      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/es/");
     });
 
     it("respects checked option", () => {
-      const syndicator = new SyndicatorIndienews({ checked: true });
-      assert.equal(syndicator.info.checked, true);
+      assert.equal(syndicator.targets[0].info.checked, true);
+    });
+  });
+
+  describe("multiple languages", () => {
+    const syndicator = new SyndicatorIndienews([
+      { language: "en" },
+      { language: "es", checked: true },
+    ]);
+
+    it("creates one target per language", () => {
+      assert.equal(syndicator.targets.length, 2);
+    });
+
+    it("first target is english", () => {
+      assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/en/");
+    });
+
+    it("second target is spanish with checked", () => {
+      assert.equal(syndicator.targets[1].info.uid, "https://news.indieweb.org/es/");
+      assert.equal(syndicator.targets[1].info.checked, true);
     });
   });
 
   describe("getSyndicationUrl", () => {
-    it("returns the uid as syndication URL", async () => {
+    it("returns the uid for the configured language", async () => {
       const syndicator = new SyndicatorIndienews({ language: "en" });
-      const result = await syndicator.getSyndicationUrl();
+      const result = await syndicator.targets[0].getSyndicationUrl();
       assert.equal(result, "https://news.indieweb.org/en/");
     });
 
-    it("returns correct URL for configured language", async () => {
-      const syndicator = new SyndicatorIndienews({ language: "es" });
-      const result = await syndicator.getSyndicationUrl();
-      assert.equal(result, "https://news.indieweb.org/es/");
+    it("each target returns its own uid", async () => {
+      const syndicator = new SyndicatorIndienews([{ language: "en" }, { language: "es" }]);
+      const [en, es] = await Promise.all(syndicator.targets.map((t) => t.getSyndicationUrl()));
+      assert.equal(en, "https://news.indieweb.org/en/");
+      assert.equal(es, "https://news.indieweb.org/es/");
     });
   });
 
   describe("init", () => {
-    it("registers syndicator with Indiekit", () => {
-      const syndicator = new SyndicatorIndienews();
+    it("registers all targets with Indiekit", () => {
+      const syndicator = new SyndicatorIndienews([{ language: "en" }, { language: "es" }]);
       const added = [];
-      const mockIndiekit = { addSyndicator: (s) => added.push(s) };
+      const mockIndiekit = { addSyndicator: (targets) => added.push(...targets) };
+      syndicator.init(mockIndiekit);
+      assert.equal(added.length, 2);
+    });
+
+    it("registers single target with Indiekit", () => {
+      const syndicator = new SyndicatorIndienews({ language: "en" });
+      const added = [];
+      const mockIndiekit = { addSyndicator: (targets) => added.push(...targets) };
       syndicator.init(mockIndiekit);
       assert.equal(added.length, 1);
-      assert.equal(added[0], syndicator);
     });
   });
 });

--- a/packages/syndicator-indienews/test/index.js
+++ b/packages/syndicator-indienews/test/index.js
@@ -1,10 +1,10 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import SyndicatorIndienews from "../index.js";
+import SyndicatorIndieNews from "../index.js";
 
 describe("syndicator-indienews", () => {
   describe("single language (default)", () => {
-    const syndicator = new SyndicatorIndienews();
+    const syndicator = new SyndicatorIndieNews();
 
     it("creates one target", () => {
       assert.equal(syndicator.targets.length, 1);
@@ -25,7 +25,10 @@ describe("syndicator-indienews", () => {
   });
 
   describe("single language (configured)", () => {
-    const syndicator = new SyndicatorIndienews({ language: "es", checked: true });
+    const syndicator = new SyndicatorIndieNews({
+      language: "es",
+      checked: true,
+    });
 
     it("creates one target with configured language", () => {
       assert.equal(syndicator.targets.length, 1);
@@ -38,7 +41,7 @@ describe("syndicator-indienews", () => {
   });
 
   describe("multiple languages", () => {
-    const syndicator = new SyndicatorIndienews([
+    const syndicator = new SyndicatorIndieNews([
       { language: "en" },
       { language: "es", checked: true },
     ]);
@@ -59,13 +62,16 @@ describe("syndicator-indienews", () => {
 
   describe("getSyndicationUrl", () => {
     it("returns the uid for the configured language", async () => {
-      const syndicator = new SyndicatorIndienews({ language: "en" });
+      const syndicator = new SyndicatorIndieNews({ language: "en" });
       const result = await syndicator.targets[0].getSyndicationUrl();
       assert.equal(result, "https://news.indieweb.org/en/");
     });
 
     it("each target returns its own uid", async () => {
-      const syndicator = new SyndicatorIndienews([{ language: "en" }, { language: "es" }]);
+      const syndicator = new SyndicatorIndieNews([
+        { language: "en" },
+        { language: "es" },
+      ]);
       const [en, es] = await Promise.all(syndicator.targets.map((t) => t.getSyndicationUrl()));
       assert.equal(en, "https://news.indieweb.org/en/");
       assert.equal(es, "https://news.indieweb.org/es/");
@@ -74,7 +80,10 @@ describe("syndicator-indienews", () => {
 
   describe("init", () => {
     it("registers all targets with Indiekit", () => {
-      const syndicator = new SyndicatorIndienews([{ language: "en" }, { language: "es" }]);
+      const syndicator = new SyndicatorIndieNews([
+        { language: "en" },
+        { language: "es" },
+      ]);
       const added = [];
       const mockIndiekit = { addSyndicator: (targets) => added.push(...targets) };
       syndicator.init(mockIndiekit);
@@ -82,7 +91,7 @@ describe("syndicator-indienews", () => {
     });
 
     it("registers single target with Indiekit", () => {
-      const syndicator = new SyndicatorIndienews({ language: "en" });
+      const syndicator = new SyndicatorIndieNews({ language: "en" });
       const added = [];
       const mockIndiekit = { addSyndicator: (targets) => added.push(...targets) };
       syndicator.init(mockIndiekit);

--- a/packages/syndicator-indienews/test/index.js
+++ b/packages/syndicator-indienews/test/index.js
@@ -1,0 +1,48 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import SyndicatorIndienews from "../index.js";
+
+describe("syndicator-indienews", () => {
+  describe("info", () => {
+    it("returns uid with default language", () => {
+      const syndicator = new SyndicatorIndienews();
+      assert.equal(syndicator.info.uid, "https://news.indieweb.org/en/");
+    });
+
+    it("returns uid with configured language", () => {
+      const syndicator = new SyndicatorIndienews({ language: "es" });
+      assert.equal(syndicator.info.uid, "https://news.indieweb.org/es/");
+    });
+
+    it("includes service info", () => {
+      const syndicator = new SyndicatorIndienews();
+      assert.equal(syndicator.info.service.name, "IndieNews");
+      assert.equal(syndicator.info.service.url, "https://news.indieweb.org");
+    });
+  });
+
+  describe("getSyndicationUrl", () => {
+    it("returns the uid as syndication URL", async () => {
+      const syndicator = new SyndicatorIndienews({ language: "en" });
+      const result = await syndicator.getSyndicationUrl();
+      assert.equal(result, "https://news.indieweb.org/en/");
+    });
+
+    it("returns correct URL for configured language", async () => {
+      const syndicator = new SyndicatorIndienews({ language: "es" });
+      const result = await syndicator.getSyndicationUrl();
+      assert.equal(result, "https://news.indieweb.org/es/");
+    });
+  });
+
+  describe("init", () => {
+    it("registers syndicator with Indiekit", () => {
+      const syndicator = new SyndicatorIndienews();
+      const added = [];
+      const mockIndiekit = { addSyndicator: (s) => added.push(s) };
+      syndicator.init(mockIndiekit);
+      assert.equal(added.length, 1);
+      assert.equal(added[0], syndicator);
+    });
+  });
+});

--- a/packages/syndicator-indienews/test/index.js
+++ b/packages/syndicator-indienews/test/index.js
@@ -8,6 +8,8 @@ describe("syndicator-indienews", () => {
 
     it("creates one target", () => {
       assert.equal(syndicator.targets.length, 1);
+      assert.equal(syndicator.targets[0].name, "IndieNews");
+      assert.equal(syndicator.targets[0].info.name, "IndieNews");
     });
 
     it("target uid defaults to english", () => {
@@ -32,6 +34,8 @@ describe("syndicator-indienews", () => {
 
     it("creates one target with configured language", () => {
       assert.equal(syndicator.targets.length, 1);
+      assert.equal(syndicator.targets[0].name, "IndieNews");
+      assert.equal(syndicator.targets[0].info.name, "IndieNews");
       assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/es");
     });
 
@@ -51,12 +55,28 @@ describe("syndicator-indienews", () => {
     });
 
     it("first target is english", () => {
+      assert.equal(syndicator.targets[0].name, "IndieNews (English)");
+      assert.equal(syndicator.targets[0].info.name, "IndieNews (English)");
       assert.equal(syndicator.targets[0].info.uid, "https://news.indieweb.org/en");
     });
 
     it("second target is spanish with checked", () => {
+      assert.equal(syndicator.targets[1].name, "IndieNews (español)");
+      assert.equal(syndicator.targets[1].info.name, "IndieNews (español)");
       assert.equal(syndicator.targets[1].info.uid, "https://news.indieweb.org/es");
       assert.equal(syndicator.targets[1].info.checked, true);
+    });
+  });
+
+  describe("unsupported language", () => {
+    const syndicator = new SyndicatorIndieNews([
+      { language: "en" },
+      { language: "xx" },
+    ]);
+
+    it("uses language code in target name", () => {
+      assert.equal(syndicator.targets[1].name, "IndieNews (xx)");
+      assert.equal(syndicator.targets[1].info.name, "IndieNews (xx)");
     });
   });
 

--- a/packages/syndicator-indienews/test/index.js
+++ b/packages/syndicator-indienews/test/index.js
@@ -80,6 +80,18 @@ describe("syndicator-indienews", () => {
     });
   });
 
+  describe("invalid language", () => {
+    const syndicator = new SyndicatorIndieNews([
+      { language: "en" },
+      { language: "not a language tag" },
+    ]);
+
+    it("uses the raw language code in target name", () => {
+      assert.equal(syndicator.targets[1].name, "IndieNews (not a language tag)");
+      assert.equal(syndicator.targets[1].info.name, "IndieNews (not a language tag)");
+    });
+  });
+
   describe("getSyndicationUrl", () => {
     it("returns the uid for the configured language", async () => {
       const syndicator = new SyndicatorIndieNews({ language: "en" });


### PR DESCRIPTION
Extends #882
Closes #860

## Summary

Adds an indienews syndicator for webmention based syndication.

> [!NOTE]
> This plugin writes the IndieNews URL into the `syndication` property of the post file. For IndieNews to actually discover the post, the post template must expose `u-syndication` in the HTML markup, and the site must send a Webmention to the IndieNews channel URL after publishing.

## Changes

### `syndicator-indienews` (new package)
- New `@indiekit/syndicator-indienews` package for [IndieNews](https://news.indieweb.org).
- Accepts a single options object or an array of options objects (for multiple language channels).
- Each configured language registers as a separate syndication target.
- Implements `getSyndicationUrl()`, returning the IndieNews channel URL.
- No `syndicate()` method — IndieNews syndication is webmention-based; this plugin handles the file-write step only.

## Interface

```js
// Optional method on syndicator targets
async getSyndicationUrl(publication) {
  // return string | string[] | null | undefined
}
```

## Configuration example

```json
{
  "plugins": ["@indiekit/syndicator-indienews"],
  "@indiekit/syndicator-indienews": { "language": "en" }
}
```

Multiple languages:
```json
{
  "@indiekit/syndicator-indienews": [
    { "language": "en" },
    { "language": "es" }
  ]
}
```