### PR TITLE
fix(endpoint-files): only show a thumbnail for photos

### DIFF
--- a/helpers/mock-agent/endpoint-files.js
+++ b/helpers/mock-agent/endpoint-files.js
@@ -23,7 +23,13 @@ export function mockClient() {
       items: [
         {
           uid: "123",
+          "media-type": "photo",
           url: photoOrigin,
+        },
+        {
+          uid: "456",
+          "media-type": "audio",
+          url: "https://website.example/audio.mp3",
         },
       ],
     })

--- a/packages/endpoint-files/lib/controllers/files.js
+++ b/packages/endpoint-files/lib/controllers/files.js
@@ -34,9 +34,10 @@ export const filesController = async (request, response, next) => {
         item.id = item.uid;
         item.icon = item["media-type"];
         item.locale = application.locale;
-        item.photo = {
-          url: item.url,
-        };
+        // Only a photo can be shown as a thumbnail
+        if (item["media-type"] === "photo") {
+          item.photo = { url: item.url };
+        }
         item.title = item.url ? getFileName(item.url) : "File";
         item.url = path.join(request.baseUrl, request.path, item.uid);
 

--- a/packages/endpoint-files/test/integration/200-files.js
+++ b/packages/endpoint-files/test/integration/200-files.js
@@ -23,5 +23,16 @@ describe("endpoint-files GET /files", () => {
     assert.equal(result.includes("photo.jpg"), true);
   });
 
+  it("Shows a thumbnail for a photo but not for other media", async () => {
+    const response = await request.get("/files").set("cookie", testCookie());
+    const dom = new JSDOM(response.text);
+    const cards = [...dom.window.document.querySelectorAll(".card")];
+    const result = cards.map((card) =>
+      Boolean(card.querySelector(".card__photo")),
+    );
+
+    assert.deepEqual(result, [true, false]);
+  });
+
   after(() => server.close());
 });


### PR DESCRIPTION
Fixes #956.

- `filesController` sets `photo` only when the item's `media-type` is `photo`; audio and video cards keep their type icon and no longer request an image transform that fails with `IPX_INVALID_IMAGE`.
- Mock agent's file listing now carries `media-type` (a photo and an audio file).
- Test: the photo card has a `.card__photo`, the audio card doesn't; on `main` both do.

Verified locally: `node --test packages/endpoint-files/test/**/*.js` 16/16, eslint and prettier clean.