### PR TITLE
fix(preset-eleventy): write posts where the advertised URL resolves

### DIFF
--- a/packages/preset-eleventy/lib/post-types.js
+++ b/packages/preset-eleventy/lib/post-types.js
@@ -12,7 +12,7 @@ export const getPostTypes = (postTypes) => {
     postTypes.set(type, {
       ...postTypes.get(type),
       post: {
-        path: `${collection}/{yyyy}-{MM}-{dd}-{slug}.md`,
+        path: `${collection}/{yyyy}/{MM}/{dd}/{slug}.md`,
         url: `${collection}/{yyyy}/{MM}/{dd}/{slug}`,
       },
       media: {

--- a/packages/preset-eleventy/test/index.js
+++ b/packages/preset-eleventy/test/index.js
@@ -35,7 +35,7 @@ describe("preset-eleventy", async () => {
 
   it("Gets publication post types", () => {
     assert.deepEqual(eleventy.postTypes.get("article").post, {
-      path: "articles/{yyyy}-{MM}-{dd}-{slug}.md",
+      path: "articles/{yyyy}/{MM}/{dd}/{slug}.md",
       url: "articles/{yyyy}/{MM}/{dd}/{slug}",
     });
   });

--- a/packages/preset-eleventy/test/unit/post-types.js
+++ b/packages/preset-eleventy/test/unit/post-types.js
@@ -16,7 +16,7 @@ describe("preset-eleventy/lib/post-types", () => {
     assert.deepEqual(result.get("article"), {
       name: "Journal post",
       post: {
-        path: "articles/{yyyy}-{MM}-{dd}-{slug}.md",
+        path: "articles/{yyyy}/{MM}/{dd}/{slug}.md",
         url: "articles/{yyyy}/{MM}/{dd}/{slug}",
       },
       media: {
@@ -26,7 +26,7 @@ describe("preset-eleventy/lib/post-types", () => {
     assert.deepEqual(result.get("note"), {
       name: "Micro post",
       post: {
-        path: "notes/{yyyy}-{MM}-{dd}-{slug}.md",
+        path: "notes/{yyyy}/{MM}/{dd}/{slug}.md",
         url: "notes/{yyyy}/{MM}/{dd}/{slug}",
       },
       media: {
@@ -36,12 +36,26 @@ describe("preset-eleventy/lib/post-types", () => {
     assert.deepEqual(result.get("puppy"), {
       name: "Puppy post",
       post: {
-        path: "puppies/{yyyy}-{MM}-{dd}-{slug}.md",
+        path: "puppies/{yyyy}/{MM}/{dd}/{slug}.md",
         url: "puppies/{yyyy}/{MM}/{dd}/{slug}",
       },
       media: {
         path: "media/puppies/{yyyy}/{MM}/{dd}/{filename}",
       },
     });
+  });
+
+  it("Advertises a post URL Eleventy serves from the same path", () => {
+    const result = getPostTypes(postTypes);
+
+    for (const type of ["article", "note", "puppy"]) {
+      const { path, url } = result.get(type).post;
+
+      assert.equal(
+        path,
+        `${url}.md`,
+        `${type}: Eleventy derives a page's URL from its input path, so a post written to \`${path}\` is not served at \`${url}\``,
+      );
+    }
   });
 });


### PR DESCRIPTION
Fixes half of #902 — the Eleventy half, which is fully solvable inside the preset.

### The problem

`getPostTypes` puts the date in the *filename* and advertises it as *path segments*:

```js
path: `${collection}/{yyyy}-{MM}-{dd}-{slug}.md`,
url:  `${collection}/{yyyy}/{MM}/{dd}/{slug}`,
```

Eleventy derives a page's URL from its input path and makes no such translation, so the URL returned in the `Location` header — and shown in the interface as "Post will be created at …" — doesn't resolve. The file is written correctly and the request succeeds, so nothing surfaces the problem. If syndication is enabled, the dead URL has already gone out.

### The change

One line: write the date as directories.

```diff
- path: `${collection}/{yyyy}-{MM}-{dd}-{slug}.md`,
+ path: `${collection}/{yyyy}/{MM}/{dd}/{slug}.md`,
   url: `${collection}/{yyyy}/{MM}/{dd}/{slug}`,
```

**The `url` template is untouched**, so the advertised URL scheme doesn't move — this only makes the file land where that URL already pointed.

### Verification

Eleventy 3, stock config, `dir.input = content`:

```
content/notes/2026/08/22/hello.md  →  _site/notes/2026/08/22/hello/index.html
```

which is exactly `notes/{yyyy}/{MM}/{dd}/{slug}`.

Test suite: `10 pass, 0 fail`. `eslint` and `prettier --check` clean on the changed files.

### On the test

The three existing expectations asserted the old path, so they move with the change. I've also added one that asserts the *property* the issue is about, rather than the literal strings:

```js
it("Advertises a post URL Eleventy serves from the same path", () => {
  for (const type of ["article", "note", "puppy"]) {
    const { path, url } = result.get(type).post;
    assert.equal(path, `${url}.md`, …);
  }
});
```

Nothing currently tests that `path` and `url` agree, which is why this was invisible. On the unfixed code it fails with:

```
article: Eleventy derives a page's URL from its input path, so a post written to
`articles/{yyyy}-{MM}-{dd}-{slug}.md` is not served at `articles/{yyyy}/{MM}/{dd}/{slug}`
  actual:   'articles/{yyyy}-{MM}-{dd}-{slug}.md'
  expected: 'articles/{yyyy}/{MM}/{dd}/{slug}.md'
```

### Worth knowing

- Existing sites keep their current URLs — old files stay where they are and continue to be served from there. Only newly written posts use the dated directories, and those are the ones whose advertised URL now resolves.
- Anyone who worked around this by configuring a permalink to match the flat filename would want to revisit that.
- `preset-jekyll` needs a different fix (front-matter `permalink`) and is left for a separate PR; `preset-hugo` is unaffected.
