### PR TITLE
fix(endpoint-syndicate): retry targets a post has not syndicated to yet

### DIFF
--- a/packages/endpoint-syndicate/lib/utils.js
+++ b/packages/endpoint-syndicate/lib/utils.js
@@ -11,13 +11,15 @@ export const getPostData = async (postsCollection, url) => {
     });
   }
 
+  // A post is awaiting syndication while `mp-syndicate-to` remains: it is
+  // deleted once every target has returned a URL, and replaced with the
+  // targets that failed otherwise. Posts already syndicated to some of their
+  // targets are therefore still awaiting the rest, and `syndicateToTargets`
+  // skips the ones already done.
   const items = await postsCollection
     .find({
       "properties.mp-syndicate-to": {
         $exists: true,
-      },
-      "properties.syndication": {
-        $exists: false,
       },
       "properties.post-status": {
         $ne: "draft",

--- a/packages/endpoint-syndicate/test/unit/utils.js
+++ b/packages/endpoint-syndicate/test/unit/utils.js
@@ -47,6 +47,25 @@ describe("endpoint-syndicate/lib/token", () => {
     );
   });
 
+  it("Gets a post with targets still awaiting syndication", async () => {
+    // A post syndicated to one of two targets keeps the failed target in
+    // `mp-syndicate-to` and gains a `syndication` URL for the one that worked.
+    const collection = database.collection("posts-partially-syndicated");
+    await collection.insertOne({
+      properties: {
+        type: "entry",
+        "mp-syndicate-to": "https://bsky.example/",
+        syndication: ["https://mastodon.example/@username/67890"],
+        url: "https://website.example/post/67890",
+      },
+    });
+
+    const result = await getPostData(collection, "");
+
+    assert.ok(result, "expected the post to be awaiting syndication");
+    assert.equal(result.properties["mp-syndicate-to"], "https://bsky.example/");
+  });
+
   it("Gets syndication target for syndication URL", () => {
     const targets = [{ info: { uid: "https://mastodon.example" } }];
     const result = getSyndicationTarget(targets, "https://mastodon.example");


### PR DESCRIPTION
Fixes #896.

```diff
   const items = await postsCollection
     .find({
       "properties.mp-syndicate-to": {
         $exists: true,
       },
-      "properties.syndication": {
-        $exists: false,
-      },
       "properties.post-status": {
         $ne: "draft",
       },
     })
```

The removed condition excluded any post that had ever been syndicated anywhere, which after a partial run is the post that still has targets outstanding: the controller replaces `mp-syndicate-to` with the failed targets and sets `syndication` to the URLs that worked, so the post holds both properties and is never selected again.

### Why removing it is safe

It reads like a guard against re-syndicating finished posts, but two things already cover that:

- a post whose targets have all returned a URL has `mp-syndicate-to` deleted by the same controller, so it stops matching the first condition;
- `syndicateToTargets` calls `hasSyndicationUrl` per target, so a post selected again is not re-syndicated to a target it already reached.

I added a comment at the query recording that, since the reasoning lives in another file.

### Test

One unit test in `test/unit/utils.js`, for a post holding `mp-syndicate-to` and `syndication` together. It fails on `main` and passes with this change. It uses its own collection so it cannot be confused with the shared fixture.

`node --test test/unit/utils.js`: 7 passing. Package-wide: **24 tests, 24 passing**; 23/23 on `main` before this change.

I checked that no existing test depended on the removed condition: `200-no-posts-awaiting-syndication.js` posts an entry with no `mp-syndicate-to` at all, so the first condition already excludes it.

### Relationship to #895

Both change `lib/utils.js` and `test/unit/utils.js`, but different functions and different tests. I merged the two branches locally to check rather than assume: they auto-merge with no conflict, and the combined result gives 25 tests, 25 passing package-wide. Either order should be fine.