### PR TITLE
docs(endpoint-share): document query parameters for pre-filling the form

### DIFF
--- a/packages/endpoint-share/README.md
+++ b/packages/endpoint-share/README.md
@@ -26,3 +26,21 @@ To customise the behaviour of this plug-in, add `@indiekit/endpoint-share` to yo
 | Option      | Type     | Description                                             |
 | :---------- | :------- | :------------------------------------------------------ |
 | `mountPath` | `string` | Path to share screen. _Optional_, defaults to `/share`. |
+
+## Pre-filling the form
+
+The share endpoint accepts query parameters to pre-fill form fields. This allows external services and browser extensions to populate the form automatically.
+
+| Parameter | Description                        |
+| :-------- | :--------------------------------- |
+| `url`     | URL to bookmark.                   |
+| `name`    | Title of the post.                 |
+| `content` | Body text of the post. _Optional_. |
+
+To enable services like [ShareOpenly](https://shareopenly.org) to share to your site, add a `<link>` element with `rel="share-url"` to your homepage:
+
+```html
+<link rel="share-url" href="https://example.com/share?url={url}&name={title}&content={text}">
+```
+
+Replace `https://example.com/share` with the URL of your share endpoint.


### PR DESCRIPTION
Related to #870

The share endpoint accepts `url`, `name`, and `content` query parameters to pre-fill the share form, but these were undocumented. This adds a "Pre-filling the form" section to the README with a parameter table and an example `<link rel="share-url">` element for ShareOpenly integration.