### PR TITLE
fix(endpoint-syndicate): call `Array.isArray` when wrapping a single target

### DIFF
--- a/packages/endpoint-syndicate/lib/utils.js
+++ b/packages/endpoint-syndicate/lib/utils.js
@@ -70,7 +70,9 @@ export const getSyndicationTarget = (syndicationTargets, syndicateTo) => {
 export const syndicateToTargets = async (publication, properties) => {
   const { syndicationTargets } = publication;
   const syndicateTo = properties["mp-syndicate-to"];
-  const syndicateToUrls = Array.isArray ? syndicateTo : [syndicateTo];
+  const syndicateToUrls = Array.isArray(syndicateTo)
+    ? syndicateTo
+    : [syndicateTo];
   const syndicatedUrls = properties.syndication || [];
   const failedTargets = [];
 

--- a/packages/endpoint-syndicate/test/unit/utils.js
+++ b/packages/endpoint-syndicate/test/unit/utils.js
@@ -7,6 +7,7 @@ import {
   getPostData,
   getSyndicationTarget,
   hasSyndicationUrl,
+  syndicateToTargets,
 } from "../../lib/utils.js";
 
 const { client, database, mongoServer } = await testDatabase();
@@ -66,6 +67,25 @@ describe("endpoint-syndicate/lib/token", () => {
     const result = getSyndicationTarget(targets, "https://mastodon.example");
 
     assert.equal(result, undefined);
+  });
+
+  it("Syndicates to a single target given as a string", async () => {
+    // Converting mf2 to JF2 collapses a single-item array to a string, so a
+    // post sent to one target arrives here as a string rather than an array.
+    const target = {
+      info: { uid: "https://mastodon.example/" },
+      async syndicate() {
+        return "https://mastodon.example/@username/67890";
+      },
+    };
+    const publication = { syndicationTargets: [target] };
+    const properties = { "mp-syndicate-to": "https://mastodon.example/" };
+
+    const result = await syndicateToTargets(publication, properties);
+
+    assert.deepEqual(result.syndicatedUrls, [
+      "https://mastodon.example/@username/67890",
+    ]);
   });
 
   it("Checks if target already returned a syndication URL", () => {


### PR DESCRIPTION
Fixes #894.

```diff
-  const syndicateToUrls = Array.isArray ? syndicateTo : [syndicateTo];
+  const syndicateToUrls = Array.isArray(syndicateTo)
+    ? syndicateTo
+    : [syndicateTo];
```

`Array.isArray` was referenced rather than called, so the condition was always truthy and the wrapping branch unreachable. A single syndication target reaches `syndicateToTargets` as a string — mf2 to JF2 conversion collapses a single-item array — the loop iterated its characters, and `new URL("h")` threw `TypeError [ERR_INVALID_URL]`, propagating out of the loop's `try` and returning 500 from `POST /syndicate`.

### Test

One unit test in `test/unit/utils.js` covering the string case. It fails on `main` with `TypeError: Invalid URL` and passes with this change.

I put it there rather than in an integration test because it needs no database: `node --test test/unit/utils.js` gives 7 passing. For the package as a whole: **24 tests, 24 passing**; 23/23 on `main` before this change.