### PR TITLE
fix(indiekit): accept local redirect paths containing `-`, `.` and `%`

### DIFF
--- a/packages/indiekit/lib/indieauth.js
+++ b/packages/indiekit/lib/indieauth.js
@@ -121,9 +121,15 @@ export const IndieAuth = class {
         const { application } = request.app.locals;
         const { code, redirect, state } = request.query;
 
-        // Check redirect is to a local path
+        // Check redirect is to a local path. The character class excludes `.`
+        // and `-`, so a protocol-relative URL such as //website.example cannot
+        // match, but neither can a legitimate path such as /auth/new-password.
+        // Allow the characters a path may contain and reject a second leading
+        // slash (or a backslash, which browsers normalise to one) instead.
         if (redirect) {
-          const validRedirect = redirect.match(/^\/[\w&/=?]*$/);
+          const validRedirect = redirect.match(
+            /^\/(?![/\\])[\w&/=?.\-~:%+@#]*$/,
+          );
 
           if (!validRedirect) {
             throw IndiekitError.forbidden(

--- a/packages/indiekit/test/integration/403-session-auth-invalid-redirect.js
+++ b/packages/indiekit/test/integration/403-session-auth-invalid-redirect.js
@@ -17,5 +17,35 @@ describe("indiekit GET /session/auth", () => {
     assert.equal(result.text.includes("Invalid redirect attempted"), true);
   });
 
+  // A protocol-relative URL is resolved by the browser as an absolute one, so
+  // //external.example redirects off-site just as https://external.example does.
+  for (const redirect of [
+    "//external.example",
+    "///external.example",
+    "//user@external.example",
+    String.raw`/\external.example`,
+  ]) {
+    it(`Returns 403 error auth with off-site redirect ${redirect}`, async () => {
+      const result = await request.get("/session/auth").query({ redirect });
+
+      assert.equal(result.status, 403);
+      assert.equal(result.text.includes("Invalid redirect attempted"), true);
+    });
+  }
+
+  // Paths containing characters beyond `[\w&/=?]` are local and permitted; the
+  // request then fails on the missing code, not on the redirect.
+  for (const redirect of [
+    "/auth/new-password",
+    "/files/upload-photos",
+    "/posts/2026%2F08",
+  ]) {
+    it(`Allows local redirect ${redirect}`, async () => {
+      const result = await request.get("/session/auth").query({ redirect });
+
+      assert.notEqual(result.status, 403);
+    });
+  }
+
   after(() => server.close());
 });


### PR DESCRIPTION
Fixes #886.

`IndieAuth.authorize()` validates the `redirect` query parameter with `/^\/[\w&/=?]*$/`. That class contains no `.`, `-` or `%`, so ordinary local paths are rejected with "Invalid redirect attempted":

- `/auth/new-password`
- `/files/upload-photos`
- `/posts/2026%2F08`

### Why not just add the characters

The narrow class is also what stops a protocol-relative URL. `//website.example` starts with a slash and contains only word characters and a dot, so adding `.` alone makes it match, and a browser resolves that as `https://website.example` — an open redirect.

So this keeps the guard on the *shape* of the value rather than on the character set:

```js
const validRedirect = redirect.match(/^\/(?![/\\])[\w&/=?.\-~:%+@#]*$/);
```

The negative lookahead rejects a second leading slash, and a backslash, since browsers normalise `/\` to `//`.

### Tests

Extends `403-session-auth-invalid-redirect.js`:

- three paths that `main` rejects today and should not — these fail without the change and pass with it;
- four off-site forms that must keep returning 403 — `//external.example`, `///external.example`, `//user@external.example` and `/\external.example`. These pass on `main` too; they are there so a later widening of the class cannot quietly reopen the redirect.

`node --test` in `packages/indiekit`: **105 tests, 105 passing**; 98/98 on `main` before this change.