### PR TITLE
feat: add page post type

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -186,6 +186,10 @@ const sidebarPlugins = [
         link: "/plugins/post-types/note",
       },
       {
+        text: "Page",
+        link: "/plugins/post-types/page",
+      },
+      {
         text: "Photo",
         link: "/plugins/post-types/photo",
       },

--- a/docs/api/add-post-type.md
+++ b/docs/api/add-post-type.md
@@ -39,7 +39,7 @@ new Indiekit.addPostType(type, options);
 
     The value must match one of the field names provided in `config.fields`.
 
-    In most cases this option is required. Only post types already defined in the [post type discovery][] algorithm (`article`, `event`, `like`, `note`, `photo`, `repost`, `rsvp`, `reply` and `video`) can ignore this option.
+    In most cases this option is required. Only post types already defined in the [post type discovery][] algorithm (`article`, `event`, `like`, `note`, `photo`, `repost`, `rsvp`, `reply` and `video`), or post types using their own vocabulary (an `h` value other than `entry`), can ignore this option.
 
 `validationSchemas`
 : An object containing [Schema](#postfield) objects.
@@ -196,7 +196,7 @@ In the above example, because both `ingredient` and `instructions` are new field
 
 When receiving Micropub requests from other clients, Indiekit needs to know what post type to assign given the properties in that request. The [post type discovery] algorithm handles this for common post types, but new post types need to be identified using another means.
 
-Indicating which property a post type will have that others won’t is a way of achieving this.
+Indicating which property a post type will have that others won’t is a way of achieving this. A post type that uses its own Microformats vocabulary, such as `h-recipe`, is identified by that vocabulary instead, so it doesn’t need a discovery property.
 
 The property to use for discovery can be added to `config.discovery`, for example:
 

--- a/docs/plugins/post-types/index.md
+++ b/docs/plugins/post-types/index.md
@@ -16,6 +16,7 @@ A [post type](../../concepts#post-type) provides an interface for creating and e
 - [Audio](audio.md) `@indiekit/post-type-audio`
 - [Event](event.md) `@indiekit/post-type-event`
 - [Jam](jam.md) `@indiekit/post-type-jam`
+- [Page](page.md) `@indiekit/post-type-page`
 - [Repost](repost.md) `@indiekit/post-type-repost`
 - [RSVP](rsvp.md) `@indiekit/post-type-rsvp`
 - [Video](video.md) `@indiekit/post-type-video`

--- a/docs/plugins/post-types/page.md
+++ b/docs/plugins/post-types/page.md
@@ -1,0 +1,1 @@
+<!--@include: ../../../packages/post-type-page/README.md-->

--- a/package-lock.json
+++ b/package-lock.json
@@ -4687,6 +4687,10 @@
       "resolved": "packages/post-type-note",
       "link": true
     },
+    "node_modules/@indiekit/post-type-page": {
+      "resolved": "packages/post-type-page",
+      "link": true
+    },
     "node_modules/@indiekit/post-type-photo": {
       "resolved": "packages/post-type-photo",
       "link": true
@@ -29368,6 +29372,14 @@
     },
     "packages/post-type-note": {
       "name": "@indiekit/post-type-note",
+      "version": "1.0.0-beta.28",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24.17"
+      }
+    },
+    "packages/post-type-page": {
+      "name": "@indiekit/post-type-page",
       "version": "1.0.0-beta.28",
       "license": "MIT",
       "engines": {

--- a/packages/endpoint-micropub/lib/post-type-discovery.js
+++ b/packages/endpoint-micropub/lib/post-type-discovery.js
@@ -11,6 +11,13 @@ export const getPostType = (postTypes, properties) => {
     return properties.type;
   }
 
+  // A post type with its own vocabulary is identified by that vocabulary
+  for (const [type, { h }] of Object.entries(postTypes)) {
+    if (h && h !== "entry" && h === properties.type) {
+      return type;
+    }
+  }
+
   // Types defined in Post Type Discovery specification
   const basePostTypes = new Map([
     ["rsvp", "rsvp"],

--- a/packages/endpoint-micropub/test/integration/202-action-create-page.js
+++ b/packages/endpoint-micropub/test/integration/202-action-create-page.js
@@ -1,0 +1,31 @@
+import { strict as assert } from "node:assert";
+import { after, describe, it } from "node:test";
+
+import { mockAgent } from "@indiekit-test/mock-agent";
+import { testServer } from "@indiekit-test/server";
+import { testToken } from "@indiekit-test/token";
+import supertest from "supertest";
+
+await mockAgent("endpoint-micropub");
+const server = await testServer({
+  plugins: ["@indiekit/post-type-page", "@indiekit/preset-eleventy"],
+  usePostTypes: false,
+});
+const request = supertest.agent(server);
+
+describe("endpoint-micropub POST /micropub", () => {
+  it("Creates page at root URL", async () => {
+    const result = await request
+      .post("/micropub")
+      .auth(testToken(), { type: "bearer" })
+      .set("accept", "application/json")
+      .send("h=page")
+      .send("name=About")
+      .send("content=All+about+me.");
+
+    assert.equal(result.status, 202);
+    assert.equal(result.headers.location, "https://website.example/about");
+  });
+
+  after(() => server.close());
+});

--- a/packages/endpoint-micropub/test/unit/post-type-discovery.js
+++ b/packages/endpoint-micropub/test/unit/post-type-discovery.js
@@ -7,7 +7,48 @@ describe("endpoint-media/lib/post-type-discovery", () => {
   const postTypes = {
     audio: { discovery: "audio" },
     bookmark: { discovery: "bookmark-of" },
+    page: { h: "page" },
+    recipe: { h: "recipe", discovery: "ingredient" },
   };
+
+  it("Discovers post type from its vocabulary", () => {
+    const result = getPostType(postTypes, {
+      type: "page",
+      name: "About",
+      content: "All about me.",
+    });
+
+    assert.equal(result, "page");
+  });
+
+  it("Discovers post type from its vocabulary before its discovery property", () => {
+    const result = getPostType(postTypes, {
+      type: "recipe",
+      name: "Cheese sandwich",
+      content: "Put cheese between bread.",
+    });
+
+    assert.equal(result, "recipe");
+  });
+
+  it("Discovers article post type for entry vocabulary with name and content", () => {
+    const result = getPostType(postTypes, {
+      type: "entry",
+      name: "About",
+      content: "All about me.",
+    });
+
+    assert.equal(result, "article");
+  });
+
+  it("Falls back to note for an unconfigured vocabulary", () => {
+    const result = getPostType(postTypes, {
+      type: "review",
+      content: "Five stars.",
+    });
+
+    assert.equal(result, "note");
+  });
 
   it("Discovers note post type", () => {
     const result = getPostType(postTypes, {

--- a/packages/post-type-page/README.md
+++ b/packages/post-type-page/README.md
@@ -1,0 +1,29 @@
+# @indiekit/post-type-page
+
+Page post type for Indiekit. A page is an undated post at the root of your website, such as `/about`, `/now` or `/uses`.
+
+## Installation
+
+`npm install @indiekit/post-type-page`
+
+## Usage
+
+Add `@indiekit/post-type-page` to your list of plug-ins, specifying options as required:
+
+```json
+{
+  "plugins": ["@indiekit/post-type-page"],
+  "@indiekit/post-type-page": {
+    "name": "Page"
+  }
+}
+```
+
+Micropub clients create a page by sending `h=page`. Presets write a page to the root of your content, where your static site generator serves it at `/{slug}`.
+
+## Options
+
+| Option   | Type     | Description                       |
+| :------- | :------- | :-------------------------------- |
+| `name`   | `string` | Post type name.                   |
+| `fields` | `Array`  | Fields to show in post interface. |

--- a/packages/post-type-page/assets/icon.svg
+++ b/packages/post-type-page/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <path fill="#FB0" d="M0 0h96v96H0z"/>
+  <path fill="#FFF" d="M28 14h28l18 18v50c0 2-2 4-4 4H28c-2 0-4-2-4-4V18c0-2 2-4 4-4Zm26 4v16h16L54 18ZM34 46v4h28v-4H34Zm0 10v4h28v-4H34Zm0 10v4h20v-4H34Z"/>
+</svg>

--- a/packages/post-type-page/index.js
+++ b/packages/post-type-page/index.js
@@ -1,0 +1,31 @@
+const defaults = {
+  name: "Page",
+  fields: {
+    name: { required: true },
+    content: { required: true },
+    summary: {},
+    category: {},
+    "post-status": {},
+    visibility: {},
+  },
+};
+
+export default class PagePostType {
+  name = "Page post type";
+
+  constructor(options = {}) {
+    this.options = { ...defaults, ...options };
+  }
+
+  get config() {
+    return {
+      name: this.options.name,
+      h: "page",
+      fields: this.options.fields,
+    };
+  }
+
+  init(Indiekit) {
+    Indiekit.addPostType("page", this);
+  }
+}

--- a/packages/post-type-page/package.json
+++ b/packages/post-type-page/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@indiekit/post-type-page",
+  "version": "1.0.0-beta.28",
+  "description": "Page post type for Indiekit",
+  "keywords": [
+    "indiekit",
+    "indiekit-plugin",
+    "indieweb",
+    "post-type",
+    "page"
+  ],
+  "homepage": "https://getindiekit.com",
+  "author": {
+    "name": "Paul Robert Lloyd",
+    "url": "https://paulrobertlloyd.com"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=24.17"
+  },
+  "type": "module",
+  "main": "index.js",
+  "files": [
+    "assets",
+    "index.js"
+  ],
+  "bugs": {
+    "url": "https://github.com/getindiekit/indiekit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getindiekit/indiekit.git",
+    "directory": "packages/post-type-page"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/preset-eleventy/lib/post-types.js
+++ b/packages/preset-eleventy/lib/post-types.js
@@ -7,6 +7,21 @@ import plur from "plur";
  */
 export const getPostTypes = (postTypes) => {
   for (const type of postTypes.keys()) {
+    // A page has no date and lives at the root, where Eleventy serves it
+    if (type === "page") {
+      postTypes.set(type, {
+        ...postTypes.get(type),
+        post: {
+          path: "{slug}.md",
+          url: "{slug}",
+        },
+        media: {
+          path: "media/pages/{filename}",
+        },
+      });
+      continue;
+    }
+
     const collection = plur(type);
 
     postTypes.set(type, {

--- a/packages/preset-eleventy/test/unit/post-types.js
+++ b/packages/preset-eleventy/test/unit/post-types.js
@@ -7,6 +7,7 @@ const postTypes = new Map([
   ["article", { name: "Journal post" }],
   ["note", { name: "Micro post" }],
   ["puppy", { name: "Puppy post" }],
+  ["page", { name: "Page" }],
 ]);
 
 describe("preset-eleventy/lib/post-types", () => {
@@ -41,6 +42,16 @@ describe("preset-eleventy/lib/post-types", () => {
       },
       media: {
         path: "media/puppies/{yyyy}/{MM}/{dd}/{filename}",
+      },
+    });
+    assert.deepEqual(result.get("page"), {
+      name: "Page",
+      post: {
+        path: "{slug}.md",
+        url: "{slug}",
+      },
+      media: {
+        path: "media/pages/{filename}",
       },
     });
   });

--- a/packages/preset-hugo/lib/post-types.js
+++ b/packages/preset-hugo/lib/post-types.js
@@ -7,6 +7,22 @@ import plur from "plur";
  */
 export const getPostTypes = (postTypes) => {
   for (const type of postTypes.keys()) {
+    // A page has no date and lives at the root of the content directory
+    if (type === "page") {
+      postTypes.set(type, {
+        ...postTypes.get(type),
+        post: {
+          path: "content/{slug}.md",
+          url: "{slug}",
+        },
+        media: {
+          path: "static/pages/{filename}",
+          url: "pages/{filename}",
+        },
+      });
+      continue;
+    }
+
     const section = plur(type);
 
     /**

--- a/packages/preset-hugo/test/unit/post-types.js
+++ b/packages/preset-hugo/test/unit/post-types.js
@@ -7,6 +7,7 @@ const postTypes = new Map([
   ["article", { name: "Journal post" }],
   ["note", { name: "Micro post" }],
   ["puppy", { name: "Puppy post" }],
+  ["page", { name: "Page" }],
 ]);
 
 describe("preset-hugo/lib/post-types", () => {
@@ -44,6 +45,17 @@ describe("preset-hugo/lib/post-types", () => {
       media: {
         path: "static/puppies/{filename}",
         url: "puppies/{filename}",
+      },
+    });
+    assert.deepEqual(result.get("page"), {
+      name: "Page",
+      post: {
+        path: "content/{slug}.md",
+        url: "{slug}",
+      },
+      media: {
+        path: "static/pages/{filename}",
+        url: "pages/{filename}",
       },
     });
   });

--- a/packages/preset-jekyll/lib/post-types.js
+++ b/packages/preset-jekyll/lib/post-types.js
@@ -16,7 +16,20 @@ export const getPostTypes = (postTypes) => {
   for (const type of postTypes.keys()) {
     const collection = plur(type);
 
-    if (type === "article") {
+    if (type === "page") {
+      // A page has no date; an index file in its own directory is served at
+      // its URL without a permalink setting
+      updates.set("page", {
+        ...postTypes.get("page"),
+        post: {
+          path: "{slug}/index.md",
+          url: "{slug}",
+        },
+        media: {
+          path: "media/pages/{filename}",
+        },
+      });
+    } else if (type === "article") {
       updates.set("article", {
         ...postTypes.get("article"),
         post: {

--- a/packages/preset-jekyll/test/unit/post-types.js
+++ b/packages/preset-jekyll/test/unit/post-types.js
@@ -7,6 +7,7 @@ const postTypes = new Map([
   ["article", { name: "Journal post" }],
   ["note", { name: "Micro post" }],
   ["puppy", { name: "Puppy post" }],
+  ["page", { name: "Page" }],
 ]);
 
 describe("preset-jekyll/lib/post-types", () => {
@@ -41,6 +42,16 @@ describe("preset-jekyll/lib/post-types", () => {
       },
       media: {
         path: "media/puppies/{yyyy}/{MM}/{dd}/{filename}",
+      },
+    });
+    assert.deepEqual(result.get("page"), {
+      name: "Page",
+      post: {
+        path: "{slug}/index.md",
+        url: "{slug}",
+      },
+      media: {
+        path: "media/pages/{filename}",
       },
     });
   });


### PR DESCRIPTION
Fixes #954. Stacked on #951 (the first commit here is that PR’s): a page is recognised by its `h=page` vocabulary, so this only works once that lands.

### The package

`packages/post-type-page` follows the other post-type packages: `name: "Page"`, `h: "page"`, fields `name` and `content` (required), `summary`, `category`, `post-status`, `visibility`; an icon; README; docs page and sidebar entry under *Post types → Official plug-ins*. Not added to the default post types.

### Presets

Each preset gets a `page` case with no date and no collection, at a path each generator serves at `/{slug}` without configuration:

| Preset | `post.path` | `post.url` |
| :--- | :--- | :--- |
| Eleventy | `{slug}.md` | `{slug}` |
| Hugo | `content/{slug}.md` | `{slug}` |
| Jekyll | `{slug}/index.md` | `{slug}` |

Media under `media/pages/` (Hugo: `static/pages/`, served at `pages/`).

### Tests

- Preset unit tests: a `page` entry in each fixture with the paths above (all three fail on `main` with the dated collection path).
- `endpoint-micropub` integration: with `@indiekit/post-type-page` and `@indiekit/preset-eleventy` installed, `h=page&name=About&content=…` answers 202 with `Location: https://website.example/about`.

One thing I noticed while writing that test: `Indiekit.postTypes` is a single Map that a preset walks in its own `init()`, so a post type listed *after* the preset in `plugins` gets no paths (501 “No configuration provided for page post type”). The test lists the page type first. That affects every add-on post type, not only this one; I can open a separate issue if you’d like it addressed.

Verified locally: preset-eleventy 9/9, preset-jekyll 9/9, preset-hugo 12/12, endpoint-micropub 151/151; eslint and prettier clean.