### PR TITLE
fix(endpoint-syndicate): ignore syndication values that aren’t URLs

### DIFF
--- a/packages/endpoint-syndicate/lib/utils.js
+++ b/packages/endpoint-syndicate/lib/utils.js
@@ -40,6 +40,11 @@ export const getPostData = async (postsCollection, url) => {
  */
 export const hasSyndicationUrl = (syndicatedUrls, syndicateTo) => {
   return syndicatedUrls.some((url) => {
+    // `syndication` is stored as given, so may hold values that aren’t URLs
+    if (!URL.canParse(url)) {
+      return false;
+    }
+
     const { origin } = new URL(url);
     return syndicateTo.includes(origin);
   });

--- a/packages/endpoint-syndicate/test/integration/200-syndicates-url-with-malformed-syndication.js
+++ b/packages/endpoint-syndicate/test/integration/200-syndicates-url-with-malformed-syndication.js
@@ -1,0 +1,49 @@
+import { strict as assert } from "node:assert";
+import { after, before, describe, it } from "node:test";
+
+import { testDatabase } from "@indiekit-test/database";
+import { mockAgent } from "@indiekit-test/mock-agent";
+import { testServer } from "@indiekit-test/server";
+import { testToken } from "@indiekit-test/token";
+import supertest from "supertest";
+
+await mockAgent("endpoint-syndicate");
+const { client, mongoServer, mongoUri } = await testDatabase();
+const server = await testServer({
+  application: { mongodbUrl: mongoUri },
+  plugins: ["@indiekit/syndicator-mastodon"],
+});
+const request = supertest.agent(server);
+
+describe("endpoint-syndicate POST /syndicate", () => {
+  before(async () => {
+    await request
+      .post("/micropub")
+      .auth(testToken(), { type: "bearer" })
+      .set("accept", "application/json")
+      .send("h=entry")
+      .send("name=foobar")
+      .send("mp-syndicate-to=https://mastodon.example/@username")
+      .send("syndication=twitter");
+  });
+
+  it("Syndicates a URL despite a syndication value that isn’t a URL", async () => {
+    const result = await request
+      .post("/syndicate")
+      .set("accept", "application/json")
+      .query({ source_url: "https://website.example/notes/foobar/" })
+      .query({ token: testToken() });
+
+    assert.equal(result.status, 200);
+    assert.equal(
+      result.body.success_description,
+      "Post updated at https://website.example/notes/foobar/",
+    );
+  });
+
+  after(async () => {
+    await client.close();
+    await mongoServer.stop();
+    server.close((error) => process.exit(error ? 1 : 0));
+  });
+});

--- a/packages/endpoint-syndicate/test/unit/utils.js
+++ b/packages/endpoint-syndicate/test/unit/utils.js
@@ -126,4 +126,17 @@ describe("endpoint-syndicate/lib/token", () => {
       false,
     );
   });
+
+  it("Ignores syndication values that aren’t URLs", () => {
+    const syndication = ["twitter", "https://mastodon.example/@username/67890"];
+
+    assert.equal(
+      hasSyndicationUrl(syndication, "https://mastodon.example"),
+      true,
+    );
+    assert.equal(
+      hasSyndicationUrl(["twitter"], "https://mastodon.example"),
+      false,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #932.

- `hasSyndicationUrl` skips values that `URL.canParse` rejects instead of throwing.
- Unit test: a non-URL value alongside a real one still matches the real one; a lone non-URL value is `false`. Fails on `main` with `TypeError: Invalid URL`.
- Integration test: a post carrying `syndication=twitter` still syndicates and answers `Post updated at …`. Fails on `main` with 500.

Verified locally: `node --test packages/endpoint-syndicate/test/**/*.js` 27/27, eslint and prettier clean.