### PR TITLE
fix(indiekit): derive application URL from each request

### DIFF
--- a/packages/indiekit/index.js
+++ b/packages/indiekit/index.js
@@ -41,6 +41,10 @@ export const Indiekit = class {
     this.config = config;
     this.package = package_;
 
+    // Captured before any request is served: `locals` middleware assigns to
+    // `config.application.url`, so the configured value has to be read here to
+    // stay distinguishable from one derived from a request.
+    this.applicationUrl = config.application?.url;
     this.collections = new Map();
     this.endpoints = new Set();
     this.installedPlugins = new Set();

--- a/packages/indiekit/lib/middleware/locals.js
+++ b/packages/indiekit/lib/middleware/locals.js
@@ -29,7 +29,7 @@ export const locals = (Indiekit) =>
       application.localeUsed = response.locals.getLocale();
       application.package = Indiekit.package;
       application.shortcuts = getShortcuts(Indiekit, response);
-      application.url ||= getUrl(request);
+      application.url = Indiekit.applicationUrl || getUrl(request);
 
       if (request.accepts("html")) {
         application.cssPath = `/assets/app-${cssHash}.css`;

--- a/packages/indiekit/test/unit/middleware/locals.js
+++ b/packages/indiekit/test/unit/middleware/locals.js
@@ -6,6 +6,14 @@ import { mockRequest, mockResponse } from "mock-req-res";
 import { defaultConfig } from "../../../config/defaults.js";
 import { locals } from "../../../lib/middleware/locals.js";
 
+const requestFrom = (host) =>
+  mockRequest({
+    accepts: () => false,
+    app: { locals: {} },
+    headers: { host },
+    protocol: "http",
+  });
+
 describe("indiekit/lib/middleware/locals", () => {
   it("Exposes configuration to frontend templates", async () => {
     const request = mockRequest({ session: { token: "token" } });
@@ -28,6 +36,40 @@ describe("indiekit/lib/middleware/locals", () => {
     );
 
     assert.equal(request.app.locals.error instanceof Error, true);
+  });
+
+  it("Derives application URL from each request", async () => {
+    const Indiekit = {
+      config: { application: {} },
+      collections: new Map(),
+      endpoints: new Set(),
+      installedPlugins: new Set(),
+      package: {},
+    };
+    const response = mockResponse({ locals: { getLocale: () => "en" } });
+
+    await locals(Indiekit)(requestFrom("127.0.0.1:3000"), response, mock.fn());
+    await locals(Indiekit)(requestFrom("localhost:3000"), response, mock.fn());
+
+    // A long-lived `application` object must not let the first request fix the
+    // host used by every response after it.
+    assert.equal(Indiekit.config.application.url, "http://localhost:3000");
+  });
+
+  it("Prefers a configured application URL over the request", async () => {
+    const Indiekit = {
+      applicationUrl: "https://server.example",
+      config: { application: {} },
+      collections: new Map(),
+      endpoints: new Set(),
+      installedPlugins: new Set(),
+      package: {},
+    };
+    const response = mockResponse({ locals: { getLocale: () => "en" } });
+
+    await locals(Indiekit)(requestFrom("127.0.0.1:3000"), response, mock.fn());
+
+    assert.equal(Indiekit.config.application.url, "https://server.example");
   });
 
   it("Throws error exposing configuration to frontend templates", async () => {


### PR DESCRIPTION
Fixes #906.

`Indiekit.applicationUrl`, as you suggested.

```js
// index.js — read where it cannot yet have been overwritten
this.applicationUrl = config.application?.url;

// lib/middleware/locals.js
application.url = Indiekit.applicationUrl || getUrl(request);
```

Capturing it in the constructor is the part that does the work. `application` **is** `config.application`, so the middleware writing `application.url` destroys the value it later needs to consult — which is how `||=` lost the ability to tell "configured" from "cached from whoever asked first". A copy taken before any request arrives keeps them distinguishable, and the request-derived case now behaves like `collections`, `localeUsed`, `package` and `shortcuts` on the lines above it.

### The impact is wider than the issue title suggests

I only framed this as missing CSS and JS. Tracing the readers, `application.url` also builds the IndieAuth `client_id` and `redirect_uri`:

```js
// lib/indieauth.js:87-89
const applicationUrl = getCanonicalUrl(application.url);
const { href: clientId }    = new URL("id", applicationUrl);
const { href: callbackUrl } = new URL("session/auth", applicationUrl);
```

So a latched host doesn't only render an unstyled page — it sends the sign-in flow's `client_id` and `redirect_uri` to a different origin from the one being browsed, where the session cookie isn't shared. Same root cause, but it reaches authentication, not just presentation. It also feeds the JF2 feed URL (`lib/controllers/feed.js:3`) and image-resize URLs (`frontend/lib/filters/url.js:66`).

Worth knowing rather than discovering later; happy to note it on the issue too.

### Tests

Two, both written against the old code first and watched fail:

- **"Derives application URL from each request"** — two requests with different `Host` headers; asserts the second reflects its own host. Failed with `actual: 'http://127.0.0.1:3000'` where the second request sent `localhost:3000`, which is the bug reproduced in a unit test.
- **"Prefers a configured application URL over the request"** — asserts the configured value survives, so the reverse-proxy behaviour documented in `configuration/application.md` is kept.

`packages/indiekit`: **111 pass, 0 fail** across 46 suites. `prettier --check` clean, `eslint` clean on the changed files.

One note on coverage: I didn't add a test for the constructor assignment itself. Nothing currently constructs `Indiekit` in the unit tests, and its siblings `this.locale` and `this.mongodbUrl` are unasserted for the same reason — the behaviour is covered at the middleware boundary instead. Say if you'd rather have one and I'll add it.

### Naming

`lib/indieauth.js:87` already declares a local `const applicationUrl`. Different scope, no conflict, but flagging it since it's the same name a few files away.

`eslint` also reports a pre-existing `import-x/order` error in `packages/indiekit/bin/cli.js`, untouched by this branch.
