### PR TITLE
feat(endpoint-files): upload several files at once

### DIFF
--- a/helpers/mock-agent/endpoint-files.js
+++ b/helpers/mock-agent/endpoint-files.js
@@ -73,7 +73,8 @@ export function mockClient() {
           location: photoOrigin,
         },
       },
-    );
+    )
+    .persist();
 
   // Upload file to external media endpoint (Unauthorized)
   agent
@@ -82,7 +83,19 @@ export function mockClient() {
       path: "/",
       method: "POST",
     })
-    .reply(401, {});
+    .reply(401, {})
+    .persist();
+
+  // Upload files to external media endpoint (first succeeds, second fails)
+  const partialOrigin = "https://partial-post-upload.example";
+  agent
+    .get(partialOrigin)
+    .intercept({ path: "/", method: "POST" })
+    .reply(201, { success: "create", success_description: photoOrigin });
+  agent
+    .get(partialOrigin)
+    .intercept({ path: "/", method: "POST" })
+    .reply(400, { error: "invalid_request", error_description: "Too big" });
 
   // Delete file at external media endpoint
   agent

--- a/packages/endpoint-files/lib/controllers/form.js
+++ b/packages/endpoint-files/lib/controllers/form.js
@@ -46,28 +46,53 @@ export const formController = {
       throw new Error(response.locals.__("files.error.file.empty"));
     }
 
-    const file = Array.isArray(request.files.file)
-      ? request.files.file[0]
-      : request.files.file;
-    const { data, name } = file;
-    const formData = new FormData();
-    formData.append("file", new Blob([new Uint8Array(data)]), name);
+    // One file or several; upload in turn, as a content store may not
+    // accept concurrent writes
+    const files = [request.files.file].flat();
+    const uploaded = [];
+    let lastError;
 
-    try {
-      const mediaResponse = await endpoint.post(
-        mediaEndpoint,
-        accessToken,
-        formData,
+    for (const { data, name } of files) {
+      const formData = new FormData();
+      formData.append("file", new Blob([new Uint8Array(data)]), name);
+
+      try {
+        uploaded.push(
+          await endpoint.post(mediaEndpoint, accessToken, formData),
+        );
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    if (uploaded.length === 0) {
+      response.status(
+        lastError instanceof IndiekitError ? lastError.status : 500,
       );
-      const message = encodeURIComponent(mediaResponse.success_description);
-
-      response.redirect(`${request.baseUrl}?success=${message}`);
-    } catch (error) {
-      response.status(error instanceof IndiekitError ? error.status : 500);
-      response.render("file-form", {
+      return response.render("file-form", {
         title: response.locals.__("files.upload.title"),
-        error,
+        error: lastError,
       });
     }
+
+    let message;
+    if (files.length === 1) {
+      message = uploaded[0].success_description;
+    } else if (uploaded.length === files.length) {
+      message = response.locals.__(
+        "files.upload.success",
+        String(files.length),
+      );
+    } else {
+      message = response.locals.__(
+        "files.upload.partial",
+        String(uploaded.length),
+        String(files.length),
+      );
+    }
+
+    response.redirect(
+      `${request.baseUrl}?success=${encodeURIComponent(message)}`,
+    );
   },
 };

--- a/packages/endpoint-files/locales/en.json
+++ b/packages/endpoint-files/locales/en.json
@@ -23,7 +23,9 @@
     "title": "Files",
     "upload": {
       "action": "Upload file",
-      "title": "Upload a new file"
+      "title": "Upload a new file",
+      "success": "%s files uploaded",
+      "partial": "%s of %s files uploaded"
     },
     "form": {
       "submit": "Upload",

--- a/packages/endpoint-files/test/integration/200-get-upload.js
+++ b/packages/endpoint-files/test/integration/200-get-upload.js
@@ -18,6 +18,7 @@ describe("endpoint-files GET /files/:uid/delete", () => {
     const result = dom.window.document.querySelector("title").textContent;
 
     assert.equal(result, "Upload a new file - Test configuration");
+    assert.ok(dom.window.document.querySelector("input[name=file][multiple]"));
   });
 
   after(() => server.close());

--- a/packages/endpoint-files/test/integration/302-post-upload-partial.js
+++ b/packages/endpoint-files/test/integration/302-post-upload-partial.js
@@ -9,22 +9,12 @@ import supertest from "supertest";
 
 await mockAgent("endpoint-files");
 const server = await testServer({
-  application: { mediaEndpoint: "https://media-endpoint.example" },
+  application: { mediaEndpoint: "https://partial-post-upload.example" },
 });
 const request = supertest.agent(server);
 
 describe("endpoint-files POST /files/upload", () => {
-  it("Uploads file and redirects to files page", async () => {
-    const result = await request
-      .post("/files/upload")
-      .set("cookie", testCookie())
-      .attach("file", getFixture("file-types/photo.jpg", false), "photo.jpg");
-
-    assert.equal(result.status, 302);
-    assert.match(result.text, /Found. Redirecting to \/files\?success/);
-  });
-
-  it("Uploads several files and redirects to files page", async () => {
+  it("Uploads the files it can and says how many", async () => {
     const result = await request
       .post("/files/upload")
       .set("cookie", testCookie())
@@ -34,7 +24,7 @@ describe("endpoint-files POST /files/upload", () => {
     assert.equal(result.status, 302);
     assert.equal(
       decodeURIComponent(result.headers.location),
-      "/files?success=2 files uploaded",
+      "/files?success=1 of 2 files uploaded",
     );
   });
 

--- a/packages/endpoint-files/test/integration/401-post-upload-unauthorized.js
+++ b/packages/endpoint-files/test/integration/401-post-upload-unauthorized.js
@@ -31,5 +31,15 @@ describe("endpoint-files POST /files/upload", () => {
     assert.match(result, /Unauthorized/);
   });
 
+  it("Returns 401 error uploading several files", async () => {
+    const response = await request
+      .post("/files/upload")
+      .set("cookie", testCookie({ scope: "profile" }))
+      .attach("file", getFixture("file-types/photo.jpg", false), "photo.jpg")
+      .attach("file", getFixture("file-types/photo.jpg", false), "photo2.jpg");
+
+    assert.equal(response.status, 401);
+  });
+
   after(() => server.close());
 });

--- a/packages/endpoint-files/views/file-form.njk
+++ b/packages/endpoint-files/views/file-form.njk
@@ -6,6 +6,9 @@
     type: "file",
     value: fieldData("file").value,
     label: __("files.form.file.label"),
+    attributes: {
+      multiple: true
+    },
     errorMessage: fieldData("file").errorMessage
   }) | indent(2) }}
 {% endblock %}


### PR DESCRIPTION
Fixes #952.

- `views/file-form.njk`: the file input gets `multiple`. No script, no new component.
- `lib/controllers/form.js`: `request.files.file` is normalised to an array and each file is posted to the media endpoint in turn (sequential on purpose: a Git-backed store may reject concurrent writes, #792). One file keeps today's message from the media endpoint; several report `files.upload.success` (“%s files uploaded”); a mix reports `files.upload.partial` (“%s of %s files uploaded”); when nothing was uploaded the form re-renders with the last error, as it does now for one file.
- `locales/en.json`: the two new strings, English only.
- Mock agent: upload intercepts persist so a test can upload twice; a `partial-post-upload.example` origin answers 201 then 400.
- Tests: the upload page has a `multiple` input; two files redirect with “2 files uploaded”; one of two failing redirects with “1 of 2 files uploaded”; two files against the 401 endpoint render the error. Three of these fail on `main`.

Verified locally: `node --test packages/endpoint-files/test/**/*.js` 18/18, eslint and prettier clean.