### PR TITLE
fix(endpoint-auth): accept code exchange without `grant_type` at the authorization endpoint

### DIFF
--- a/packages/endpoint-auth/lib/middleware/code.js
+++ b/packages/endpoint-auth/lib/middleware/code.js
@@ -17,13 +17,20 @@ export const codeValidator = async (request, response, next) => {
     const { client_id, code, code_verifier, grant_type, redirect_uri } =
       parameters;
 
+    // This middleware guards two routes: the authorization endpoint, where a
+    // code is exchanged for a profile URL, and the token endpoint, where it is
+    // exchanged for an access token. Clients predating the 2020 specification
+    // perform the former without `grant_type` — indieauth.com still does — so
+    // accept its omission there. The token endpoint continues to require it.
+    const isProfileExchange = request.path === "/";
+
     // Validate presence of required parameters
-    for (const parameter of [
-      "client_id",
-      "code",
-      "grant_type",
-      "redirect_uri",
-    ]) {
+    const requiredParameters = ["client_id", "code", "redirect_uri"];
+    if (!isProfileExchange) {
+      requiredParameters.push("grant_type");
+    }
+
+    for (const parameter of requiredParameters) {
       if (!Object.keys(parameters).includes(parameter)) {
         throw IndiekitError.badRequest(
           response.locals.__("BadRequestError.missingParameter", parameter),
@@ -31,8 +38,8 @@ export const codeValidator = async (request, response, next) => {
       }
     }
 
-    // `grant_type` must equal `authorization_code`
-    if (grant_type !== "authorization_code") {
+    // `grant_type` must equal `authorization_code` where given
+    if ((grant_type ?? "authorization_code") !== "authorization_code") {
       throw IndiekitError.badRequest(
         response.locals.__("BadRequestError.invalidValue", "grant_type"),
       );

--- a/packages/endpoint-auth/test/integration/200-authorization-profile-no-grant-type.js
+++ b/packages/endpoint-auth/test/integration/200-authorization-profile-no-grant-type.js
@@ -1,0 +1,43 @@
+import { strict as assert } from "node:assert";
+import { after, before, describe, it } from "node:test";
+
+import { mockAgent } from "@indiekit-test/mock-agent";
+import { testServer } from "@indiekit-test/server";
+import supertest from "supertest";
+
+import { signToken } from "../../lib/token.js";
+
+await mockAgent("endpoint-auth");
+const server = await testServer();
+const request = supertest.agent(server);
+
+describe("endpoint-auth POST /auth", () => {
+  before(async () => {
+    await request
+      .get("/auth")
+      .query({ client_id: "https://auth-endpoint.example" })
+      .query({ redirect_uri: "https://auth-endpoint.example/redirect" })
+      .query({ response_type: "code" })
+      .query({ state: "12345" });
+  });
+
+  it("Returns profile when `grant_type` omitted", async () => {
+    const code = signToken({
+      access_token: "token",
+      me: "https://website.example",
+      scope: "create update delete media",
+      token_type: "Bearer",
+    });
+    const response = await request
+      .post("/auth")
+      .set("accept", "application/json")
+      .query({ client_id: "https://auth-endpoint.example" })
+      .query({ code })
+      .query({ redirect_uri: "https://auth-endpoint.example/redirect" });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.body.me, "https://website.example");
+  });
+
+  after(() => server.close());
+});

--- a/packages/endpoint-auth/test/integration/400-token-grant-no-grant-type.js
+++ b/packages/endpoint-auth/test/integration/400-token-grant-no-grant-type.js
@@ -1,0 +1,31 @@
+import { strict as assert } from "node:assert";
+import { after, describe, it } from "node:test";
+
+import { testServer } from "@indiekit-test/server";
+import supertest from "supertest";
+
+const server = await testServer();
+const request = supertest.agent(server);
+
+describe("endpoint-auth POST /auth/token", () => {
+  // The authorization endpoint accepts a code exchange without `grant_type`,
+  // for clients predating the specification that introduced it. That allowance
+  // is deliberately limited to the profile exchange: issuing an access token
+  // still requires the parameter.
+  it("Returns 400 error no `grant_type`", async () => {
+    const result = await request
+      .post("/auth/token")
+      .set("accept", "application/json")
+      .query({ client_id: "https://server.example" })
+      .query({ code: "code" })
+      .query({ redirect_uri: "/" });
+
+    assert.equal(result.status, 400);
+    assert.equal(
+      result.body.error_description,
+      "Missing parameter: `grant_type`",
+    );
+  });
+
+  after(() => server.close());
+});


### PR DESCRIPTION
Fixes #890.

`codeValidator` requires `grant_type` on both routes it guards — the authorization endpoint, where a code is exchanged for a profile URL, and the token endpoint, where it is exchanged for an access token.

Clients predating the specification that introduced the parameter perform the profile exchange without it. indieauth.com is one. I originally cited its developer documentation for that; its source is more direct. The verification request is built at
[`controllers/auth-web.rb:562`](https://github.com/aaronpk/IndieAuth.com/blob/main/controllers/auth-web.rb#L562):

```ruby
data = RestClient.post session[:attempted_profile], {
  :code => params[:code],
  :client_id => "https://#{request.host}/",
  :redirect_uri => "https://#{request.host}/auth/indieauth/redirect"
}, :accept => 'application/json'
```

Three parameters; `grant_type` appears nowhere in that repository. So signing in to an Indiekit site through it fails *after* the user has authenticated and been redirected back:

```json
{"error":"bad_request","error_description":"Missing parameter: `grant_type`"}
```

### The change

```js
const isProfileExchange = request.path === "/";

const requiredParameters = ["client_id", "code", "redirect_uri"];
if (!isProfileExchange) {
  requiredParameters.push("grant_type");
}
```

and the value check becomes `(grant_type ?? "authorization_code") !== "authorization_code"`, so a parameter that is present but wrong is still rejected on both routes.

### Why scope it rather than drop the requirement

Only the authorization endpoint needs the allowance. For indieauth.com this is checkable rather than assumed: `token_endpoint` appears nowhere in its source, and its only outbound request to a user's server is the profile exchange quoted above, so it never reaches `/token` at all.

Generalising from that one client is a judgement, not a measurement — I have not surveyed every client that omits `grant_type`. But the asymmetry favours scoping: the authorization endpoint returns a profile URL, `/token` issues credentials, and widening validation there buys compatibility only for a client that would have to be simultaneously old enough to omit the parameter and new enough to want a token. `/token` therefore keeps requiring it.

### Tests

- `200-authorization-profile-no-grant-type.js` — the profile exchange without `grant_type`. Fails on `main` with 400, passes with this change.
- `400-token-grant-no-grant-type.js` — the token endpoint still rejects its absence. This passes on `main` too; there was no coverage for that case, so nothing would have caught the allowance being widened to both routes.

`node --test` in `packages/endpoint-auth`: **68 tests, 68 passing** with the change. Reverting only `code.js` and keeping both tests leaves exactly one failure, the new profile-exchange test. `main` is 66/66 before this change.

### Relationship to #884

That PR fixes the same class of problem one step earlier, where `response_type` is required of clients that predate it. They are independent — this branch is cut from `main`, not from that one — but a client using indieauth.com needs both to sign in: without #884 the authorization request is rejected, and without this the code exchange is. Both are now confirmed together against a live deployment; see the comment below.

### Relationship to #893

#893 also changes `packages/endpoint-auth/lib/middleware/code.js`, and I want to flag an interaction I only found after opening both.

The two merge cleanly — this PR adds a `grant_type` allowance to the required-parameter list, #893 replaces the checks that follow it, and git resolves that without conflict. But the merged result **fails a test, and it is this PR's**: `200-authorization-profile-no-grant-type.js` signs a code carrying neither `client_id` nor `redirect_uri`, and #893 begins rejecting codes missing those claims. It passes on either branch alone and fails on both together.

Adding the two claims to that fixture resolves it, after which the combined branches give 70 tests, 70 passing.

So if this merges second, CI goes red until that one-line fixture change is made, and the cause is in this branch rather than in #893. Nothing structural, but it will not go green on the merge alone.

### Update: the client this affects is deprecated

indieauth.com now carries a deprecation notice — the service is being retired in favour of [indielogin.com](https://indielogin.com).

The replacement does not need this fix. When it delegates to a user's own IndieAuth server it sends the parameters: `response_type=code` is set by `indieauth-client-php` ([`src/IndieAuth/Client.php:435`](https://github.com/indieweb/indieauth-client-php/blob/main/src/IndieAuth/Client.php#L435)), and `grant_type=authorization_code` together with `code_verifier` at [`app/Provider/IndieAuth.php:73`](https://github.com/aaronpk/indielogin.com/blob/main/app/Provider/IndieAuth.php#L73).

So this is compatibility with a service on its way out, and worth weighing on that basis. Against that: indieauth.com is still serving, and people still sign in through it — confirmed against a live Indiekit deployment today — so the breakage is real until the shutdown happens.

I also wrote above that indieauth.com is what the IndieWeb wiki authenticates with. I went to verify that and could not: I found no reference to either service on indieweb.org's login or front page. I should not have asserted it, so treat that claim as withdrawn — it does not affect the rest, which is about what indieauth.com sends.