### PR TITLE
fix(syndicator-bluesky): thread replies to Bluesky posts

### DIFF
--- a/packages/syndicator-bluesky/lib/bluesky.js
+++ b/packages/syndicator-bluesky/lib/bluesky.js
@@ -63,6 +63,23 @@ export class Bluesky {
   }
 
   /**
+   * Get reply reference for a Bluesky post
+   *
+   * A reply records both its parent and the root of the thread; replying to a
+   * reply keeps that reply’s root.
+   * @param {string} postUrl - URL of post being replied to
+   * @returns {Promise<import("@atproto/api").AppBskyFeedPost.ReplyRef>} Reply reference
+   * @see {@link https://docs.bsky.app/docs/tutorials/creating-a-post#replies}
+   */
+  async getReplyRef(postUrl) {
+    const post = await this.getPost(postUrl);
+    const parent = { uri: post.uri, cid: post.cid };
+    const root = post.value.reply?.root || parent;
+
+    return { root, parent };
+  }
+
+  /**
    * Post a like
    * @param {string} postUrl - URL of post to like
    * @returns {Promise<string>} Bluesky post URL
@@ -149,9 +166,10 @@ export class Bluesky {
    * Post a post
    * @param {object} richText - Rich text
    * @param {object} [images] - Images
+   * @param {object} [reply] - Reply reference
    * @returns {Promise<string>} Bluesky post URL
    */
-  async postPost(richText, images) {
+  async postPost(richText, images, reply) {
     const client = await this.#client();
 
     /**
@@ -162,6 +180,7 @@ export class Bluesky {
       text: richText.text,
       facets: richText.facets,
       createdAt: new Date().toISOString(),
+      ...(reply && { reply }),
       ...(images?.length > 0 && {
         embed: {
           $type: "app.bsky.embed.images",
@@ -275,6 +294,13 @@ export class Bluesky {
       return;
     }
 
+    // Thread reply to a Bluesky post
+    const inReplyTo = properties["in-reply-to"];
+    const reply =
+      inReplyTo && isSameOrigin(inReplyTo, this.profileUrl)
+        ? await this.getReplyRef(inReplyTo)
+        : undefined;
+
     const text = getPostText(
       properties,
       this.includePermalink,
@@ -282,6 +308,6 @@ export class Bluesky {
     );
     const richText = await createRichText(client, text);
 
-    return this.postPost(richText, images);
+    return this.postPost(richText, images, reply);
   }
 }

--- a/packages/syndicator-bluesky/test/unit/bluesky.js
+++ b/packages/syndicator-bluesky/test/unit/bluesky.js
@@ -195,6 +195,54 @@ describe("syndicator-bluesky/lib/bluesky", () => {
     assert.match(result, BLUESKY_POST_URL);
   });
 
+  it("Posts a threaded reply to a Bluesky post", async () => {
+    const result = await bluesky.post(
+      {
+        content: { html: "<p>Me too!</p>" },
+        "in-reply-to": postUrl,
+        "post-type": "reply",
+      },
+      me,
+    );
+    const parent = await bluesky.getPost(postUrl);
+    const reply = await bluesky.getPost(result);
+
+    assert.match(result, BLUESKY_POST_URL);
+    assert.equal(reply.value.reply.parent.uri, parent.uri);
+    assert.equal(reply.value.reply.root.uri, parent.uri);
+  });
+
+  it("Roots a reply to a reply at the original post", async () => {
+    const firstReplyUrl = await bluesky.post(
+      { content: { html: "<p>Me too!</p>" }, "in-reply-to": postUrl },
+      me,
+    );
+    const result = await bluesky.post(
+      { content: { html: "<p>And me.</p>" }, "in-reply-to": firstReplyUrl },
+      me,
+    );
+    const original = await bluesky.getPost(postUrl);
+    const first = await bluesky.getPost(firstReplyUrl);
+    const second = await bluesky.getPost(result);
+
+    assert.equal(second.value.reply.parent.uri, first.uri);
+    assert.equal(second.value.reply.root.uri, original.uri);
+  });
+
+  it("Posts a reply to a URL on another site without threading", async () => {
+    const result = await bluesky.post(
+      {
+        content: { html: "<p>Me too!</p>" },
+        "in-reply-to": "https://another.example/post/1",
+      },
+      me,
+    );
+    const post = await bluesky.getPost(result);
+
+    assert.match(result, BLUESKY_POST_URL);
+    assert.equal(post.value.reply, undefined);
+  });
+
   it("Posts a post to Bluesky", async () => {
     const result = await bluesky.post(
       {


### PR DESCRIPTION
Fixes #946.

- `Bluesky#getReplyRef(postUrl)` fetches the post with the existing `getPost()` and returns `{ root, parent }`, using the parent’s own `reply.root` when the parent is a reply.
- `post()` resolves it when `in-reply-to` is on the configured profile origin (`isSameOrigin`, as `repost-of` and `like-of` already do) and passes it to `postPost()`, which sets `reply` on the record. `in-reply-to` pointing elsewhere is unchanged.
- Tests on the `@atproto/dev-env` test network: a reply to Bob’s post has `reply.parent` and `reply.root` equal to that post; a reply to that reply has `parent` = the first reply and `root` = the original; a reply to a URL on another site has no `reply`. The first two fail on `main`.

Verified locally: `node --test packages/syndicator-bluesky/test/**/*.js` 50/50, eslint and prettier clean.