### PR TITLE
fix(endpoint-webmention-io): cope with authors without a photo or a valid URL

### DIFF
--- a/packages/endpoint-webmention-io/lib/controllers/webmentions.js
+++ b/packages/endpoint-webmention-io/lib/controllers/webmentions.js
@@ -35,6 +35,7 @@ export const webmentionsController = (options) => {
         headers: {
           accept: "application/json",
         },
+        signal: AbortSignal.timeout(15_000),
       });
 
       if (!endpointResponse.ok) {
@@ -60,9 +61,9 @@ export const webmentionsController = (options) => {
           item.description = { html };
           item.published ||= item["wm-received"];
           item.user = {
-            avatar: { src: item.author.photo },
+            ...(item.author?.photo && { avatar: { src: item.author.photo } }),
             name: getAuthorName(item),
-            url: item.author.url,
+            url: item.author?.url,
           };
 
           return item;

--- a/packages/endpoint-webmention-io/lib/utils.js
+++ b/packages/endpoint-webmention-io/lib/utils.js
@@ -50,11 +50,17 @@ export const getMentionTitle = (jf2) => {
  * @returns {string} Mention title
  */
 export const getAuthorName = (jf2) => {
-  let url = jf2.author?.url || jf2.url;
-  url = new URL(url);
-  url = url.hostname + url.pathname.replace(/\/$/, "");
+  if (jf2.author?.name) {
+    return jf2.author.name;
+  }
 
-  return jf2.author?.name || url;
+  const url = jf2.author?.url || jf2.url;
+  if (!URL.canParse(url)) {
+    return url;
+  }
+
+  const { hostname, pathname } = new URL(url);
+  return hostname + pathname.replace(/\/$/, "");
 };
 
 /**

--- a/packages/endpoint-webmention-io/test/integration/200-webmentions.js
+++ b/packages/endpoint-webmention-io/test/integration/200-webmentions.js
@@ -25,5 +25,15 @@ describe("endpoint-webmention-io GET /webmentions", () => {
     assert.equal(result.includes("This looks interesting"), true);
   });
 
+  it("Omits avatar if author has no photo", async () => {
+    const response = await request
+      .get("/webmentions")
+      .set("cookie", testCookie());
+    const dom = new JSDOM(response.text);
+    const result = dom.window.document.querySelectorAll("img.avatar");
+
+    assert.equal(result.length, 0);
+  });
+
   after(() => server.close());
 });

--- a/packages/endpoint-webmention-io/test/unit/utils.js
+++ b/packages/endpoint-webmention-io/test/unit/utils.js
@@ -55,6 +55,17 @@ describe("endpoint-webmention-io/lib/utils", () => {
         "another.example/likes/1",
       );
     });
+
+    await t.test("from author name if author URL isn’t a URL", () => {
+      assert.equal(
+        getAuthorName({ author: { name: "Paul", url: "paul" } }),
+        "Paul",
+      );
+    });
+
+    await t.test("from author URL if it isn’t a URL", () => {
+      assert.equal(getAuthorName({ author: { url: "paul" } }), "paul");
+    });
   });
 
   it("Normalises paragraphs", async (t) => {


### PR DESCRIPTION
Fixes #934.

- `avatar` is only set when the author has a `photo`; the fixture author has none, and the list rendered `<img class="avatar" src="">` for it.
- `getAuthorName` returns `author.name` before touching the URL, and returns the raw value when it doesn’t parse, instead of throwing `TypeError: Invalid URL`.
- The webmention.io fetch gets `AbortSignal.timeout(15_000)`; a timeout reaches the error handler like any other fetch failure.
- Tests: integration test asserts no `img.avatar` (fails on `main`: 1); two unit cases for non-URL author values (fail on `main` with `Invalid URL`).

Verified locally: `node --test packages/endpoint-webmention-io/test/**/*.js` 16/16, eslint and prettier clean.