### PR TITLE
fix(create-indiekit): generated Docker deployments fail to start, and ship a vulnerable MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ A [MongoDB](https://www.mongodb.com) database is optional, but required for the 
 - Syndicating posts
 - Viewing and deleting previously uploaded media files
 
-> [!NOTE]
-> This project is known to work with MongoDB v4.4 or later. It may also work with the last openly licenced version, v4.0.3, but this has not been tested.
+> [!IMPORTANT]
+> Use a currently supported MongoDB release. Version 4.4.29 and earlier — which includes the `mongo:4` Docker tag — are affected by [CVE-2025-14847](https://www.mongodb.com/company/blog/news/mongodb-server-security-update-december-2025) (“MongoBleed”), an unauthenticated remote memory disclosure that can leak credentials and access tokens. It is fixed in 4.4.30, 5.0.32, 6.0.27, 7.0.28, 8.0.17 and 8.2.3.
+>
+> MongoDB has been licensed under the SSPL since v4.0.4. If you would rather not run SSPL-licensed software, [FerretDB](https://www.ferretdb.com) is an Apache-2.0 licensed database that implements the MongoDB wire protocol (it has not been tested with Indiekit). Note that v4.0.3, the last openly licensed MongoDB release, predates the fix above and should not be used.
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A [MongoDB](https://www.mongodb.com) database is optional, but required for the 
 - Syndicating posts
 - Viewing and deleting previously uploaded media files
 
-> [!IMPORTANT]
+> [!WARNING]
 > Use a currently supported MongoDB release. Version 4.4.29 and earlier — which includes the `mongo:4` Docker tag — are affected by [CVE-2025-14847](https://www.mongodb.com/company/blog/news/mongodb-server-security-update-december-2025) (“MongoBleed”), an unauthenticated remote memory disclosure that can leak credentials and access tokens. It is fixed in 4.4.30, 5.0.32, 6.0.27, 7.0.28, 8.0.17 and 8.2.3.
 >
 > MongoDB has been licensed under the SSPL since v4.0.4. If you would rather not run SSPL-licensed software, [FerretDB](https://www.ferretdb.com) is an Apache-2.0 licensed database that implements the MongoDB wire protocol (it has not been tested with Indiekit). Note that v4.0.3, the last openly licensed MongoDB release, predates the fix above and should not be used.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -32,8 +32,10 @@ A [MongoDB](https://www.mongodb.com) database is optional, but required for the 
 - Syndicating posts
 - Viewing and deleting previously uploaded media files
 
-> [!NOTE]
-> This project is known to work with MongoDB v4.4 or later. It may also work with the last openly licenced version, v4.0.3, but this has not been tested.
+> [!IMPORTANT]
+> Use a currently supported MongoDB release. Version 4.4.29 and earlier — which includes the `mongo:4` Docker tag — are affected by [CVE-2025-14847](https://www.mongodb.com/company/blog/news/mongodb-server-security-update-december-2025) (“MongoBleed”), an unauthenticated remote memory disclosure that can leak credentials and access tokens. It is fixed in 4.4.30, 5.0.32, 6.0.27, 7.0.28, 8.0.17 and 8.2.3.
+>
+> MongoDB has been licensed under the SSPL since v4.0.4. If you would rather not run SSPL-licensed software, [FerretDB](https://www.ferretdb.com) is an Apache-2.0 licensed database that implements the MongoDB wire protocol (it has not been tested with Indiekit). Note that v4.0.3, the last openly licensed MongoDB release, predates the fix above and should not be used.
 
 You don’t need access to a [Git](https://git-scm.com) repository, but some hosts can deploy and update your server automatically when you commit changes.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -32,7 +32,7 @@ A [MongoDB](https://www.mongodb.com) database is optional, but required for the 
 - Syndicating posts
 - Viewing and deleting previously uploaded media files
 
-> [!IMPORTANT]
+> [!WARNING]
 > Use a currently supported MongoDB release. Version 4.4.29 and earlier — which includes the `mongo:4` Docker tag — are affected by [CVE-2025-14847](https://www.mongodb.com/company/blog/news/mongodb-server-security-update-december-2025) (“MongoBleed”), an unauthenticated remote memory disclosure that can leak credentials and access tokens. It is fixed in 4.4.30, 5.0.32, 6.0.27, 7.0.28, 8.0.17 and 8.2.3.
 >
 > MongoDB has been licensed under the SSPL since v4.0.4. If you would rather not run SSPL-licensed software, [FerretDB](https://www.ferretdb.com) is an Apache-2.0 licensed database that implements the MongoDB wire protocol (it has not been tested with Indiekit). Note that v4.0.3, the last openly licensed MongoDB release, predates the fix above and should not be used.

--- a/packages/create-indiekit/files/template.dockerfile
+++ b/packages/create-indiekit/files/template.dockerfile
@@ -1,5 +1,7 @@
-# Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.5.0
+# Adjust NODE_VERSION as desired. Indiekit requires Node.js v24.17 or later.
+# Floating on the major version keeps security updates flowing, rather than
+# pinning to a patch release that will eventually be too old to run Indiekit.
+ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine
 
 # Create app directory

--- a/packages/create-indiekit/lib/docker.js
+++ b/packages/create-indiekit/lib/docker.js
@@ -24,7 +24,7 @@ export const getDockerComposeFileContent = (environment) => {
         ],
       },
       mongo: {
-        image: "mongo:4",
+        image: "mongo:8",
         restart: "always",
         volumes: ["mongo:/data/db"],
         environment: [

--- a/packages/create-indiekit/test/unit/docker.js
+++ b/packages/create-indiekit/test/unit/docker.js
@@ -12,6 +12,9 @@ describe("create-indiekit/lib/docker", () => {
     const result = await getDockerComposeFileContent(["FOO", "BAR"]);
 
     assert.equal(result.includes("name: indiekit"), true);
+    // Guard against regressing to an end-of-life MongoDB image: `mongo:4`
+    // resolves to v4.4.29, which predates the fix for CVE-2025-14847.
+    assert.equal(result.includes("image: mongo:8"), true);
     assert.match(result, /- FOO\n/);
     assert.match(result, /- BAR\n/);
   });


### PR DESCRIPTION
Two problems in what `npm create indiekit` generates, plus the requirements note that points at the same MongoDB version. Reproduced on Node.js 24.18.0 / npm 11.16.0 / Docker 29.1.3 against `main` at f326f60.

## 1. The generated Dockerfile builds, then the container dies on startup

`packages/create-indiekit/files/template.dockerfile` pins `NODE_VERSION=20.5.0`, while `@indiekit/*` declares `engines.node >= 24.17`. npm only *warns* about `EBADENGINE`, so the image builds cleanly and the failure appears later — and in a dependency, which makes it hard to trace back:

```
file:///usr/src/app/node_modules/sharp/dist/utility.mjs:14
import pkg from "../package.json" with { type: "json" };
                                  ^^^^
SyntaxError: Unexpected token 'with'
Node.js v20.5.0
```

Import attributes need Node.js 20.10+. As far as I can tell this means **every Docker deployment produced by the wizard currently fails to start**, which matters because `docs/get-started.md` presents `npm create indiekit` as the primary path.

Changed to float on the Node.js 24 major, so the image keeps receiving security updates rather than rotting against a fixed patch release the way `20.5.0` did.

I verified the fix by building and running the corrected Dockerfile: the container stays up and `/auth` returns 200.

## 2. The generated Compose file specifies a MongoDB vulnerable to an actively exploited CVE

```
$ docker run --rm mongo:4 mongod --version
db version v4.4.29
$ docker inspect mongo:4 --format '{{.Created}}'
2024-02-29T23:25:19Z
```

[CVE-2025-14847](https://www.mongodb.com/company/blog/news/mongodb-server-security-update-december-2025) ("MongoBleed") is an unauthenticated remote read of uninitialised heap memory that can leak credentials, API keys and access tokens. There is a public PoC and exploitation has been observed in the wild. It is patched in 4.4.30, 5.0.32, 6.0.27, 7.0.28, 8.0.17 and 8.2.3 — `mongo:4` is one patch release short.

Changed to `mongo:8`, with an assertion added to the existing unit test so it cannot silently regress to an end-of-life image.

## 3. The requirements note recommends the same vulnerable version

`README.md` and `docs/get-started.md` both said:

> This project is known to work with MongoDB v4.4 or later. It may also work with the last openly licenced version, v4.0.3, but this has not been tested.

"v4.4 or later" is satisfied by the vulnerable 4.4.29.

**I've deliberately kept the licensing concern rather than deleting it** — it's a legitimate position and I didn't want to steamroll it. But I think two things are worth separating:

- The licence argument can't justify staying on 4.4.29, because everything after 4.0.3 is SSPL. 4.4.29 and 4.4.30 are *equally* non-free, so there's no licensing cost to taking the patch.
- v4.0.3 is from 2018 and has no fix for an actively exploited unauthenticated memory disclosure, so recommending it today seems worse than the licensing problem it solves.

The rewritten note therefore requires a patched release, warns about `mongo:4` and v4.0.3 specifically, and points SSPL-averse readers at [FerretDB](https://www.ferretdb.com) (Apache-2.0, implements the MongoDB wire protocol). **I've marked FerretDB as untested with Indiekit, because I haven't tested it** — worth noting its docs list gaps in aggregation-pipeline support, and Indiekit's `post-type-count.js` uses `$addFields`/`$toDate`. Happy to drop that suggestion, or to actually test it first, whichever you'd prefer.

## Verification

```
node --test packages/create-indiekit/test/unit/*.js   → 13 pass, 0 fail
npx eslint <changed js>                               → clean
npx prettier . --check                                → only packages/endpoint-share/README.md,
                                                        which is pre-existing and untouched here
```

## Related

The same broken Dockerfile is duplicated byte-for-byte in `getindiekit/example-config`, along with several other things that stop that repo running at all — I've opened getindiekit/example-config#3 for those.