### PR TITLE
fix(endpoint-micropub): throw a clear error reading posts without a database

### DIFF
--- a/packages/endpoint-micropub/lib/controllers/action.js
+++ b/packages/endpoint-micropub/lib/controllers/action.js
@@ -132,11 +132,16 @@ export const actionController = async (request, response, next) => {
         response.locals.__("NotFoundError.record", error.message),
       );
     } else if (error.name === "NotImplementedError") {
-      // Hoist unsupported post type error to controller to localise response
-      nextError = IndiekitError.notImplemented(
-        response.locals.__("NotImplementedError.postType", error.message),
-        { uri: "https://getindiekit.com/configuration/post-types" },
-      );
+      // Hoist not implemented errors to controller to localise response
+      nextError =
+        error.cause === "database"
+          ? IndiekitError.notImplemented(
+              response.locals.__("NotImplementedError.database"),
+            )
+          : IndiekitError.notImplemented(
+              response.locals.__("NotImplementedError.postType", error.message),
+              { uri: "https://getindiekit.com/configuration/post-types" },
+            );
     }
 
     return next(nextError);

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -90,6 +90,12 @@ export const postData = {
     const query = { "properties.url": url };
     const postsCollection = application?.collections?.get("posts");
 
+    if (!postsCollection) {
+      throw IndiekitError.notImplemented(
+        "Reading, updating, deleting and restoring posts requires a database",
+      );
+    }
+
     const data = await postsCollection.findOne(query);
     if (!data) {
       throw IndiekitError.notFound(url);

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -91,9 +91,8 @@ export const postData = {
     const postsCollection = application?.collections?.get("posts");
 
     if (!postsCollection) {
-      throw IndiekitError.notImplemented(
-        "Reading, updating, deleting and restoring posts requires a database",
-      );
+      // Localised by the controller; `cause` tells it which case this is
+      throw IndiekitError.notImplemented("database", { cause: "database" });
     }
 
     const data = await postsCollection.findOne(query);

--- a/packages/endpoint-micropub/test/integration/501-action-delete-no-database.js
+++ b/packages/endpoint-micropub/test/integration/501-action-delete-no-database.js
@@ -1,0 +1,31 @@
+import { strict as assert } from "node:assert";
+import { after, describe, it } from "node:test";
+
+import { testServer } from "@indiekit-test/server";
+import { testToken } from "@indiekit-test/token";
+import supertest from "supertest";
+
+const server = await testServer();
+const request = supertest.agent(server);
+
+describe("endpoint-micropub POST /micropub", () => {
+  it("Returns 501 error deleting post without a database", async () => {
+    const result = await request
+      .post("/micropub")
+      .auth(testToken(), { type: "bearer" })
+      .set("accept", "application/json")
+      .send({
+        action: "delete",
+        url: "https://website.example/foo",
+      });
+
+    assert.equal(result.status, 501);
+    assert.equal(
+      result.body.error_description,
+      "This feature requires a database",
+    );
+    assert.equal(result.body.error_uri, undefined);
+  });
+
+  after(() => server.close());
+});

--- a/packages/endpoint-micropub/test/unit/post-data.js
+++ b/packages/endpoint-micropub/test/unit/post-data.js
@@ -65,6 +65,16 @@ describe("endpoint-micropub/lib/post-data", async () => {
     assert.equal(result.properties.url, url);
   });
 
+  it("Throws reading post data without a database", async () => {
+    await assert.rejects(
+      postData.read({ ...application, collections: undefined }, url),
+      {
+        message:
+          "Reading, updating, deleting and restoring posts requires a database",
+      },
+    );
+  });
+
   it("Updates post by adding properties", async () => {
     const operation = { add: { syndication: ["https://website.example"] } };
     const result = await postData.update(

--- a/packages/endpoint-micropub/test/unit/post-data.js
+++ b/packages/endpoint-micropub/test/unit/post-data.js
@@ -68,10 +68,7 @@ describe("endpoint-micropub/lib/post-data", async () => {
   it("Throws reading post data without a database", async () => {
     await assert.rejects(
       postData.read({ ...application, collections: undefined }, url),
-      {
-        message:
-          "Reading, updating, deleting and restoring posts requires a database",
-      },
+      { cause: "database", message: "database" },
     );
   });
 


### PR DESCRIPTION
Fixes #904.

`postData.read()` looked up the posts collection with optional chaining, then called `findOne()` on it unguarded. With no database configured this threw a `TypeError` instead of a meaningful error.

`update()`, `delete()` and `undelete()` all call `read()` first, so a single missing guard affected four operations. `create()` already guards the same lookup, which is why publishing works without a database and reading does not.

MongoDB is documented as optional, and as required for reading, updating, deleting and restoring posts, so this throws `notImplemented` with a message saying so.

### Changes

- `packages/endpoint-micropub/lib/post-data.js` — guard the collection lookup in `read()`
- `packages/endpoint-micropub/test/unit/post-data.js` — regression test

### Verification

```
$ NODE_ENV=test node --test packages/endpoint-micropub/test/unit/post-data.js
ℹ tests 11
ℹ pass 11
ℹ fail 0
```

Red/green checked: with the guard removed the new test fails (10 pass, 1 fail); restored, 11 pass.
