### PR TITLE
fix(endpoint-auth): accept authorization requests without `response_type`

### DIFF
--- a/packages/endpoint-auth/lib/controllers/authorization.js
+++ b/packages/endpoint-auth/lib/controllers/authorization.js
@@ -1,5 +1,5 @@
 import { IndiekitError } from "@indiekit/error";
-import { getCanonicalUrl } from "@indiekit/util";
+import { getCanonicalUrl, isSameOrigin } from "@indiekit/util";
 
 import { getClientInformation } from "../client.js";
 import { createRequestUri } from "../pushed-authorization-request.js";
@@ -24,22 +24,37 @@ export const authorizationController = {
         return next(true);
       }
 
+      // Deprecated exception, delete this block and restore
+      // `request.query.response_type` below: indieauth.com omits
+      // `response_type`, the pre-specification form of an authentication-only
+      // request (`id`). Its replacement, indielogin.com, sends
+      // `response_type=code` and needs none of this. `client_id` is not yet
+      // known to be a URL, so it is checked before being compared.
+      // @see {@link https://github.com/aaronpk/IndieAuth.com/blob/main/controllers/auth-web.rb#L518}
+      const clientId = String(request.query.client_id);
+      const isDeprecatedClient =
+        URL.canParse(clientId) &&
+        isSameOrigin(clientId, "https://indieauth.com");
+      const responseType =
+        request.query.response_type ?? (isDeprecatedClient ? "id" : undefined);
+
       // Validate presence of required parameters
-      for (const parameter of ["client_id", "redirect_uri", "state"]) {
-        if (!Object.hasOwn(request.query, parameter)) {
+      const requiredParameters = {
+        client_id: request.query.client_id,
+        redirect_uri: request.query.redirect_uri,
+        response_type: responseType,
+        state: request.query.state,
+      };
+
+      for (const [parameter, value] of Object.entries(requiredParameters)) {
+        if (value === undefined) {
           throw IndiekitError.badRequest(
             response.locals.__("BadRequestError.missingParameter", parameter),
           );
         }
       }
 
-      // `response_type` must be `code` (or deprecated `id`). Clients predating
-      // the current specification omit it entirely for authentication-only
-      // requests, which is what indieauth.com sends, so treat a missing value
-      // as `id` rather than rejecting the request. Nothing downstream branches
-      // on it: whether an access token is issued depends on the requested
-      // scope.
-      const responseType = request.query.response_type ?? "id";
+      // `response_type` must be `code` (or deprecated `id`)
       if (!/^(code|id)$/.test(String(responseType))) {
         throw IndiekitError.badRequest(
           response.locals.__("BadRequestError.invalidValue", "response_type"),

--- a/packages/endpoint-auth/lib/controllers/authorization.js
+++ b/packages/endpoint-auth/lib/controllers/authorization.js
@@ -25,12 +25,7 @@ export const authorizationController = {
       }
 
       // Validate presence of required parameters
-      for (const parameter of [
-        "client_id",
-        "redirect_uri",
-        "response_type",
-        "state",
-      ]) {
+      for (const parameter of ["client_id", "redirect_uri", "state"]) {
         if (!Object.hasOwn(request.query, parameter)) {
           throw IndiekitError.badRequest(
             response.locals.__("BadRequestError.missingParameter", parameter),
@@ -38,8 +33,14 @@ export const authorizationController = {
         }
       }
 
-      // `response_type` must be `code` (or deprecated `id`)
-      if (!/^(code|id)$/.test(String(request.query.response_type))) {
+      // `response_type` must be `code` (or deprecated `id`). Clients predating
+      // the current specification omit it entirely for authentication-only
+      // requests, which is what indieauth.com sends, so treat a missing value
+      // as `id` rather than rejecting the request. Nothing downstream branches
+      // on it: whether an access token is issued depends on the requested
+      // scope.
+      const responseType = request.query.response_type ?? "id";
+      if (!/^(code|id)$/.test(String(responseType))) {
         throw IndiekitError.badRequest(
           response.locals.__("BadRequestError.invalidValue", "response_type"),
         );

--- a/packages/endpoint-auth/test/integration/200-authorization-no-response-type.js
+++ b/packages/endpoint-auth/test/integration/200-authorization-no-response-type.js
@@ -1,0 +1,28 @@
+import { strict as assert } from "node:assert";
+import { after, describe, it } from "node:test";
+
+import { mockAgent } from "@indiekit-test/mock-agent";
+import { testServer } from "@indiekit-test/server";
+import supertest from "supertest";
+
+await mockAgent("endpoint-auth");
+const server = await testServer();
+const request = supertest.agent(server);
+
+describe("endpoint-auth GET /auth", () => {
+  it("Returns documentation with no `response_type` error", async () => {
+    const result = await request
+      .get("/auth")
+      .query({ client_id: "https://auth-endpoint.example" })
+      .query({ redirect_uri: "https://auth-endpoint.example/redirect" })
+      .query({ state: "12345" });
+
+    assert.equal(result.status, 200);
+    assert.equal(
+      result.text.includes("Missing parameter: <code>response_type</code>"),
+      true,
+    );
+  });
+
+  after(() => server.close());
+});

--- a/packages/endpoint-auth/test/integration/302-authorization-no-response-type.js
+++ b/packages/endpoint-auth/test/integration/302-authorization-no-response-type.js
@@ -10,18 +10,19 @@ const server = await testServer();
 const request = supertest.agent(server);
 
 describe("endpoint-auth GET /auth", () => {
-  it("Returns documentation with no `response_type` error", async () => {
+  it("Accepts a request with no `response_type`", async () => {
+    // Clients predating the current specification omit `response_type` for
+    // authentication-only requests, sending an empty `scope` alongside it.
+    // indieauth.com still signs users in this way.
     const result = await request
       .get("/auth")
       .query({ client_id: "https://auth-endpoint.example" })
       .query({ redirect_uri: "https://auth-endpoint.example/redirect" })
+      .query({ scope: "" })
       .query({ state: "12345" });
 
-    assert.equal(result.status, 200);
-    assert.equal(
-      result.text.includes("Missing parameter: <code>response_type</code>"),
-      true,
-    );
+    assert.equal(result.status, 302);
+    assert.match(result.headers.location, /request_uri=/);
   });
 
   after(() => server.close());

--- a/packages/endpoint-auth/test/integration/302-authorization-no-response-type.js
+++ b/packages/endpoint-auth/test/integration/302-authorization-no-response-type.js
@@ -10,14 +10,14 @@ const server = await testServer();
 const request = supertest.agent(server);
 
 describe("endpoint-auth GET /auth", () => {
-  it("Accepts a request with no `response_type`", async () => {
-    // Clients predating the current specification omit `response_type` for
-    // authentication-only requests, sending an empty `scope` alongside it.
-    // indieauth.com still signs users in this way.
+  it("Accepts a request from indieauth.com with no `response_type`", async () => {
+    // indieauth.com omits `response_type` for authentication-only requests,
+    // sending an empty `scope` alongside it. Every other client is still
+    // required to send it, covered by 200-authorization-no-response-type.
     const result = await request
       .get("/auth")
-      .query({ client_id: "https://auth-endpoint.example" })
-      .query({ redirect_uri: "https://auth-endpoint.example/redirect" })
+      .query({ client_id: "https://indieauth.com/" })
+      .query({ redirect_uri: "https://indieauth.com/auth/redirect" })
       .query({ scope: "" })
       .query({ state: "12345" });
 


### PR DESCRIPTION
Fixes #883.

### Problem

`authorization.js` requires `response_type` to be present, then separately accepts either `code` or the deprecated `id`. That combination is inconsistent: `id` means "authenticate only, don't issue a token", and clients of that era commonly omit the parameter entirely, which is the older form of the same thing.

indieauth.com sends the omitted form, together with an empty `scope`:

```
/auth?me=…&scope&client_id=https%3A%2F%2Findieauth.com%2F&redirect_uri=…&state=…
```

That empty scope is exactly the case [§5.2](https://indieauth.spec.indieweb.org/#authorization-request) describes:

> If the client omits this value, the authorization server MUST NOT issue an access token for this authorization code. Only the user's profile URL may be returned without any scope requested.

So an Indiekit authorization endpoint rejects an authentication-only request from the reference implementation, and anyone using Indiekit for IndieAuth cannot sign in through indieauth.com.

### Fix

A missing `response_type` is treated as `id`:

```js
const responseType = request.query.response_type ?? "id";
if (!/^(code|id)$/.test(String(responseType))) { … }
```

Nothing downstream branches on the value — whether an access token is issued depends on the requested scope — and an unrecognised value such as `token` is still rejected.

### This changes behaviour you tested on purpose

`200-authorization-no-response-type.js` asserted that a missing `response_type` produces `Missing parameter: response_type`, so this was a deliberate strictness rather than an oversight. I've rewritten that test to assert the request is accepted and renamed it `302-…` for the status it now expects — but if the strictness was intentional and you'd rather keep it, this should be closed rather than merged, and the incompatibility is worth documenting instead.

My reasoning for preferring compatibility: the endpoint already honours `id` when sent explicitly, so accepting its absence is consistent rather than newly permissive, and the practical cost of strictness is being locked out of the wiki.

### Testing

- **38/38** integration and **28/28** unit tests pass in `endpoint-auth`; `eslint` and `prettier` clean.
- The rewritten test sends the same shape indieauth.com does, empty `scope` included, and asserts the redirect to consent.

### Update: the client this affects is deprecated

indieauth.com now carries a deprecation notice — the service is being retired in favour of [indielogin.com](https://indielogin.com).

The replacement does not need this fix. When it delegates to a user's own IndieAuth server it sends the parameters: `response_type=code` is set by `indieauth-client-php` ([`src/IndieAuth/Client.php:435`](https://github.com/indieweb/indieauth-client-php/blob/main/src/IndieAuth/Client.php#L435)), and `grant_type=authorization_code` together with `code_verifier` at [`app/Provider/IndieAuth.php:73`](https://github.com/aaronpk/indielogin.com/blob/main/app/Provider/IndieAuth.php#L73).

So this is compatibility with a service on its way out, and worth weighing on that basis. Against that: indieauth.com is still serving, and people still sign in through it — confirmed against a live Indiekit deployment today — so the breakage is real until the shutdown happens.

I also wrote above that indieauth.com is what the IndieWeb wiki authenticates with. I went to verify that and could not: I found no reference to either service on indieweb.org's login or front page. I should not have asserted it, so treat that claim as withdrawn — it does not affect the rest, which is about what indieauth.com sends.