### PR TITLE
fix(indiekit): only send stack traces and error causes in development

### DIFF
--- a/packages/frontend/layouts/error.njk
+++ b/packages/frontend/layouts/error.njk
@@ -12,8 +12,10 @@
 {% block content %}
 {{ prose({ text: content | linkTo(uri) }) }}
 
+{% if stack %}
 {{ details({
   summary: "Status code: <code>" + status + "</code>",
   text: "```\n" + stack + "\n```"
 }) }}
+{% endif %}
 {% endblock %}

--- a/packages/indiekit/lib/middleware/error.js
+++ b/packages/indiekit/lib/middleware/error.js
@@ -25,6 +25,13 @@ export const internalServer = (error, request, response, next) => {
   const status = error.status || 500;
   response.status(status);
 
+  // A stack trace describes the server: absolute paths, dependency versions and
+  // the shape of its internals. `cause` can carry more still, since it holds
+  // whatever a wrapped error was given. Neither helps whoever made the request,
+  // so send them only in development, matching how `devMode` is derived in
+  // lib/routes.js.
+  const isDevelopment = process.env.NODE_ENV === "development";
+
   // Send debug logging output to console.error
   debug.log = console.error.bind(console);
   debug("Error", error);
@@ -34,7 +41,7 @@ export const internalServer = (error, request, response, next) => {
       title: response.locals.__(`${error.name}.title:${error.name}`),
       content: error.message,
       name: error.name,
-      stack: error.stack,
+      ...(isDevelopment && { stack: error.stack }),
       status,
       uri: error.uri,
     });
@@ -44,8 +51,8 @@ export const internalServer = (error, request, response, next) => {
       error_description: error.message || error.cause?.message,
       ...(error.uri && { error_uri: error.uri }),
       ...(error.scope && { scope: error.scope }),
-      stack: cleanStack(error.stack),
-      ...(error.cause && { cause: error.cause }),
+      ...(isDevelopment && { stack: cleanStack(error.stack) }),
+      ...(isDevelopment && error.cause && { cause: error.cause }),
     });
   } else {
     response.send(error.toString());

--- a/packages/indiekit/test/unit/middleware/error.js
+++ b/packages/indiekit/test/unit/middleware/error.js
@@ -1,10 +1,15 @@
 import { strict as assert } from "node:assert";
-import { describe, it, mock } from "node:test";
+import { afterEach, describe, it, mock } from "node:test";
 
 import { IndiekitError } from "@indiekit/error";
 import { mockRequest, mockResponse } from "mock-req-res";
 
 import { notFound, internalServer } from "../../../lib/middleware/error.js";
+
+const jsonRequest = () =>
+  mockRequest({ accepts: (mimeType) => mimeType.includes("json") });
+const htmlRequest = () =>
+  mockRequest({ accepts: (mimeType) => mimeType.includes("html") });
 
 describe("indiekit/lib/middleware/error", () => {
   it("Passes error onto next middleware", () => {
@@ -68,5 +73,72 @@ describe("indiekit/lib/middleware/error", () => {
       response.send.calledWith("IndiekitError: Error message"),
       true,
     );
+  });
+
+  describe("stack traces", () => {
+    const nodeEnvironment = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = nodeEnvironment;
+    });
+
+    it("Omits stack and cause from JSON outside development", () => {
+      process.env.NODE_ENV = "production";
+      const testError = new IndiekitError("Error message", {
+        cause: new Error("Database connection string"),
+      });
+      const response = mockResponse();
+
+      internalServer(testError, jsonRequest(), response, mock.fn());
+
+      const body = response.json.firstCall.args[0];
+      assert.equal("stack" in body, false);
+      assert.equal("cause" in body, false);
+      assert.equal(body.error_description, "Error message");
+    });
+
+    it("Includes stack and cause in JSON during development", () => {
+      process.env.NODE_ENV = "development";
+      const testError = new IndiekitError("Error message", {
+        cause: new Error("Cause message"),
+      });
+      const response = mockResponse();
+
+      internalServer(testError, jsonRequest(), response, mock.fn());
+
+      const body = response.json.firstCall.args[0];
+      assert.ok(body.stack);
+      assert.ok(body.cause);
+    });
+
+    it("Omits stack from HTML outside development", () => {
+      process.env.NODE_ENV = "production";
+      const response = mockResponse({ locals: { __() {} } });
+
+      internalServer(
+        new IndiekitError("Error message"),
+        htmlRequest(),
+        response,
+        mock.fn(),
+      );
+
+      const locals = response.render.firstCall.args[1];
+      assert.equal("stack" in locals, false);
+    });
+
+    it("Includes stack in HTML during development", () => {
+      process.env.NODE_ENV = "development";
+      const response = mockResponse({ locals: { __() {} } });
+
+      internalServer(
+        new IndiekitError("Error message"),
+        htmlRequest(),
+        response,
+        mock.fn(),
+      );
+
+      const locals = response.render.firstCall.args[1];
+      assert.ok(locals.stack);
+    });
   });
 });


### PR DESCRIPTION
Fixes #888.

`internalServer` sends `error.stack` in every error response and `error.cause` in every JSON one, in all environments. A stack trace names absolute paths, dependency versions and internal structure; `cause` holds whatever a wrapped error was given, which deeper in the stack can be a driver or upstream API error. Any unauthenticated request that triggers an error can read it, and the server already logs the whole error via `debug("Error", error)`.

Both are now gated on:

```js
const isDevelopment = process.env.NODE_ENV === "development";
```

This is the same test used to derive `devMode` in `lib/routes.js`. Choosing `=== "development"` rather than `!== "production"` means an unset or unrecognised `NODE_ENV` is treated as production, so the safer branch is the default.

`layouts/error.njk` rendered the stack in a `details` block unconditionally, which would print "undefined" once the value is absent, so that block is now wrapped in `{% if stack %}`. The error message itself still renders.

### Tests

Four cases added to `test/unit/middleware/error.js`, covering JSON and HTML in both directions. The two "omits" cases fail without this change and pass with it; the two "includes" cases guard against over-correcting and hiding stacks from developers too.

`node --test` in `packages/indiekit`: **102 tests, 102 passing**; 98/98 on `main` before this change. `packages/frontend` is 22/22.

### A note on scope

I have deliberately not touched `error_description`, which falls back to `error.cause?.message`. That is the description shown to the user by design, and narrowing it is a larger behavioural change than this fix. Worth a separate look if you think the fallback leaks too.