### PR TITLE
fix(endpoint-syndicate): syndicate posts awaiting syndication oldest first

### DIFF
--- a/packages/endpoint-syndicate/lib/utils.js
+++ b/packages/endpoint-syndicate/lib/utils.js
@@ -2,7 +2,7 @@
  * Get post data
  * @param {object} postsCollection - Posts database collection
  * @param {string} url - URL of existing post (optional)
- * @returns {Promise<object>} Post data for given URL else recently published post
+ * @returns {Promise<object>} Post data for given URL else oldest post awaiting syndication
  */
 export const getPostData = async (postsCollection, url) => {
   if (url) {
@@ -15,7 +15,8 @@ export const getPostData = async (postsCollection, url) => {
   // deleted once every target has returned a URL, and replaced with the
   // targets that failed otherwise. Posts already syndicated to some of their
   // targets are therefore still awaiting the rest, and `syndicateToTargets`
-  // skips the ones already done.
+  // skips the ones already done. Oldest first, so a backlog is syndicated in
+  // the order it was published.
   const items = await postsCollection
     .find({
       "properties.mp-syndicate-to": {
@@ -25,7 +26,7 @@ export const getPostData = async (postsCollection, url) => {
         $ne: "draft",
       },
     })
-    .sort({ "properties.published": -1 })
+    .sort({ "properties.published": 1 })
     .limit(1)
     .toArray();
 

--- a/packages/endpoint-syndicate/test/unit/utils.js
+++ b/packages/endpoint-syndicate/test/unit/utils.js
@@ -67,6 +67,28 @@ describe("endpoint-syndicate/lib/token", () => {
     assert.equal(result.properties["mp-syndicate-to"], "https://bsky.example/");
   });
 
+  it("Gets oldest post awaiting syndication first", async () => {
+    const collection = database.collection("posts-awaiting-syndication");
+    await collection.insertMany(
+      [
+        "2023-01-26T12:00:00Z",
+        "2023-01-26T10:00:00Z",
+        "2023-01-26T11:00:00Z",
+      ].map((published, index) => ({
+        properties: {
+          type: "entry",
+          "mp-syndicate-to": "https://mastodon.example/",
+          published,
+          url: `https://website.example/post/${index}`,
+        },
+      })),
+    );
+
+    const result = await getPostData(collection, "");
+
+    assert.equal(result.properties.published, "2023-01-26T10:00:00Z");
+  });
+
   it("Gets syndication target for syndication URL", () => {
     const targets = [{ info: { uid: "https://mastodon.example" } }];
     const result = getSyndicationTarget(targets, "https://mastodon.example");


### PR DESCRIPTION
Fixes #584.

`getPostData` selected the pending post to syndicate with `.sort({ "properties.published": -1 })`, so after a deployment outage a backlog drained newest first, one post per `/syndicate` call. Sorting ascending syndicates it in publication order.

- One-token change in `lib/utils.js`, plus the JSDoc and comment.
- Unit test seeds three pending posts published at 12:00, 10:00 and 11:00 and expects the 10:00 one; on `main` it gets 12:00.

This is the smallest fix; #581's separate-queue design would supersede it. Verified locally: `node --test packages/endpoint-syndicate/test/**/*.js` 26/26, eslint and prettier clean.