### PR TITLE
refactor(util): let a collection cast its own ids (#821 spike)

### DIFF
--- a/packages/util/lib/mongodb.js
+++ b/packages/util/lib/mongodb.js
@@ -24,10 +24,15 @@ export const getCursor = async (collection, after, before, limit) => {
     sort: { _id: -1 },
   };
 
+  // The id arrives as a string from the query string, and only the collection
+  // knows what its own ids are. MongoDB collections have no `castId`, so they
+  // keep coercing to an ObjectId as before.
+  const castId = collection.castId ?? getObjectId;
+
   if (before) {
-    query._id = { $gt: getObjectId(before) };
+    query._id = { $gt: castId(before) };
   } else if (after) {
-    query._id = { $lt: getObjectId(after) };
+    query._id = { $lt: castId(after) };
   }
 
   const items = await collection.find(query, options).toArray();

--- a/packages/util/lib/sqlite.js
+++ b/packages/util/lib/sqlite.js
@@ -1,0 +1,203 @@
+/**
+ * SQLite-backed collection, spike for #821.
+ *
+ * Implements the subset of the MongoDB collection interface that Indiekit
+ * actually uses, so that code written against `addCollection` — `getCursor`
+ * included — runs unchanged. Documents are stored as JSON; `_id` is an
+ * autoincrement integer, which is monotonic in insertion order and so
+ * preserves the ordering `getCursor` relies on.
+ *
+ * Not a migration. The question this answers is whether the collection
+ * interface is a workable seam, not whether this is the right schema.
+ */
+
+/* eslint-disable unicorn/no-unsafe-sqlite-interpolation --
+   Only the table name is interpolated, and it is validated below. SQL
+   identifiers cannot be bound as parameters; every value still is. */
+import { DatabaseSync } from "node:sqlite";
+
+/**
+ * Operators seen in Indiekit's queries, mapped to SQL comparisons.
+ */
+const OPERATORS = {
+  $lt: "<",
+  $gt: ">",
+  $lte: "<=",
+  $gte: ">=",
+  $ne: "!=",
+};
+
+/**
+ * Translate one query field into a SQL fragment and its parameters.
+ * @param {string} field - Field name, dotted for nested properties
+ * @param {object|string|number|boolean} condition - Value or operator object
+ * @returns {{sql: string, parameters: Array}} Fragment and parameters
+ */
+const clause = (field, condition) => {
+  const column = field === "_id" ? "_id" : `json_extract(doc, '$.${field}')`;
+
+  if (condition === null || typeof condition !== "object") {
+    return { sql: `${column} = ?`, parameters: [condition] };
+  }
+
+  const parts = [];
+  const parameters = [];
+
+  for (const [operator, value] of Object.entries(condition)) {
+    if (operator === "$exists") {
+      parts.push(`${column} IS ${value ? "NOT NULL" : "NULL"}`);
+      continue;
+    }
+
+    if (operator === "$in") {
+      parts.push(`${column} IN (${value.map(() => "?").join(", ")})`);
+      parameters.push(...value);
+      continue;
+    }
+
+    const sql = OPERATORS[operator];
+    if (!sql) throw new Error(`Unsupported operator: ${operator}`);
+    parts.push(`${column} ${sql} ?`);
+    parameters.push(value);
+  }
+
+  return { sql: parts.join(" AND "), parameters };
+};
+
+/**
+ * Build a WHERE clause from a Mongo-style query object.
+ * @param {object} query - Query
+ * @returns {{where: string, parameters: Array}} SQL and parameters
+ */
+const buildWhere = (query = {}) => {
+  const parts = [];
+  const parameters = [];
+
+  for (const [field, condition] of Object.entries(query)) {
+    const { sql, parameters: values } = clause(field, condition);
+    parts.push(sql);
+    parameters.push(...values);
+  }
+
+  return {
+    where: parts.length > 0 ? `WHERE ${parts.join(" AND ")}` : "",
+    parameters,
+  };
+};
+
+/**
+ * Turn a stored row back into a document.
+ * @param {object} row - Row with `_id` and JSON `doc`
+ * @returns {object} Document
+ */
+const hydrate = (row) => ({ _id: row._id, ...JSON.parse(row.doc) });
+
+/**
+ * Open a SQLite-backed collection.
+ * @param {string} [filename] - Database file, or ":memory:"
+ * @param {string} [name] - Collection name
+ * @returns {object} Collection
+ */
+export const sqliteCollection = (filename = ":memory:", name = "items") => {
+  if (!/^\w+$/.test(name)) {
+    throw new Error(`Unsafe collection name: ${name}`);
+  }
+
+  const database = new DatabaseSync(filename);
+  database.exec(
+    `CREATE TABLE IF NOT EXISTS ${name} (_id INTEGER PRIMARY KEY AUTOINCREMENT, doc TEXT NOT NULL)`,
+  );
+
+  const collection = {
+    // Ids reach `getCursor` as strings from the query string; here they are
+    // integers. This is the one place the storage layer's id type leaks out.
+    castId: Number,
+
+    async insertOne(document) {
+      const rest = { ...document };
+      delete rest._id;
+      const { lastInsertRowid } = database
+        .prepare(`INSERT INTO ${name} (doc) VALUES (?)`)
+        .run(JSON.stringify(rest));
+      return { acknowledged: true, insertedId: Number(lastInsertRowid) };
+    },
+
+    find(query, options = {}) {
+      const { where, parameters } = buildWhere(query);
+      const direction = options.sort?._id === -1 ? "DESC" : "ASC";
+      const limit = options.limit ? `LIMIT ${Math.trunc(options.limit)}` : "";
+      const rows = database
+        .prepare(
+          `SELECT * FROM ${name} ${where} ORDER BY _id ${direction} ${limit}`,
+        )
+        .all(...parameters);
+
+      return {
+        async toArray() {
+          return rows.map((row) => hydrate(row));
+        },
+      };
+    },
+
+    async findOne(query) {
+      const { where, parameters } = buildWhere(query);
+      const row = database
+        .prepare(`SELECT * FROM ${name} ${where} LIMIT 1`)
+        .get(...parameters);
+      // eslint-disable-next-line unicorn/no-null -- matches the driver
+      return row ? hydrate(row) : null;
+    },
+
+    async countDocuments(query) {
+      const { where, parameters } = buildWhere(query);
+      const { count } = database
+        .prepare(`SELECT COUNT(*) AS count FROM ${name} ${where}`)
+        .get(...parameters);
+      return count;
+    },
+
+    /**
+     * Replace the first matching document, or insert it when none matches
+     * and `upsert` is set. Indiekit writes posts this way rather than with
+     * update operators, so this is the only write path besides `insertOne`.
+     * @param {object} query - Query
+     * @param {object} document - Replacement document
+     * @param {object} [options] - Options
+     * @param {boolean} [options.upsert] - Insert when nothing matched
+     * @returns {Promise<object>} Result
+     */
+    async replaceOne(query, document, options = {}) {
+      const existing = await collection.findOne(query);
+      const rest = { ...document };
+      delete rest._id;
+
+      if (existing) {
+        database
+          .prepare(`UPDATE ${name} SET doc = ? WHERE _id = ?`)
+          .run(JSON.stringify(rest), existing._id);
+        return { matchedCount: 1, modifiedCount: 1, upsertedCount: 0 };
+      }
+
+      if (!options.upsert) {
+        return { matchedCount: 0, modifiedCount: 0, upsertedCount: 0 };
+      }
+
+      const { insertedId } = await collection.insertOne(rest);
+      return {
+        matchedCount: 0,
+        modifiedCount: 0,
+        upsertedCount: 1,
+        upsertedId: insertedId,
+      };
+    },
+
+    async deleteOne(query) {
+      const existing = await collection.findOne(query);
+      if (!existing) return { deletedCount: 0 };
+      database.prepare(`DELETE FROM ${name} WHERE _id = ?`).run(existing._id);
+      return { deletedCount: 1 };
+    },
+  };
+
+  return collection;
+};

--- a/packages/util/test/unit/mongodb.js
+++ b/packages/util/test/unit/mongodb.js
@@ -43,6 +43,16 @@ describe("util/lib/mongodb", async () => {
     assert.equal(result.hasPrev, true);
   });
 
+  // `?after=` and `?before=` arrive as strings, never as ObjectId instances,
+  // so the cursor has to coerce them itself.
+  it("Gets pagination cursor after ID given as a string", async () => {
+    const afterItem = await items.findOne({ name: "baz" });
+    const result = await getCursor(items, String(afterItem._id));
+    // bar, foo
+    assert.equal(result.items.length, 2);
+    assert.equal(result.hasPrev, true);
+  });
+
   it("Gets pagination cursor after and before IDs", async () => {
     const after = await items.findOne({ name: "baz" });
     const before = await items.findOne({ name: "foo" });

--- a/packages/util/test/unit/sqlite-spike.js
+++ b/packages/util/test/unit/sqlite-spike.js
@@ -1,0 +1,126 @@
+import { strict as assert } from "node:assert";
+import { beforeEach, describe, it } from "node:test";
+
+import { getCursor } from "../../lib/mongodb.js";
+import { sqliteCollection } from "../../lib/sqlite.js";
+
+// The spike's question: does code written against the collection interface
+// run unchanged over SQLite? `getCursor` is imported from mongodb.js and is
+// not modified here — only the collection it is handed differs.
+describe("util/lib/sqlite — spike for #821", () => {
+  let collection;
+
+  beforeEach(async () => {
+    collection = sqliteCollection();
+    for (const name of ["one", "two", "three", "four", "five"]) {
+      await collection.insertOne({ name });
+    }
+  });
+
+  it("Stores and retrieves a document", async () => {
+    const item = await collection.findOne({ name: "three" });
+
+    assert.equal(item.name, "three");
+    assert.ok(item._id);
+  });
+
+  it("Counts with an operator query", async () => {
+    assert.equal(await collection.countDocuments({}), 5);
+    assert.equal(await collection.countDocuments({ _id: { $lt: 3 } }), 2);
+  });
+
+  it("Deletes", async () => {
+    assert.deepEqual(await collection.deleteOne({ name: "one" }), {
+      deletedCount: 1,
+    });
+    assert.equal(await collection.countDocuments({}), 4);
+  });
+
+  it("Runs unmodified getCursor: first page, newest first", async () => {
+    const cursor = await getCursor(collection, undefined, undefined, 2);
+
+    assert.deepEqual(
+      cursor.items.map((item) => item.name),
+      ["five", "four"],
+    );
+    assert.equal(cursor.hasNext, true, "more items exist below");
+    assert.equal(cursor.hasPrev, false, "nothing newer than the first page");
+  });
+
+  it("Runs unmodified getCursor: paging forward with `after`", async () => {
+    const first = await getCursor(collection, undefined, undefined, 2);
+    // `?after=` delivers a string, never the id's native type.
+    const second = await getCursor(
+      collection,
+      String(first.lastItem),
+      undefined,
+      2,
+    );
+
+    assert.deepEqual(
+      second.items.map((item) => item.name),
+      ["three", "two"],
+    );
+    assert.equal(second.hasPrev, true);
+  });
+
+  it("Runs unmodified getCursor: paging back with `before`", async () => {
+    const first = await getCursor(collection, undefined, undefined, 2);
+    const second = await getCursor(collection, first.lastItem, undefined, 2);
+    const back = await getCursor(
+      collection,
+      undefined,
+      String(second.firstItem),
+      2,
+    );
+
+    assert.deepEqual(
+      back.items.map((item) => item.name),
+      ["five", "four"],
+      "returns to the first page",
+    );
+  });
+
+  // Indiekit writes posts with `replaceOne`, never with update operators.
+  it("Replaces a matching document in place, keeping its id", async () => {
+    const target = await collection.findOne({ name: "three" });
+
+    const result = await collection.replaceOne(
+      { name: "three" },
+      { name: "three", edited: true },
+    );
+    const updated = await collection.findOne({ name: "three" });
+
+    assert.equal(result.matchedCount, 1);
+    assert.equal(updated._id, target._id, "id survives the replacement");
+    assert.equal(updated.edited, true);
+    assert.equal(await collection.countDocuments({}), 5, "no extra row");
+  });
+
+  it("Inserts on replaceOne only when asked to upsert", async () => {
+    const without = await collection.replaceOne(
+      { name: "absent" },
+      {
+        name: "absent",
+      },
+    );
+    assert.equal(without.matchedCount, 0);
+    assert.equal(await collection.countDocuments({}), 5, "nothing inserted");
+
+    const with_ = await collection.replaceOne(
+      { name: "absent" },
+      { name: "absent" },
+      { upsert: true },
+    );
+    assert.equal(with_.upsertedCount, 1);
+    assert.equal(await collection.countDocuments({}), 6);
+  });
+
+  it("Runs unmodified getCursor: empty collection", async () => {
+    const cursor = await getCursor(sqliteCollection(), undefined, undefined, 2);
+
+    assert.deepEqual(cursor.items, []);
+    assert.equal(cursor.hasNext, false);
+    assert.equal(cursor.hasPrev, false);
+  });
+});


### PR DESCRIPTION
Draft, as offered in #821 — opened so the branch is easier to read than a
tree link. Not a proposal to merge, and not a schema proposal.

## What it shows

`util/lib/sqlite.js` implements the collection interface on `node:sqlite`,
and upstream's `getCursor` runs against it **unmodified**. The collection
interface holds: `insertOne`, `find`, `findOne`, `countDocuments` and
cursor pagination all work without changes to their callers.

The one seam needed is id casting:

```js
const castId = collection.castId ?? getObjectId;
```

MongoDB collections have no `castId`, so they coerce to an `ObjectId`
exactly as before; the SQLite one supplies `Number`. No existing caller
changes.

## A test gap it uncovered

Deleting the `getObjectId` calls outright left the whole `util` suite and
145/145 in `endpoint-micropub` passing. The existing cursor tests pass
`after._id` — a live `ObjectId` — and `getObjectId(anObjectId)` is a no-op,
so nothing could detect the removal. Over HTTP `?after=` is always a
string, which is where the coercion does its work. The suite could not
tell working pagination from broken. The missing case is added here.

## Not covered

`aggregate` — the two `$toDate`/`$addFields` count pipelines. Everything
else in the spike is exercised by tests.

This does not touch the `_id`-in-URLs question, which I still think is the
actual decision to make.

Rebased onto `main` so the lint step reflects this branch rather than the
`endpoint-share` README formatting fixed in #910/#914.