### PR TITLE
fix(frontend): serve cached page on a slow network, skip cross-origin and auth requests

### DIFF
--- a/packages/frontend/lib/serviceworker.js
+++ b/packages/frontend/lib/serviceworker.js
@@ -123,48 +123,68 @@ addEventListener("message", (event) => {
 addEventListener("fetch", (event) => {
   const request = event.request;
 
-  // Ignore non-GET requests
-  if (request.method !== "GET") {
+  // Ignore cross-origin and non-GET requests. Cross-origin images (avatars,
+  // for example) are left to the browser: their opaque responses can’t be
+  // inspected and each is padded to several megabytes when cached.
+  const requestUrl = new URL(request.url);
+  if (requestUrl.origin !== location.origin || request.method !== "GET") {
     return;
   }
 
-  const retrieveFromCache = caches.match(request);
+  // Never cache authentication and session pages. Cached responses would
+  // show a stale signed-in state, and their URLs carry one-time codes.
+  if (/^\/(auth|session)(?:\/|$)/.test(requestUrl.pathname)) {
+    event.respondWith(fetch(request));
+    return;
+  }
 
   // For HTML requests, try network, fall back to cache, else show offline page
   if (
     request.mode === "navigate" ||
-    request.headers.get("Accept").includes("text/html")
+    (request.headers.get("Accept") || "").includes("text/html")
   ) {
     event.respondWith(
       (async () => {
-        // CHECK CACHE
-        const timer = setTimeout(async () => {
-          const responseFromCache = await retrieveFromCache;
-          if (responseFromCache) {
-            return responseFromCache;
-          }
-        }, timeout);
+        const responseFromCache = await caches.match(request);
+        const responseFromNetwork = (async () => {
+          const preloadResponse = await Promise.resolve(event.preloadResponse);
+          return preloadResponse || (await fetch(request));
+        })();
 
         try {
-          const preloadResponse = await Promise.resolve(event.preloadResponse);
-          const responseFromPreloadOrFetch =
-            preloadResponse || (await fetch(request));
+          // Only give up on a slow network when there is a cached copy to
+          // show instead; otherwise waiting beats showing the offline page
+          const response = responseFromCache
+            ? await Promise.race([
+                responseFromNetwork,
+                new Promise((resolve, reject) => {
+                  setTimeout(
+                    () => reject(new Error("Network timeout")),
+                    timeout,
+                  );
+                }),
+              ])
+            : await responseFromNetwork;
 
           // NETWORK
           // Save a copy of page to pages cache
-          clearTimeout(timer);
-          const copy = responseFromPreloadOrFetch.clone();
+          const copy = response.clone();
           const pagesCache = await caches.open(pagesCacheName);
           await pagesCache.put(request, copy);
 
-          return responseFromPreloadOrFetch;
+          return response;
         } catch (error) {
           console.error(error, request);
 
           // CACHE or OFFLINE PAGE
-          clearTimeout(timer);
-          const responseFromCache = await retrieveFromCache;
-          return responseFromCache || caches.match("/offline");
+          return (
+            responseFromCache ||
+            (await caches.match("/offline")) ||
+            new Response("Offline", {
+              status: 503,
+              headers: { "Content-Type": "text/plain" },
+            })
+          );
         }
       })(),
     );
@@ -176,7 +196,7 @@ addEventListener("fetch", (event) => {
   event.respondWith(
     (async () => {
       try {
-        const responseFromCache = await retrieveFromCache;
+        const responseFromCache = await caches.match(request);
 
         if (responseFromCache) {
           // CACHE
@@ -206,6 +226,11 @@ addEventListener("fetch", (event) => {
             },
           });
         }
+
+        return new Response("Network error", {
+          status: 503,
+          headers: { "Content-Type": "text/plain" },
+        });
       }
     })(),
   );

--- a/packages/frontend/test/unit/serviceworker.js
+++ b/packages/frontend/test/unit/serviceworker.js
@@ -1,0 +1,195 @@
+import { strict as assert } from "node:assert";
+import { afterEach, before, describe, it, mock } from "node:test";
+
+// Service worker globals
+const handlers = {};
+const stores = new Map();
+const state = { fetch: undefined, cacheMatchCount: 0 };
+
+const location = new URL("https://indiekit.test/");
+const cacheKey = (request) =>
+  typeof request === "string"
+    ? new URL(request, location).href
+    : new URL(request.url, location).href;
+
+Object.assign(globalThis, {
+  location,
+  registration: {},
+  skipWaiting: () => {},
+  clients: {
+    claim: async () => {},
+    matchAll: async () => [],
+  },
+  addEventListener: (type, handler) => {
+    handlers[type] ||= [];
+    handlers[type].push(handler);
+  },
+  fetch: (...arguments_) => state.fetch(...arguments_),
+  caches: {
+    async open(name) {
+      if (!stores.has(name)) {
+        stores.set(name, new Map());
+      }
+
+      const store = stores.get(name);
+      return {
+        async addAll(urls) {
+          for (const url of urls) {
+            store.set(cacheKey(url), new Response(`cached ${url}`));
+          }
+        },
+        async delete(request) {
+          return store.delete(cacheKey(request));
+        },
+        async keys() {
+          return [...store.keys()].map((url) => new Request(url));
+        },
+        async match(request) {
+          return store.get(cacheKey(request))?.clone();
+        },
+        async put(request, response) {
+          store.set(cacheKey(request), response);
+        },
+      };
+    },
+    async match(request) {
+      state.cacheMatchCount++;
+      const key = cacheKey(request);
+      for (const store of stores.values()) {
+        if (store.has(key)) {
+          return store.get(key).clone();
+        }
+      }
+    },
+    async keys() {
+      return [...stores.keys()];
+    },
+    async delete(name) {
+      return stores.delete(name);
+    },
+  },
+});
+
+await import("../../lib/serviceworker.js");
+
+/**
+ * Dispatch a fetch event to the service worker
+ * @param {string} url - Request URL
+ * @param {object} [options] - Options
+ * @param {string} [options.accept] - Accept header
+ * @returns {Promise<Response>|undefined} Response passed to `respondWith`
+ */
+const dispatchFetch = (url, { accept = "text/html" } = {}) => {
+  let result;
+  const event = {
+    request: new Request(new URL(url, location), { headers: { accept } }),
+    preloadResponse: undefined,
+    respondWith(response) {
+      result = response;
+    },
+  };
+
+  for (const handler of handlers.fetch) {
+    handler(event);
+  }
+
+  return result;
+};
+
+/**
+ * Await a response, failing if none arrives within a second of real time
+ * @param {Promise<Response>} result - Response promise
+ * @returns {Promise<Response>} Response
+ */
+const settle = (result) =>
+  Promise.race([
+    result,
+    new Promise((resolve, reject) => {
+      AbortSignal.timeout(1000).addEventListener("abort", () =>
+        reject(new Error("No response")),
+      );
+    }),
+  ]);
+
+describe("frontend/lib/serviceworker", () => {
+  before(async () => {
+    mock.method(console, "error", () => {});
+    const assetCache = await caches.open("assets-APP_VERSION");
+    await assetCache.addAll(["/offline"]);
+  });
+
+  afterEach(() => {
+    stores.get("pages")?.clear();
+    stores.get("images")?.clear();
+    state.cacheMatchCount = 0;
+    mock.timers.reset();
+  });
+
+  it("Serves cached page when network is slow", async () => {
+    const pagesCache = await caches.open("pages");
+    await pagesCache.put(
+      new Request(new URL("/posts", location)),
+      new Response("cached page"),
+    );
+    state.fetch = () => new Promise(() => {});
+    mock.timers.enable({ apis: ["setTimeout"] });
+
+    const result = dispatchFetch("/posts");
+    // Let the worker reach its timeout before advancing the clock
+    await new Promise((resolve) => setImmediate(resolve));
+    mock.timers.tick(5000);
+    const response = await settle(result);
+
+    assert.equal(await response.text(), "cached page");
+  });
+
+  it("Waits for network when page not cached", async () => {
+    state.fetch = async () => new Response("network page");
+
+    const response = await settle(dispatchFetch("/posts"));
+
+    assert.equal(await response.text(), "network page");
+  });
+
+  it("Serves offline page when network fails and page not cached", async () => {
+    state.fetch = async () => {
+      throw new TypeError("Failed to fetch");
+    };
+
+    const response = await settle(dispatchFetch("/posts"));
+
+    assert.equal(await response.text(), "cached /offline");
+  });
+
+  it("Ignores cross-origin requests", () => {
+    state.fetch = async () => new Response("avatar");
+
+    const result = dispatchFetch("https://other.example/avatar.jpg", {
+      accept: "image/*",
+    });
+
+    assert.equal(result, undefined);
+  });
+
+  it("Never caches or serves auth and session pages from cache", async () => {
+    state.fetch = async () => new Response("login page");
+
+    const response = await settle(dispatchFetch("/session/login"));
+
+    assert.equal(await response.text(), "login page");
+    assert.equal(state.cacheMatchCount, 0);
+    assert.equal(stores.get("pages")?.size ?? 0, 0);
+  });
+
+  it("Responds with an error when a non-HTML request fails", async () => {
+    state.fetch = async () => {
+      throw new TypeError("Failed to fetch");
+    };
+
+    const response = await settle(
+      dispatchFetch("/assets/app.js", { accept: "*/*" }),
+    );
+
+    assert.equal(response.status, 503);
+  });
+});


### PR DESCRIPTION
Fixes #936.

- HTML requests look the page up in the cache first and race the network against the 5 s timeout only when a cached copy exists; without one the worker keeps waiting rather than showing the offline page early. The cache-or-offline fallback ends in a 503 `Response` rather than `undefined`.
- Cross-origin and non-GET requests return early, so the browser handles them and no opaque responses are cached.
- `/auth` and `/session` (endpoint-auth’s and the session’s default mount paths) are always fetched from the network and never cached.
- Non-HTML requests that fail respond with a 503 instead of `undefined`.
- New `test/unit/serviceworker.js` stubs `caches`, `clients`, `fetch` and `location`, imports the worker, and dispatches fetch events; the timeout case uses `mock.timers`. Four of the six tests fail on `main`.

Left as they were: stale-while-revalidate for assets and any client-notification on update.

Verified locally: `node --test packages/frontend/test/**/*.js` 28/28, eslint and prettier clean.