### PR TITLE
fix: report an invalid syndicator URL instead of throwing

### DIFF
--- a/packages/endpoint-micropub/lib/config.js
+++ b/packages/endpoint-micropub/lib/config.js
@@ -19,12 +19,22 @@ export const getConfig = (application, publication) => {
     "syndicate-to",
   ];
 
-  // Ensure syndication targets use absolute URLs
-  const syndicateTo = syndicationTargets.map((target) => target.info);
-  for (const info of syndicateTo) {
-    if (info.service && info.service.photo) {
+  // Ensure syndication targets use absolute URLs. A target whose `info`
+  // can’t be read is left out rather than failing the whole query.
+  const syndicateTo = [];
+  for (const target of syndicationTargets) {
+    let info;
+    try {
+      info = target.info;
+    } catch {
+      continue;
+    }
+
+    if (info.service?.photo) {
       info.service.photo = new URL(info.service.photo, url).href;
     }
+
+    syndicateTo.push(info);
   }
 
   return {

--- a/packages/endpoint-micropub/lib/jf2.js
+++ b/packages/endpoint-micropub/lib/jf2.js
@@ -316,7 +316,13 @@ export const getSyndicateToProperty = (properties, syndicationTargets) => {
   const property = [];
 
   for (const target of syndicationTargets) {
-    const { uid } = target.info;
+    let uid;
+    try {
+      ({ uid } = target.info);
+    } catch {
+      // A target whose `info` can’t be read can’t be syndicated to
+      continue;
+    }
 
     if (requested.includes(uid)) {
       property.push(uid);

--- a/packages/endpoint-micropub/test/unit/config.js
+++ b/packages/endpoint-micropub/test/unit/config.js
@@ -34,6 +34,31 @@ describe("endpoint-micropub/lib/config", () => {
     assert.equal(result["syndicate-to"][0].user.name, "@username");
   });
 
+  it("Omits syndication target whose info can’t be read", () => {
+    const application = {
+      url: "https://endpoint.example",
+    };
+    const mastodon = new MastodonSyndicator({
+      url: "https://mastodon.example",
+      user: "username",
+    });
+    const broken = {
+      get info() {
+        throw new Error("Valid server URL required");
+      },
+    };
+    const publication = {
+      categories: [],
+      channels: {},
+      postTypes: config.publication.postTypes,
+      syndicationTargets: [broken, mastodon],
+    };
+    const result = getConfig(application, publication);
+
+    assert.equal(result["syndicate-to"].length, 1);
+    assert.equal(result["syndicate-to"][0].service.name, "Mastodon");
+  });
+
   it("Filters a list", () => {
     const result = queryConfig(list, { filter: "web" });
 

--- a/packages/endpoint-micropub/test/unit/jf2.js
+++ b/packages/endpoint-micropub/test/unit/jf2.js
@@ -519,4 +519,18 @@ describe("endpoint-micropub/lib/jf2", () => {
 
     assert.equal(result.name, "What I had for lunch");
   });
+
+  it("Skips syndication target whose info can’t be read getting syndicate-to property", () => {
+    const uid = "https://mastodon.example/@username";
+    const result = getSyndicateToProperty({ "mp-syndicate-to": [uid] }, [
+      {
+        get info() {
+          throw new Error("Valid server URL required");
+        },
+      },
+      { info: { uid } },
+    ]);
+
+    assert.deepEqual(result, [uid]);
+  });
 });

--- a/packages/endpoint-posts/lib/utils.js
+++ b/packages/endpoint-posts/lib/utils.js
@@ -192,17 +192,27 @@ export const getSyndicateToItems = (
   publication,
   shouldCheckTargets = false,
 ) => {
-  return publication.syndicationTargets.map((target) => ({
-    label: target.info.service.name,
-    ...(target?.info?.error
-      ? {
-          disabled: true,
-          hint: target?.info?.error || false,
-        }
-      : {
-          hint: target?.info.uid,
-          value: target?.info.uid,
-          ...(shouldCheckTargets && { checked: target.options.checked }),
-        }),
-  }));
+  return publication.syndicationTargets.map((target) => {
+    // A target whose `info` can’t be read is shown disabled, with the reason
+    let info;
+    try {
+      info = target.info;
+    } catch (error) {
+      info = { error: error.message, service: { name: target.name } };
+    }
+
+    return {
+      label: info.service?.name,
+      ...(info.error
+        ? {
+            disabled: true,
+            hint: info.error,
+          }
+        : {
+            hint: info.uid,
+            value: info.uid,
+            ...(shouldCheckTargets && { checked: target.options.checked }),
+          }),
+    };
+  });
 };

--- a/packages/endpoint-posts/test/unit/utils.js
+++ b/packages/endpoint-posts/test/unit/utils.js
@@ -279,4 +279,24 @@ describe("endpoint-posts/lib/utils", () => {
     assert.equal(result[1].label, "Internet Archive");
     assert.equal(result[1].value, undefined);
   });
+
+  it("Disables syndication target whose info can’t be read", () => {
+    const result = getSyndicateToItems({
+      syndicationTargets: [
+        ...publication.syndicationTargets,
+        {
+          name: "Broken syndicator",
+          get info() {
+            throw new Error("Valid server URL required");
+          },
+        },
+      ],
+    });
+
+    assert.equal(result.length, 3);
+    assert.equal(result[2].disabled, true);
+    assert.equal(result[2].hint, "Valid server URL required");
+    assert.equal(result[2].label, "Broken syndicator");
+    assert.equal(result[2].value, undefined);
+  });
 });

--- a/packages/syndicator-bluesky/index.js
+++ b/packages/syndicator-bluesky/index.js
@@ -50,23 +50,29 @@ export default class BlueskySyndicator {
   }
 
   get info() {
-    const username = this.options?.handle?.replace("@", "");
-    const url = new URL(this.options.profileUrl).href + "/" + username;
-
     const info = {
       checked: this.options.checked,
-      name: this.#user,
-      uid: url,
       service: {
         name: "Bluesky",
         photo: "/assets/@indiekit-syndicator-bluesky/icon.svg",
-        url: this.#serviceUrl,
-      },
-      user: {
-        name: this.#user,
-        url,
       },
     };
+
+    if (
+      !URL.canParse(this.options.profileUrl) ||
+      !URL.canParse(this.options.serviceUrl)
+    ) {
+      info.error = "Valid profile URL required";
+      return info;
+    }
+
+    const username = this.options?.handle?.replace("@", "");
+    const url = this.#profileUrl + "/" + username;
+
+    info.name = this.#user;
+    info.uid = url;
+    info.service.url = this.#serviceUrl;
+    info.user = { name: this.#user, url };
 
     if (!this.#user) {
       info.error = "User identifier required";

--- a/packages/syndicator-bluesky/test/index.js
+++ b/packages/syndicator-bluesky/test/index.js
@@ -69,6 +69,16 @@ describe("syndicator-bluesky", async () => {
     assert.equal(result.info.error, "User identifier required");
   });
 
+  it("Returns error information if profile URL invalid", () => {
+    const result = new BlueskySyndicator({
+      handle: "alice.test",
+      password: "password",
+      profileUrl: "",
+    });
+
+    assert.equal(result.info.error, "Valid profile URL required");
+  });
+
   it("Initiates plug-in", async () => {
     const indiekit = await Indiekit.initialize({ config: {} });
     bluesky.init(indiekit);

--- a/packages/syndicator-mastodon/index.js
+++ b/packages/syndicator-mastodon/index.js
@@ -44,24 +44,27 @@ export default class MastodonSyndicator {
   }
 
   get info() {
+    const info = {
+      checked: this.options.checked,
+      service: {
+        name: "Mastodon",
+        photo: "/assets/@indiekit-syndicator-mastodon/icon.svg",
+      },
+    };
+
+    if (!URL.canParse(this.options.url)) {
+      info.error = "Valid server URL required";
+      return info;
+    }
+
     const user = this.#user;
     const url = this.#url;
     const uid = `${url.protocol}//${path.join(url.hostname, user)}`;
 
-    const info = {
-      checked: this.options.checked,
-      name: `${user}@${url.hostname}`,
-      uid,
-      service: {
-        name: "Mastodon",
-        photo: "/assets/@indiekit-syndicator-mastodon/icon.svg",
-        url: url.href,
-      },
-      user: {
-        name: user,
-        url: uid,
-      },
-    };
+    info.name = `${user}@${url.hostname}`;
+    info.uid = uid;
+    info.service.url = url.href;
+    info.user = { name: user, url: uid };
 
     if (!user) {
       info.error = "User name required";

--- a/packages/syndicator-mastodon/test/index.js
+++ b/packages/syndicator-mastodon/test/index.js
@@ -45,6 +45,16 @@ describe("syndicator-mastodon", () => {
     assert.equal(result.info.error, "User name required");
   });
 
+  it("Returns error information if server URL invalid", () => {
+    const result = new MastodonSyndicator({
+      accessToken: "token",
+      url: "",
+      user: "username",
+    });
+
+    assert.equal(result.info.error, "Valid server URL required");
+  });
+
   it("Gets plug-in installation prompts", () => {
     assert.equal(
       mastodon.prompts[0].message,


### PR DESCRIPTION
Fixes #930.

- `syndicator-mastodon` and `syndicator-bluesky`: `info` returns `error: "Valid server URL required"` / `"Valid profile URL required"` for an unparseable URL, alongside `checked` and `service`, instead of throwing `TypeError: Invalid URL`.
- `endpoint-micropub`: `getConfig` leaves out a target whose `info` throws; `getSyndicateToProperty` skips it. Guards for third-party syndicators that still throw.
- `endpoint-posts`: `getSyndicateToItems` shows such a target disabled with the error message as its hint, using the plug-in’s `name` as label. `info` is now read once per target.
- Tests in all four packages; each fails before the fix (`TypeError: Invalid URL` in the syndicators, an uncaught throw in the consumers).

Verified locally: syndicator-mastodon 38/38, syndicator-bluesky 40/40, endpoint-micropub 148/148, endpoint-posts 33/33; eslint and prettier clean.