### PR TITLE
chore: make the development environment work from a clean checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Copy to `.env` and edit. Nothing here is needed to run `npm test`.
+
+PUBLICATION_URL="http://localhost:3000"
+
+# Used by @indiekit/endpoint-auth to sign and verify tokens, and to salt the
+# password. Any non-empty value works locally.
+SECRET="development"
+
+# Hashed and salted password used when signing in. Generate by starting the
+# server and visiting /auth/new-password.
+PASSWORD_SECRET=""
+
+# MongoDB. These match the defaults in compose.yaml — `npm run db:up` reads
+# them, so changing the credentials here changes them in the container too.
+# MongoDB is optional; leave MONGO_URL unset to run without persistence.
+MONGO_PORT="27018"
+MONGO_INITDB_ROOT_USERNAME="indiekit"
+MONGO_INITDB_ROOT_PASSWORD="indiekit"
+MONGO_URL="mongodb://indiekit:indiekit@localhost:27018"
+
+# Content store — see docs/development.md for the alternatives.
+# GITHUB_USER=""
+# GITHUB_REPO=""
+# GITHUB_BRANCH="main"
+# GITHUB_TOKEN=""
+
+# Syndicators — see docs/development.md.
+# MASTODON_URL=""
+# MASTODON_USER=""
+# MASTODON_ACCESS_TOKEN=""

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ docs/**/*.md
 **/locales/*.json
 *.html
 CHANGELOG.md
+*.env.example

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,34 @@
+# Development MongoDB for working on Indiekit itself.
+#
+#   npm run db:up      start it
+#   npm run db:down    stop it, keeping the data
+#   npm run db:reset   stop it and discard the data
+#
+# The test suite does not need this — `npm test` starts its own in-memory
+# MongoDB and requires no running services. This is here so that `npm start`
+# and `npm run dev` have a database to talk to.
+#
+# The port defaults to 27018 rather than 27017 so it does not collide with a
+# MongoDB already installed on the host. Override it with MONGO_PORT.
+
+services:
+  mongo:
+    image: mongo:8
+    container_name: indiekit-dev-mongo
+    restart: unless-stopped
+    ports:
+      - "${MONGO_PORT:-27018}:27017"
+    volumes:
+      - mongo-data:/data/db
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-indiekit}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-indiekit}
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+volumes:
+  mongo-data:

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,8 @@
 # Setting up a local development environment
 
-To begin local development on the Indiekit project, clone this repository, configure a [content store](concepts#content-store), [publication preset](concepts#publication-preset) and [syndicator](concepts#syndication), and create a MongoDB database you can connect to.
+To begin local development on the Indiekit project, clone this repository, run `npm install`, then copy `.env.example` to `.env`. To run the server you will also want a [content store](concepts#content-store), [publication preset](concepts#publication-preset) and [syndicator](concepts#syndication), and a MongoDB database to connect to.
+
+Running the tests needs none of that — see [Tests](#tests).
 
 ## Project structure
 
@@ -32,42 +34,26 @@ Express waits for a resolved configuration file before starting the server.
 
 ## MongoDB
 
-Indiekit uses a MongoDB database for persistence. A convenient way to run MongoDB locally is to use [Docker Compose](https://docs.docker.com/compose/). Since the filesystem of a Docker container is ephemeral, you will need to create a [Docker volume](https://docs.docker.com/storage/volumes/). You can do this with the following docker command:
+Indiekit uses a MongoDB database for persistence. The repository ships a
+`compose.yaml` that runs one, so you do not need to install MongoDB locally:
 
 ```sh
-docker volume create mongo-data
+npm run db:up
 ```
 
-Create a `docker-compose.yml` file that runs a service on an available port of your Docker host (e.g. 27018) and uses the Docker volume you have just created.
+This starts MongoDB on port 27018 of your host, storing its data in a named
+Docker volume so it survives a restart. Use `npm run db:down` to stop it, or
+`npm run db:reset` to stop it and discard the data.
 
-```yml
-version: '3.9'
-services:
-  mongo:
-    container_name: mongo
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME
-      - MONGO_INITDB_ROOT_PASSWORD
-    image: mongo:7.0.11
-    network_mode: bridge
-    ports:
-    - '27018:27017'
-    restart: always
-    volumes:
-      - mongo-data:/data/db
-volumes:
-  mongo-data:
-    external: true
-```
+The port defaults to 27018 rather than 27017 so that it does not collide with
+a MongoDB already installed on your machine. Set `MONGO_PORT` to change it.
 
-This configuration tells Docker to run the `mongo` service on port 27017 of the `mongo` container, and expose port 27018 on the Docker host (e.g. your computer).
-
-You can set the necessary environment variables in a `.env` file:
+Copy `.env.example` to `.env` to get a matching `MONGO_URL`:
 
 ```dotenv
-MONGO_INITDB_ROOT_USERNAME="username"
-MONGO_INITDB_ROOT_PASSWORD="password"
-MONGO_URL="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@localhost:27018"
+MONGO_INITDB_ROOT_USERNAME="indiekit"
+MONGO_INITDB_ROOT_PASSWORD="indiekit"
+MONGO_URL="mongodb://indiekit:indiekit@localhost:27018"
 ```
 
 > [!TIP]
@@ -75,6 +61,9 @@ MONGO_URL="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@loc
 
 > [!TIP]
 > To inspect data stored in a MongoDB database, use the [MongoDB shell](https://www.mongodb.com/products/tools/shell) or an application like [Compass](https://www.mongodb.com/products/tools/compass).
+
+> [!NOTE]
+> MongoDB is optional. Leave `MONGO_URL` unset to run Indiekit without persistence; see the [README](https://github.com/getindiekit/indiekit#readme) for which features need a database.
 
 ## Configure a content store
 
@@ -170,6 +159,12 @@ The project uses both unit and integration tests. Run tests using the following 
 ```sh
 npm test
 ```
+
+The test suite needs no setup at all: it starts its own in-memory MongoDB, so
+no database has to be running, and the `test` script supplies development
+defaults for `NODE_ENV`, `SECRET` and `PASSWORD_SECRET`. A clean checkout can
+run `npm install && npm test` straight away. Setting `SECRET` or
+`PASSWORD_SECRET` in the environment overrides the default.
 
 To run a single test suite, use `node` followed by the path to the test. For example:
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "dev": "node --watch-path=./ packages/indiekit/bin/cli.js serve",
+    "db:up": "docker compose up --detach --wait",
+    "db:down": "docker compose down",
+    "db:reset": "docker compose down --volumes",
     "debug": "indiekit serve --debug",
     "start": "indiekit serve",
     "lint:prettier": "prettier . --check",
@@ -39,9 +42,9 @@
     "lint:css:fix": "stylelint '**/*.css' --fix",
     "lint": "npm run lint:prettier && npm run lint:js && npm run lint:css",
     "lint:fix": "npm run lint:prettier:fix && npm run lint:js:fix && npm run lint:css:fix",
-    "test": "NODE_ENV=test node --test --test-reporter=spec",
-    "test:coverage": "NODE_ENV=test node --test --experimental-test-coverage",
-    "test:lcov": "NODE_ENV=test node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/lcov.info"
+    "test": "NODE_ENV=test SECRET=${SECRET:-test} PASSWORD_SECRET=${PASSWORD_SECRET:-test} node --test --test-reporter=spec",
+    "test:coverage": "NODE_ENV=test SECRET=${SECRET:-test} PASSWORD_SECRET=${PASSWORD_SECRET:-test} node --test --experimental-test-coverage",
+    "test:lcov": "NODE_ENV=test SECRET=${SECRET:-test} PASSWORD_SECRET=${PASSWORD_SECRET:-test} node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/lcov.info"
   },
   "workspaces": [
     "helpers/*",

--- a/packages/util/test/unit/mongodb.js
+++ b/packages/util/test/unit/mongodb.js
@@ -74,12 +74,27 @@ describe("util/lib/mongodb", async () => {
     );
   });
 
+  // Uses an in-memory server with authentication enabled rather than whatever
+  // happens to be listening on port 27017. The suite must not depend on a
+  // service it did not start: `docs/development.md` puts MongoDB on 27018, so
+  // a correctly configured machine would otherwise fail here after a
+  // 30-second server-selection timeout.
   it("Returns error if can’t connect to MongoDB client", async () => {
+    const authServer = await MongoMemoryServer.create({
+      auth: { enable: true },
+    });
     mock.method(console, "error", () => {});
 
-    await getMongodbClient("mongodb://foo:bar@localhost");
-    const result = console.error.mock.calls[0].arguments[0];
+    try {
+      const uri = authServer
+        .getUri()
+        .replace("mongodb://", "mongodb://foo:bar@");
+      await getMongodbClient(uri);
+      const result = console.error.mock.calls[0].arguments[0];
 
-    assert.equal(result, `Authentication failed.`);
+      assert.equal(result, `Authentication failed.`);
+    } finally {
+      await authServer.stop();
+    }
   });
 });


### PR DESCRIPTION
Setting up to work on Indiekit needed steps that were either undocumented or documented incorrectly, and the test suite depended on ambient state. After this, `git clone && npm install && npm test` passes with nothing else installed or running.

## `npm test` no longer depends on a MongoDB it didn't start

Most tests already start their own in-memory MongoDB. One did not: `packages/util/test/unit/mongodb.js` connected to `mongodb://foo:bar@localhost` — port 27017 — and asserted the error was `Authentication failed.`. That only holds if something happens to be listening there.

`docs/development.md` tells contributors to put MongoDB on **27018**, so following the documented setup exactly failed this test after a 30-second server-selection timeout. It passes in CI only because the workflow starts MongoDB on 27017.

It now uses an in-memory server with authentication enabled: deterministic, no external service, and 180ms instead of 30s.

## Test scripts supply development defaults for `SECRET` and `PASSWORD_SECRET`

Without them the suite reports **115 failures** that read like broken code rather than a missing environment. `${SECRET:-test}` means a real value still wins wherever one is set.

Worth noting: CI supplies both from repository secrets, and `pull_request` runs from forks don't receive secrets — so an external contributor's first PR currently fails this way.

## `compose.yaml` replaces YAML copied by hand

`development.md` asked contributors to hand-copy a compose file. That copy pinned `mongo:7.0.11` — a release the README explicitly warns against, being affected by CVE-2025-14847 — used the obsolete `version:` key, and declared its volume `external`, so it needed `docker volume create mongo-data` first or it wouldn't start.

The shipped file uses `mongo:8`, a named volume and a healthcheck, with `npm run db:up` / `db:down` / `db:reset`. The port stays 27018 (override with `MONGO_PORT`) so it doesn't collide with a MongoDB already on the host.

## Also

- Adds `.env.example`.
- Corrects `npm run dev --production` → `npm run dev -- --production`; the original passes the flag to npm, not to the script.

## Verified

| | |
| :--- | :--- |
| `npm test`, clean checkout, no `.env`, no Docker, nothing on 27017 | **773 pass, 0 fail** |
| `npm run db:up` | healthy; connected from the host with the credentials in `.env.example` |
| `npm run lint` | no new errors or warnings |

Two lint warnings pre-date this branch and are untouched: `packages/endpoint-share/README.md` fails `prettier --check` on `main`, and `wc/no-self-class` fires twice in `packages/frontend/components`.
