### PR TITLE
fix(endpoint-micropub): throw a clear error reading posts without a database

### DIFF
--- a/packages/endpoint-micropub/lib/controllers/action.js
+++ b/packages/endpoint-micropub/lib/controllers/action.js
@@ -132,11 +132,16 @@ export const actionController = async (request, response, next) => {
         response.locals.__("NotFoundError.record", error.message),
       );
     } else if (error.name === "NotImplementedError") {
-      // Hoist unsupported post type error to controller to localise response
-      nextError = IndiekitError.notImplemented(
-        response.locals.__("NotImplementedError.postType", error.message),
-        { uri: "https://getindiekit.com/configuration/post-types" },
-      );
+      // Hoist not implemented errors to controller to localise response
+      nextError =
+        error.cause === "database"
+          ? IndiekitError.notImplemented(
+              response.locals.__("NotImplementedError.database"),
+            )
+          : IndiekitError.notImplemented(
+              response.locals.__("NotImplementedError.postType", error.message),
+              { uri: "https://getindiekit.com/configuration/post-types" },
+            );
     }
 
     return next(nextError);

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -90,6 +90,12 @@ export const postData = {
     const query = { "properties.url": url };
     const postsCollection = application?.collections?.get("posts");
 
+    if (!postsCollection) {
+      throw IndiekitError.notImplemented(
+        "Reading, updating, deleting and restoring posts requires a database",
+      );
+    }
+
     const data = await postsCollection.findOne(query);
     if (!data) {
       throw IndiekitError.notFound(url);

--- a/packages/endpoint-micropub/lib/post-data.js
+++ b/packages/endpoint-micropub/lib/post-data.js
@@ -91,9 +91,8 @@ export const postData = {
     const postsCollection = application?.collections?.get("posts");
 
     if (!postsCollection) {
-      throw IndiekitError.notImplemented(
-        "Reading, updating, deleting and restoring posts requires a database",
-      );
+      // Localised by the controller; `cause` tells it which case this is
+      throw IndiekitError.notImplemented("database", { cause: "database" });
     }
 
     const data = await postsCollection.findOne(query);

--- a/packages/endpoint-micropub/test/integration/501-action-delete-no-database.js
+++ b/packages/endpoint-micropub/test/integration/501-action-delete-no-database.js
@@ -1,0 +1,31 @@
+import { strict as assert } from "node:assert";
+import { after, describe, it } from "node:test";
+
+import { testServer } from "@indiekit-test/server";
+import { testToken } from "@indiekit-test/token";
+import supertest from "supertest";
+
+const server = await testServer();
+const request = supertest.agent(server);
+
+describe("endpoint-micropub POST /micropub", () => {
+  it("Returns 501 error deleting post without a database", async () => {
+    const result = await request
+      .post("/micropub")
+      .auth(testToken(), { type: "bearer" })
+      .set("accept", "application/json")
+      .send({
+        action: "delete",
+        url: "https://website.example/foo",
+      });
+
+    assert.equal(result.status, 501);
+    assert.equal(
+      result.body.error_description,
+      "This feature requires a database",
+    );
+    assert.equal(result.body.error_uri, undefined);
+  });
+
+  after(() => server.close());
+});

--- a/packages/endpoint-micropub/test/unit/post-data.js
+++ b/packages/endpoint-micropub/test/unit/post-data.js
@@ -65,6 +65,16 @@ describe("endpoint-micropub/lib/post-data", async () => {
     assert.equal(result.properties.url, url);
   });
 
+  it("Throws reading post data without a database", async () => {
+    await assert.rejects(
+      postData.read({ ...application, collections: undefined }, url),
+      {
+        message:
+          "Reading, updating, deleting and restoring posts requires a database",
+      },
+    );
+  });
+
   it("Updates post by adding properties", async () => {
     const operation = { add: { syndication: ["https://website.example"] } };
     const result = await postData.update(

--- a/packages/endpoint-micropub/test/unit/post-data.js
+++ b/packages/endpoint-micropub/test/unit/post-data.js
@@ -68,10 +68,7 @@ describe("endpoint-micropub/lib/post-data", async () => {
   it("Throws reading post data without a database", async () => {
     await assert.rejects(
       postData.read({ ...application, collections: undefined }, url),
-      {
-        message:
-          "Reading, updating, deleting and restoring posts requires a database",
-      },
+      { cause: "database", message: "database" },
     );
   });
 


### PR DESCRIPTION
Fixes #904. Supersedes #905, re-opened from a `getindiekit/indiekit` branch so CI runs the tests (a fork-head PR stops at the Localazy step); same commits, rebased on current `main`, with the change you asked for there applied.

`postData.read()` looked up the posts collection with optional chaining, then called `findOne()` on it unguarded. With no database configured this threw a `TypeError` instead of a meaningful error. `update()`, `delete()` and `undelete()` all call `read()` first, so one missing guard affected four operations, while `create()` already guards the same lookup — which is why publishing works without a database and editing does not.

### Changes

- `lib/post-data.js` — `read()` throws `notImplemented("database", { cause: "database" })` from the model layer, the same shape as the post-type guard.
- `lib/controllers/action.js` — the hoist that localises not-implemented errors maps `cause === "database"` to `NotImplementedError.database` (“This feature requires a database”), and everything else to the post-type message with its documentation link, so the two cases no longer share a label. No new strings.
- Tests: `501-action-delete-no-database.js` (integration: `action=delete` without a database → 501, the database message, no `error_uri`; on `main` it is a `TypeError` 500) and the unit test for `read()`.

Verified locally: `node --test packages/endpoint-micropub/test/**/*.js` 148/148, eslint and prettier clean.