### PR TITLE
fix(endpoint-micropub): count other posts of a type when rendering the n token

### DIFF
--- a/packages/endpoint-micropub/lib/post-type-count.js
+++ b/packages/endpoint-micropub/lib/post-type-count.js
@@ -8,7 +8,7 @@ export const postTypeCount = {
    * @returns {Promise<object>} Post count
    */
   async get(postsCollection, properties) {
-    if (!postsCollection || !postsCollection.count()) {
+    if (!postsCollection) {
       console.warn("No database configuration provided");
       console.info(
         "See https://getindiekit.com/configuration/application/#mongodburl",

--- a/packages/endpoint-micropub/lib/post-type-count.js
+++ b/packages/endpoint-micropub/lib/post-type-count.js
@@ -19,7 +19,6 @@ export const postTypeCount = {
 
     // Post type
     const postType = properties["post-type"];
-    const postUid = properties.uid;
     const startDate = new Date(new Date(properties.published).toDateString());
     const endDate = new Date(startDate);
     endDate.setDate(endDate.getDate() + 1);
@@ -34,12 +33,18 @@ export const postTypeCount = {
         },
         {
           $match: {
-            _id: getObjectId(postUid),
             "properties.post-type": postType,
             convertedDate: {
               $gte: startDate,
               $lt: endDate,
             },
+            // Don’t count the post being updated
+            ...(properties.uid && {
+              _id: { $ne: getObjectId(properties.uid) },
+            }),
+            ...(properties.url && {
+              "properties.url": { $ne: properties.url },
+            }),
           },
         },
       ])

--- a/packages/endpoint-micropub/test/unit/post-type-count.js
+++ b/packages/endpoint-micropub/test/unit/post-type-count.js
@@ -7,18 +7,30 @@ import { postTypeCount } from "../../lib/post-type-count.js";
 
 const { client, database, mongoServer } = await testDatabase();
 const posts = database.collection("posts");
+const published = new Date();
 
-describe("endpoint-media/lib/post-type-count", () => {
+describe("endpoint-micropub/lib/post-type-count", () => {
   before(async () => {
-    await posts.insertOne({
-      properties: {
-        type: "entry",
-        "post-type": "note",
-        published: new Date(),
-        name: "Foo",
-        url: "https://website.example/foo",
+    await posts.insertMany([
+      {
+        properties: {
+          type: "entry",
+          "post-type": "note",
+          published,
+          name: "Foo",
+          url: "https://website.example/foo",
+        },
       },
-    });
+      {
+        properties: {
+          type: "entry",
+          "post-type": "note",
+          published,
+          name: "Bar",
+          url: "https://website.example/bar",
+        },
+      },
+    ]);
   });
 
   after(async () => {
@@ -26,17 +38,46 @@ describe("endpoint-media/lib/post-type-count", () => {
     await mongoServer.stop();
   });
 
-  it("Counts the number of posts of a given type", async () => {
+  it("Counts posts of a given type published on the same day", async () => {
+    const result = await postTypeCount.get(posts, {
+      type: "entry",
+      published,
+      "post-type": "note",
+    });
+
+    assert.equal(result, 2);
+  });
+
+  it("Doesn’t count the post being updated, by its ID", async () => {
     const post = await posts.findOne({});
     const result = await postTypeCount.get(posts, {
       uid: post._id.toString(),
       type: "entry",
-      published: new Date(),
-      name: "Bar",
-      "mp-slug": "bar",
+      published,
       "post-type": "note",
     });
 
     assert.equal(result, 1);
+  });
+
+  it("Doesn’t count the post being updated, by its URL", async () => {
+    const result = await postTypeCount.get(posts, {
+      type: "entry",
+      published,
+      "post-type": "note",
+      url: "https://website.example/foo",
+    });
+
+    assert.equal(result, 1);
+  });
+
+  it("Doesn’t count posts of another type", async () => {
+    const result = await postTypeCount.get(posts, {
+      type: "entry",
+      published,
+      "post-type": "photo",
+    });
+
+    assert.equal(result, 0);
   });
 });


### PR DESCRIPTION
Fixes #746.

`postTypeCount.get` matched `_id` *equal to* the post's `uid` (310a3515 replaced the earlier `"properties.url": { $ne }`), and nothing sets `uid` on create, so the aggregate matched nothing: the count was always 0 and `{n}` always 1, which is why a second note on the same day collides with the first.

- The match now excludes the post being updated, by `uid` when present and by `properties.url` when present, and otherwise counts every post of that type published the same day.
- Unit test rewritten with two seeded notes: counts 2 on create; 1 when excluding by id; 1 when excluding by URL; 0 for another type. The first and third cases fail on `main` (`0 !== 2`, `0 !== 1`). The previous single test asserted the buggy result (1 for the only post, which was the post itself).

Verified locally: `node --test packages/endpoint-micropub/test/**/*.js` 149/149 on two consecutive runs, eslint and prettier clean.