### PR TITLE
style(endpoint-share): keep the share-url example on one line

### DIFF
--- a/packages/endpoint-share/README.md
+++ b/packages/endpoint-share/README.md
@@ -39,11 +39,9 @@ The share endpoint accepts query parameters to pre-fill form fields. This allows
 
 To enable services like [ShareOpenly](https://shareopenly.org) to share to your site, add a `<link>` element with `rel="share-url"` to your homepage:
 
+<!-- prettier-ignore -->
 ```html
-<link
-  rel="share-url"
-  href="https://example.com/share?url={url}&name={title}&content={text}"
-/>
+<link rel="share-url" href="https://example.com/share?url={url}&name={title}&content={text}">
 ```
 
 Replace `https://example.com/share` with the URL of your share endpoint.


### PR DESCRIPTION
Follows @paulrobertlloyd's comment on #910.

#910 cleared the failing Prettier check by accepting what Prettier wanted, which split the `<link>` over three lines and made it self-closing. As noted there, that is the wrong way round: a void element needs no trailing slash, and having one [suggests a meaning it does not have](https://jakearchibald.com/2023/against-self-closing-tags-in-html/).

This restores the original one-line example and adds `<!-- prettier-ignore -->` above the block instead.

On why Prettier caught it at all: `.prettierignore` excludes `*.html`, but this is a fenced ```html block inside a Markdown file, so that pattern never applied and Prettier formatted it as embedded code. The ignore comment scopes the exclusion to this one block, leaving the rest of the file checked.

Verified with `git ls-files -z | xargs -0 npx prettier --check --ignore-unknown` — all tracked files pass.