### PR TITLE
docs: say how to quote PASSWORD_SECRET for Docker Compose and direnv

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -129,6 +129,9 @@ Follow these steps to create this value:
 3. enter the password you want to use and click ‘Generate password secret’.
 4. copy the value shown and set it for `PASSWORD_SECRET` in your environment variables.
 
+> [!WARNING]
+> The generated value contains `$` characters, which Docker Compose and direnv read as the start of a variable. In an `.env` or `.envrc` file, wrap the value in single quotes (`PASSWORD_SECRET='…'`); in `compose.yml`, write each `$` as `$$`. Otherwise everything after the third `$` is silently dropped and you will not be able to sign in. The `.env` file created by `npm create indiekit` is already quoted.
+
 #### `MONGO_URL` (optional)
 
 A [MongoDB connection string](https://www.mongodb.com/docs/manual/reference/connection-string/) if you want to use features that require a database.


### PR DESCRIPTION
Fixes #634.

Adds a warning under the `PASSWORD_SECRET` steps in Get started. As you suggested there, it documents rather than escapes: single quotes in `.env` and `.envrc`, `$$` in `compose.yml`, and a note that the `.env` scaffolded by `npm create indiekit` is already single-quoted (5eafd281).

Verified with Docker Compose 2.40.3: a single-quoted bcrypt hash passes through intact; unquoted or double-quoted, everything between the third `$` and the next `.` is dropped, with Compose warning that a variable named after that fragment is not set.