### PR TITLE
fix(indiekit): return error instead of redirect for API GET requests with invalid bearer token

### DIFF
--- a/packages/endpoint-micropub/test/integration/403-query-invalid-me-in-api-get.js
+++ b/packages/endpoint-micropub/test/integration/403-query-invalid-me-in-api-get.js
@@ -1,0 +1,29 @@
+import { strict as assert } from "node:assert";
+import { after, describe, it } from "node:test";
+
+import { mockAgent } from "@indiekit-test/mock-agent";
+import { testServer } from "@indiekit-test/server";
+import supertest from "supertest";
+
+await mockAgent("indiekit");
+
+const server = await testServer({
+  application: {
+    tokenEndpoint: "https://token-endpoint.example",
+    introspectionEndpoint: "https://token-endpoint.example/introspect",
+  },
+});
+
+describe("endpoint-micropub GET /micropub", () => {
+  it("Returns 403 error when me does not match publication in api GET request", async () => {
+    const result = await supertest(server)
+      .get("/micropub")
+      .auth("another", { type: "bearer" })
+      .set("accept", "application/json")
+      .query({ q: "config" });
+
+    assert.equal(result.status, 403);
+  });
+
+  after(() => server.close());
+});

--- a/packages/indiekit/lib/indieauth.js
+++ b/packages/indiekit/lib/indieauth.js
@@ -242,7 +242,11 @@ export const IndieAuth = class {
 
         next();
       } catch (error) {
-        if (request.method === "GET") {
+        const isApiRequest =
+          request.headers.authorization?.toLowerCase().startsWith("bearer ") ||
+          request.headers.accept?.includes("application/json");
+
+        if (!isApiRequest && request.method === "GET") {
           return response.redirect(
             `/session/login?redirect=${request.originalUrl}`,
           );


### PR DESCRIPTION
## What

When a GET request to the Micropub query endpoint includes an `Authorization: Bearer` token but authentication fails, the middleware now returns an error response (401/403) instead of redirecting to the login page.

## Why

The `authenticate()` middleware was redirecting all failing GET requests to `/session/login`, regardless of whether the request was from a browser or an API client. Micropub clients like Omnibear send a bearer token on GET requests but have no session cookie, and were receiving a 302 redirect instead of a usable error response.

POST requests were already handled correctly (passed to the error handler). This fix brings GET requests in line with that behaviour when an `Authorization: Bearer` header is present.

## Changes

- `packages/indiekit/lib/indieauth.js`: detect API-style GET requests (those with an `Authorization: Bearer` header or `Accept: application/json`) and pass errors to `next(error)` instead of redirecting
- `packages/endpoint-micropub/test/integration/403-query-invalid-me.js`: new integration test that verifies a bearer token GET request returns 403 instead of redirecting when the token's `me` does not match the publication

Fixes #825