### PR TITLE
feat(create-indiekit): offer the file system content store

### DIFF
--- a/packages/create-indiekit/lib/setup-prompts.js
+++ b/packages/create-indiekit/lib/setup-prompts.js
@@ -49,6 +49,10 @@ export const setupPrompts = [
         value: "@indiekit/store-bitbucket",
       },
       {
+        title: "File system",
+        value: "@indiekit/store-file-system",
+      },
+      {
         title: "FTP",
         value: "@indiekit/store-ftp",
       },

--- a/packages/create-indiekit/package.json
+++ b/packages/create-indiekit/package.json
@@ -40,6 +40,7 @@
     "@indiekit/preset-hugo": "^1.0.0-beta.28",
     "@indiekit/preset-jekyll": "^1.0.0-beta.28",
     "@indiekit/store-bitbucket": "^1.0.0-beta.28",
+    "@indiekit/store-file-system": "^1.0.0-beta.28",
     "@indiekit/store-ftp": "^1.0.0-beta.29",
     "@indiekit/store-gitea": "^1.0.0-beta.28",
     "@indiekit/store-github": "^1.0.0-beta.29",

--- a/packages/create-indiekit/test/unit/setup-prompts.js
+++ b/packages/create-indiekit/test/unit/setup-prompts.js
@@ -2,10 +2,23 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
 import { setupPrompts } from "../../lib/setup-prompts.js";
+import { getPlugin } from "../../lib/utils.js";
 
 describe("create-indiekit/lib/setup-prompts", () => {
   it("Gets plug-in installation prompts", () => {
     assert.equal(setupPrompts[0].message, "What is your website’s URL?");
+  });
+
+  it("Offers a content store that needs no credentials", async () => {
+    const question = setupPrompts.find((p) => p.name === "storePlugin");
+    const values = question.choices.map((choice) => choice.value);
+
+    assert.ok(values.includes("@indiekit/store-file-system"));
+
+    // Without this, every offered store requires an account and a token, so
+    // there is no way to reach a working server from the wizard alone.
+    const store = await getPlugin("@indiekit/store-file-system");
+    assert.equal(store.environment, undefined);
   });
 
   it("Asks for a valid URL", () => {


### PR DESCRIPTION
Every content store the setup wizard offers — Bitbucket, FTP, Gitea, GitHub, GitLab and S3 — requires an account, a repository and a token before it will accept a single post.

So there is currently no path from `npm create indiekit` to a running server that publishes something, without first setting up a remote service. That is a lot of ceremony for someone who is still deciding whether they want Indiekit at all, and it is the first thing they meet.

`@indiekit/store-file-system` already does everything the wizard needs:

- it exports `prompts` (a single "Which directory do you want to save files in?" question), so `addPluginConfig` configures it with no special-casing
- it declares no `environment`, so `getDockerEnvironment` adds no secrets and the generated `.env` has no `<REQUIRED>` placeholders to fill in

It was simply missing from the list of choices. This adds it, keeping the list alphabetical.

Combined with the fact that MongoDB is optional, the wizard can now produce a server that publishes a post with **no external services configured at all** — which seems like a valuable thing to be able to offer someone evaluating the project.

## Why this matters more than it looks

I hit this while working through onboarding end to end. `docs/get-started.md` presents `npm create indiekit` as the primary path, but a reader who just wants to see Indiekit work has to go and create a GitHub token first. Documenting a zero-dependency local path currently means telling people to hand-write the config files rather than use the wizard, which rather undermines the wizard.

## Verification

```
node --test packages/create-indiekit/test/unit/*.js   → 14 pass, 0 fail
```

The added test asserts the property that matters rather than the string: that at least one offered store needs no credentials, checked by confirming the plug-in exposes no `environment`.

## Note on CI

The `build` workflow fails on pull requests from forks at the "Download localisations" step, before `npm ci`/`lint`/`test` ever run — `secrets.LOCALAZY_READ_KEY` is not available to forks. That failure is not related to this change.

Separately: getindiekit/indiekit#900 fixes the generated Dockerfile (pinned to Node.js 20.5.0, so the container dies on startup) and `mongo:4` (vulnerable to CVE-2025-14847). These are independent, but a user following the Docker path needs both.