### PR TITLE
feat: add `getSyndicationUrl` hook to syndicator interface

### DIFF
--- a/packages/endpoint-micropub/lib/post-content.js
+++ b/packages/endpoint-micropub/lib/post-content.js
@@ -16,6 +16,30 @@ export const postContent = {
 
     const { postTemplate, store, storeMessageTemplate } = publication;
     const { path, properties } = postData;
+
+    // Call getSyndicationUrl on any targeted syndicator that implements it
+    const syndicationTargets = publication.syndicationTargets ?? [];
+    const requestedUids = [properties["mp-syndicate-to"] ?? []].flat();
+    for (const target of syndicationTargets) {
+      if (
+        typeof target.getSyndicationUrl === "function" &&
+        requestedUids.includes(target.info.uid)
+      ) {
+        try {
+          const urls = [await target.getSyndicationUrl(publication)]
+            .flat()
+            .filter(Boolean);
+          const existing = [properties.syndication ?? []].flat();
+          const newUrls = urls.filter((url) => !existing.includes(url));
+          if (newUrls.length > 0) {
+            properties.syndication = [...existing, ...newUrls];
+          }
+        } catch (error) {
+          debug(`getSyndicationUrl failed for ${target.info.uid}: %O`, error);
+        }
+      }
+    }
+
     const metadata = {
       action: "create",
       result: "created",

--- a/packages/endpoint-micropub/test/unit/post-content.js
+++ b/packages/endpoint-micropub/test/unit/post-content.js
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 
 import { mockAgent } from "@indiekit-test/mock-agent";
 import { deletedPostData, postData } from "@indiekit-test/post-data";
@@ -85,5 +85,62 @@ describe("endpoint-micropub/lib/post-content", () => {
     await assert.rejects(postContent.undelete(false, postData), {
       message: "postTemplate is not a function",
     });
+  });
+
+  it("Calls getSyndicationUrl on targeted syndicator and sets syndication property", async () => {
+    const getSyndicationUrl = mock.fn(async () => "https://news.indieweb.org/en/");
+    const syndicator = {
+      info: { uid: "https://news.indieweb.org/en/" },
+      getSyndicationUrl,
+    };
+    const pub = { ...publication, syndicationTargets: [syndicator] };
+    const data = {
+      path: "foo.md",
+      properties: {
+        ...postData.properties,
+        "mp-syndicate-to": ["https://news.indieweb.org/en/"],
+      },
+    };
+    await postContent.create(pub, data);
+    assert.equal(getSyndicationUrl.mock.calls.length, 1);
+  });
+
+  it("Does not call getSyndicationUrl on syndicator not in mp-syndicate-to", async () => {
+    const getSyndicationUrl = mock.fn(async () => "https://news.indieweb.org/en/");
+    const syndicator = {
+      info: { uid: "https://news.indieweb.org/en/" },
+      getSyndicationUrl,
+    };
+    const pub = { ...publication, syndicationTargets: [syndicator] };
+    const data = {
+      path: "foo.md",
+      properties: {
+        ...postData.properties,
+        "mp-syndicate-to": ["https://other.example/"],
+      },
+    };
+    await postContent.create(pub, data);
+    assert.equal(getSyndicationUrl.mock.calls.length, 0);
+  });
+
+  it("Appends to existing syndication without duplicates", async () => {
+    const getSyndicationUrl = mock.fn(async () => "https://news.indieweb.org/en/");
+    const syndicator = {
+      info: { uid: "https://news.indieweb.org/en/" },
+      getSyndicationUrl,
+    };
+    const pub = { ...publication, syndicationTargets: [syndicator] };
+    const data = {
+      path: "foo.md",
+      properties: {
+        ...postData.properties,
+        syndication: ["https://news.indieweb.org/en/"],
+        "mp-syndicate-to": ["https://news.indieweb.org/en/"],
+      },
+    };
+    await postContent.create(pub, data);
+    // getSyndicationUrl was called but returned a duplicate — syndication stays length 1
+    assert.equal(getSyndicationUrl.mock.calls.length, 1);
+    assert.deepEqual(data.properties.syndication, ["https://news.indieweb.org/en/"]);
   });
 });

--- a/packages/endpoint-micropub/test/unit/post-content.js
+++ b/packages/endpoint-micropub/test/unit/post-content.js
@@ -103,6 +103,7 @@ describe("endpoint-micropub/lib/post-content", () => {
     };
     await postContent.create(pub, data);
     assert.equal(getSyndicationUrl.mock.calls.length, 1);
+    assert.deepEqual(data.properties.syndication, ["https://news.indieweb.org/en/"]);
   });
 
   it("Does not call getSyndicationUrl on syndicator not in mp-syndicate-to", async () => {

--- a/packages/endpoint-micropub/test/unit/post-content.js
+++ b/packages/endpoint-micropub/test/unit/post-content.js
@@ -144,4 +144,21 @@ describe("endpoint-micropub/lib/post-content", () => {
     assert.equal(getSyndicationUrl.mock.calls.length, 1);
     assert.deepEqual(data.properties.syndication, ["https://news.indieweb.org/en/"]);
   });
+
+  it("Silently skips syndicator when getSyndicationUrl throws", async () => {
+    const syndicator = {
+      info: { uid: "https://news.indieweb.org/en/" },
+      getSyndicationUrl: async () => { throw new Error("network error"); },
+    };
+    const pub = { ...publication, syndicationTargets: [syndicator] };
+    const data = {
+      path: "foo.md",
+      properties: {
+        ...postData.properties,
+        "mp-syndicate-to": ["https://news.indieweb.org/en/"],
+      },
+    };
+    await assert.doesNotReject(() => postContent.create(pub, data));
+    assert.equal(data.properties.syndication, undefined);
+  });
 });

--- a/packages/endpoint-syndicate/lib/utils.js
+++ b/packages/endpoint-syndicate/lib/utils.js
@@ -79,6 +79,10 @@ export const syndicateToTargets = async (publication, properties) => {
     const alreadySyndicated = hasSyndicationUrl(syndicatedUrls, url);
 
     if (target && !alreadySyndicated) {
+      if (typeof target.syndicate !== "function") {
+        continue;
+      }
+
       try {
         const syndicatedUrl = await target.syndicate(properties, publication);
 

--- a/packages/endpoint-syndicate/test/unit/utils.js
+++ b/packages/endpoint-syndicate/test/unit/utils.js
@@ -7,6 +7,7 @@ import {
   getPostData,
   getSyndicationTarget,
   hasSyndicationUrl,
+  syndicateToTargets,
 } from "../../lib/utils.js";
 
 const { client, database, mongoServer } = await testDatabase();
@@ -86,5 +87,24 @@ describe("endpoint-syndicate/lib/token", () => {
       hasSyndicationUrl(syndication, "https://mastodon.foobar"),
       false,
     );
+  });
+
+  it("Skips syndicator target without syndicate method", async () => {
+    const targetWithoutSyndicate = {
+      info: { uid: "https://example.com/" },
+      // no syndicate method
+    };
+    const publication = {
+      syndicationTargets: [targetWithoutSyndicate],
+    };
+    const properties = {
+      "mp-syndicate-to": ["https://example.com/"],
+      url: "https://me.example/post/1",
+    };
+
+    const result = await syndicateToTargets(publication, properties);
+
+    assert.deepEqual(result.syndicatedUrls, []);
+    assert.equal(result.failedTargets, undefined);
   });
 });


### PR DESCRIPTION
Closes #860

## Summary

Adds an optional `getSyndicationUrl(publication)` hook to the syndicator plugin interface, enabling syndication URLs to be written into post files at creation time — without requiring a database or async syndication step.

This is needed for webmention-based syndication targets where the syndication URL is known at post creation time, but `mp-syndicate-to` is stripped before the file is written (correct per the Micropub spec — it is a server command, not a content property).

## Changes

### `endpoint-syndicate`
- `syndicate()` is now optional on syndicator targets. Targets without it are skipped rather than throwing. This allows syndicators that only implement `getSyndicationUrl()` to register without providing an empty no-op.

### `endpoint-micropub`
- In `post-content.js` `create()`, after resolving syndication targets and before `getPostTemplateProperties()` strips `mp-*` keys, calls `getSyndicationUrl(publication)` on any target whose `info.uid` is in `mp-syndicate-to`.
- Returned URLs are normalized to an array, deduplicated against existing `syndication` values (exact string match), and appended to `properties.syndication`.
- Errors from `getSyndicationUrl()` are caught and logged via `debug()` — the create request is never failed.

## Interface

```js
// Optional method to add to a syndicator target
async getSyndicationUrl(publication) {
  // return string | string[] | null | undefined
}
```

A syndicator implementing this hook can return the syndication URL synchronously at post creation time. The endpoint handles appending it to `syndication` before the file is written.

This is scoped to `create()` only. Update behaviour is a separate concern.