### PR TITLE
style(endpoint-share): format share-url example

### DIFF
--- a/packages/endpoint-share/README.md
+++ b/packages/endpoint-share/README.md
@@ -40,7 +40,10 @@ The share endpoint accepts query parameters to pre-fill form fields. This allows
 To enable services like [ShareOpenly](https://shareopenly.org) to share to your site, add a `<link>` element with `rel="share-url"` to your homepage:
 
 ```html
-<link rel="share-url" href="https://example.com/share?url={url}&name={title}&content={text}">
+<link
+  rel="share-url"
+  href="https://example.com/share?url={url}&name={title}&content={text}"
+/>
 ```
 
 Replace `https://example.com/share` with the URL of your share endpoint.


### PR DESCRIPTION
`prettier . --check` has failed on `packages/endpoint-share/README.md` since ba8e19a7, when the `rel="share-url"` example was added.

Because `lint` runs `lint:prettier && lint:js && lint:css`, that failure ends the linter step before `lint:js` and `lint:css` run, and the `Run tests` step is skipped — so **every** pull request currently goes red without its tests being exercised. Spotted while opening #909, whose tests were skipped for this reason.

This is `prettier --write` output and nothing else — formatting only, no change to the documented markup.

Verified on this branch: `npm run lint` exits 0 (prettier clean, eslint 0 errors, stylelint clean).

If you'd rather keep the example on one line, a `<!-- prettier-ignore -->` above the fence would do it instead — happy to switch.
