### PR TITLE
fix(create-indiekit): handle command-line arguments

### DIFF
--- a/packages/create-indiekit/bin/create.js
+++ b/packages/create-indiekit/bin/create.js
@@ -2,6 +2,7 @@
 import process from "node:process";
 
 import { init } from "../index.js";
+import { getCliResult, parseCliArguments } from "../lib/cli.js";
 import { isCompatibleNodeVersion } from "../lib/utils.js";
 
 const minimumSupportedVersion = "24.17";
@@ -12,4 +13,30 @@ if (!isCompatibleNodeVersion(process.versions.node, minimumSupportedVersion)) {
   process.exit(1);
 }
 
-await init();
+const result = getCliResult(parseCliArguments(process.argv.slice(2)));
+
+if (result) {
+  const log = result.code === 0 ? console.info : console.error;
+
+  log(result.message);
+  process.exit(result.code);
+}
+
+// Setup asks questions, which needs an interactive terminal. Without one,
+// `prompts` never settles, so the await below never resolves and Node exits
+// reporting an unsettled top-level await instead of anything actionable.
+if (!process.stdin.isTTY) {
+  console.error("This command needs an interactive terminal.");
+  process.exit(1);
+}
+
+try {
+  await init();
+} catch (error) {
+  if (error.code === "ERR_SETUP_CANCELLED") {
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  throw error;
+}

--- a/packages/create-indiekit/index.js
+++ b/packages/create-indiekit/index.js
@@ -26,7 +26,17 @@ export async function init() {
   log(`${styleText("green", ">")} ${styleText("white", "Gathering details…")}`);
 
   // Ask setup questions
-  const setup = await prompts(setupPrompts);
+  //
+  // Without `onCancel`, cancelling resolves with whatever has been answered so
+  // far, so a cancelled run carries on and scaffolds using empty answers.
+  const setup = await prompts(setupPrompts, {
+    onCancel() {
+      const error = new Error("Setup cancelled");
+      error.code = "ERR_SETUP_CANCELLED";
+
+      throw error;
+    },
+  });
 
   // Get values for package.json based on answers
   const { config, dependencies } = await getPackageValues(setup);

--- a/packages/create-indiekit/lib/cli.js
+++ b/packages/create-indiekit/lib/cli.js
@@ -1,0 +1,75 @@
+import { createRequire } from "node:module";
+import { parseArgs } from "node:util";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json");
+
+export const usage = `Usage: npm create indiekit [directory]
+
+Creates an Indiekit server in [directory], asking which content store,
+preset and syndicators to use.
+
+Options:
+  -h, --help     Show this message
+  -v, --version  Show version number`;
+
+/**
+ * Parse command-line arguments
+ *
+ * Parsed non-strictly so that an unrecognised option is reported by name
+ * rather than throwing, and so a future option cannot crash an older binary.
+ * @param {string[]} argv - Arguments, excluding the Node and script paths
+ * @returns {object} Parsed arguments
+ */
+export const parseCliArguments = (argv) => {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    options: {
+      help: { type: "boolean", short: "h" },
+      version: { type: "boolean", short: "v" },
+    },
+    allowPositionals: true,
+    strict: false,
+  });
+
+  const known = new Set(["help", "version"]);
+
+  return {
+    help: Boolean(values.help),
+    version: Boolean(values.version),
+    directory: positionals[0],
+    unknownOption: Object.keys(values).find((key) => !known.has(key)),
+  };
+};
+
+/**
+ * Get the message and exit code for a set of parsed arguments, or false if
+ * the setup flow should run
+ * @param {object} parsed - Parsed arguments from `parseCliArguments`
+ * @returns {object|boolean} Message and exit code, else false
+ */
+export const getCliResult = (parsed) => {
+  if (parsed.help) {
+    return { message: usage, code: 0 };
+  }
+
+  if (parsed.version) {
+    return { message: version, code: 0 };
+  }
+
+  if (parsed.unknownOption) {
+    return {
+      message: `Unknown option: --${parsed.unknownOption}\n\n${usage}`,
+      code: 1,
+    };
+  }
+
+  // `base-create` requires a directory, but only checks once every setup
+  // question has been answered. Checking here keeps those answers from
+  // being thrown away.
+  if (!parsed.directory) {
+    return { message: `Provide a directory.\n\n${usage}`, code: 1 };
+  }
+
+  return false;
+};

--- a/packages/create-indiekit/test/unit/cli.js
+++ b/packages/create-indiekit/test/unit/cli.js
@@ -1,0 +1,74 @@
+import { strict as assert } from "node:assert";
+import { createRequire } from "node:module";
+import { describe, it } from "node:test";
+
+import { getCliResult, parseCliArguments, usage } from "../../lib/cli.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../../package.json");
+
+describe("create-indiekit/lib/cli", () => {
+  it("Parses a directory", () => {
+    const result = parseCliArguments(["myproject"]);
+
+    assert.equal(result.directory, "myproject");
+    assert.equal(result.help, false);
+    assert.equal(result.version, false);
+    assert.equal(result.unknownOption, undefined);
+  });
+
+  it("Parses help and version options", () => {
+    assert.equal(parseCliArguments(["--help"]).help, true);
+    assert.equal(parseCliArguments(["-h"]).help, true);
+    assert.equal(parseCliArguments(["--version"]).version, true);
+    assert.equal(parseCliArguments(["-v"]).version, true);
+  });
+
+  it("Reports an unrecognised option by name", () => {
+    assert.equal(parseCliArguments(["--foo"]).unknownOption, "foo");
+    assert.equal(
+      parseCliArguments(["--foo", "myproject"]).unknownOption,
+      "foo",
+    );
+  });
+
+  it("Shows usage", () => {
+    const result = getCliResult(parseCliArguments(["--help"]));
+
+    assert.equal(result.code, 0);
+    assert.equal(result.message, usage);
+  });
+
+  it("Shows version number", () => {
+    const result = getCliResult(parseCliArguments(["--version"]));
+
+    assert.equal(result.code, 0);
+    assert.equal(result.message, version);
+  });
+
+  it("Rejects an unrecognised option", () => {
+    const result = getCliResult(parseCliArguments(["--foo"]));
+
+    assert.equal(result.code, 1);
+    assert.match(result.message, /Unknown option: --foo/);
+  });
+
+  it("Asks for a directory before any questions are asked", () => {
+    const result = getCliResult(parseCliArguments([]));
+
+    assert.equal(result.code, 1);
+    assert.match(result.message, /Provide a directory/);
+  });
+
+  it("Runs setup when given a directory", () => {
+    assert.equal(getCliResult(parseCliArguments(["myproject"])), false);
+  });
+
+  it("Does not treat an option as the directory to create", () => {
+    // `base-create` takes `process.argv[2]` verbatim, so an unhandled option
+    // would otherwise become the name of the scaffolded directory.
+    for (const option of ["--help", "--version", "--foo"]) {
+      assert.notEqual(parseCliArguments([option]).directory, option);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #908.

`create-indiekit` never read `process.argv`, so `--help` and `--version` fell through to the setup questions, and an unrecognised option became the name of the scaffolded directory — `base-create` takes `process.argv[2]` verbatim.

### What this changes

- **`lib/cli.js`** (new) parses arguments with `parseArgs` from `node:util`. `--help`/`--version` print and exit 0; an unrecognised option is named and exits 1.
- **A missing directory is reported before any question is asked.** `base-create` already requires one, but only checks after the last answer, so those answers were thrown away.
- **`bin/create.js` checks for an interactive terminal** before prompting. Without one, `prompts` never settles and Node reported an unsettled top-level await; it now says what's wrong and exits 1.
- **`index.js` passes `onCancel` to `prompts`.** Cancelling resolved with whatever had been answered so far, so a cancelled run carried on and scaffolded with empty answers. It now throws, and `bin/create.js` turns that into a clean exit 1.

### Notes on the approach

Parsed **non-strictly**, so an unrecognised option is reported by name rather than throwing. Under `strict: true`, `parseArgs` throws on anything unknown, which would turn a currently-harmless stray option into a crash.

I used `parseArgs` rather than `commander` to avoid adding a dependency — the package already imports from `node:util`, and this needs two booleans and one positional. `packages/indiekit` uses `commander` for its CLI, so say the word if you'd rather the two binaries matched and I'll switch.

Cancellation is signalled with an `error.code` of `ERR_SETUP_CANCELLED` rather than calling `process.exit()` in `index.js`, since `unicorn/no-process-exit` restricts that to the binary.

### Verification

`packages/create-indiekit` unit tests: 23 pass, 0 fail (9 new, in `test/unit/cli.js`). `eslint` and `prettier` clean.

```console
$ node bin/create.js --help          # usage, exit 0
$ node bin/create.js --version       # 1.0.0-beta.29, exit 0
$ node bin/create.js --foo           # Unknown option: --foo, exit 1
$ node bin/create.js                 # Provide a directory. exit 1
$ node bin/create.js myproject       # (no TTY) This command needs an interactive terminal. exit 1
```

No directory named `--help` is created in any of those.

### Not addressed here

Two inconsistencies noted in #908 that felt out of scope for this change: `engines.node` is `>=24.17` while the runtime guard in `bin/create.js` only rejects Node < 20, and `docs/get-started.md` documents the directory as optional though `base-create` requires it. Happy to fold either in.
