### PR TITLE
fix(endpoint-micropub): reject unconfigured post type on update, delete and undelete

### DIFF
--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -11,6 +11,21 @@ import { getPostTemplateProperties, renderPath } from "./utils.js";
 
 const debug = makeDebug("indiekit:endpoint-micropub:post-data");
 
+/**
+ * Get post type configuration, which must include a post path
+ * @param {object} postTypes - Publication post types
+ * @param {string} type - Post type
+ * @returns {object} Post type configuration
+ */
+const getTypeConfig = (postTypes, type) => {
+  const typeConfig = postTypes[type];
+  if (!typeConfig?.post?.path) {
+    throw IndiekitError.notImplemented(type);
+  }
+
+  return typeConfig;
+};
+
 export const postData = {
   /**
    * Create post data
@@ -40,10 +55,7 @@ export const postData = {
     properties["post-type"] = type;
 
     // Get post type configuration
-    const typeConfig = postTypes[type];
-    if (!typeConfig || !typeConfig.post?.path) {
-      throw IndiekitError.notImplemented(type);
-    }
+    const typeConfig = getTypeConfig(postTypes, type);
 
     // Post paths
     const path = await renderPath(
@@ -150,7 +162,7 @@ export const postData = {
 
     // Post type
     const type = getPostType(postTypes, properties);
-    const typeConfig = postTypes[type];
+    const typeConfig = getTypeConfig(postTypes, type);
     properties["post-type"] = type;
 
     // Post paths
@@ -220,7 +232,7 @@ export const postData = {
 
     // Post type
     const type = properties["post-type"];
-    const typeConfig = postTypes[type];
+    const typeConfig = getTypeConfig(postTypes, type);
 
     // Post paths
     const path = await renderPath(
@@ -262,7 +274,7 @@ export const postData = {
 
     // Post type
     const type = properties["post-type"];
-    const typeConfig = postTypes[type];
+    const typeConfig = getTypeConfig(postTypes, type);
 
     // Post paths
     const path = await renderPath(

--- a/packages/endpoint-micropub/test/unit/post-data.js
+++ b/packages/endpoint-micropub/test/unit/post-data.js
@@ -168,4 +168,31 @@ describe("endpoint-micropub/lib/post-data", async () => {
       },
     );
   });
+  it("Throws error updating post data for non-configured post type", async () => {
+    publication.postTypes = {};
+
+    await assert.rejects(
+      postData.update(application, publication, url, {
+        add: { category: ["baz"] },
+      }),
+      { message: "note" },
+    );
+  });
+
+  it("Throws error deleting post data for non-configured post type", async () => {
+    publication.postTypes = {};
+
+    await assert.rejects(postData.delete(application, publication, url), {
+      message: "note",
+    });
+  });
+
+  it("Throws error undeleting post data for non-configured post type", async () => {
+    await postData.delete(application, publication, url);
+    publication.postTypes = {};
+
+    await assert.rejects(postData.undelete(application, publication, url), {
+      message: "note",
+    });
+  });
 });


### PR DESCRIPTION
Fixes #928.

- `getTypeConfig(postTypes, type)` throws `notImplemented` when the type has no `post.path`; `create()`, `update()`, `delete()` and `undelete()` all use it, so the four actions answer 501 consistently.
- Unit tests for the three previously unguarded actions; before the fix each fails with `TypeError: Cannot read properties of undefined (reading 'post')`.

Touches the same file as #905 but different hunks.

Verified locally: `node --test packages/endpoint-micropub/test/**/*.js` 149/149, eslint and prettier clean.