### PR TITLE
build: official container image with release, nightly and preview channels

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+node_modules
+**/node_modules
+**/test
+**/tests

--- a/.github/workflows/docker-check.yml
+++ b/.github/workflows/docker-check.yml
@@ -1,0 +1,36 @@
+name: docker-check
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - package-lock.json
+      - .github/workflows/docker-*.yml
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: indiekit:check
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run the image
+        run: docker run --rm --user 4242:4242 -e HOME=/nonexistent indiekit:check node packages/indiekit/bin/cli.js --version

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,63 @@
+name: docker-image
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to build
+        required: true
+        type: string
+      tags:
+        description: Newline-separated full image tags
+        required: true
+        type: string
+      version:
+        description: Value for org.opencontainers.image.version
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository == 'getindiekit/indiekit'
+    concurrency:
+      group: docker-${{ inputs.version }}
+      cancel-in-progress: false
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ inputs.tags }}
+          provenance: false
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.licenses=MIT
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,0 +1,61 @@
+name: docker-nightly
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  changed:
+    runs-on: ubuntu-latest
+    if: github.repository == 'getindiekit/indiekit'
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      build: ${{ steps.check.outputs.build }}
+      sha: ${{ steps.check.outputs.sha }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compare main with the last nightly
+        id: check
+        run: |
+          set -uo pipefail
+          sha=$(git rev-parse HEAD)
+          short=${sha:0:7}
+          echo "sha=$short" >> "$GITHUB_OUTPUT"
+          # A nightly always tags its image main-<short>. If the registry
+          # already has that tag, main has not moved since the last nightly.
+          # Any failure (no package yet, registry down) falls through to
+          # build=true: the check is an optimisation, never a gate.
+          if docker manifest inspect "ghcr.io/${{ github.repository }}:main-$short" >/dev/null 2>&1; then
+            echo "main-$short is already published; skipping"
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  image:
+    needs: changed
+    if: needs.changed.outputs.build == 'true'
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      ref: main
+      tags: |
+        ghcr.io/${{ github.repository }}:nightly
+        ghcr.io/${{ github.repository }}:main-${{ needs.changed.outputs.sha }}
+      version: main-${{ needs.changed.outputs.sha }}
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/docker-preview.yml
+++ b/.github/workflows/docker-preview.yml
@@ -1,0 +1,60 @@
+name: docker-preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag or commit to build
+        required: true
+        type: string
+        default: main
+      channel:
+        description: Channel name for the moving tag, e.g. preview-v1 or rc
+        required: true
+        type: string
+
+jobs:
+  tags:
+    runs-on: ubuntu-latest
+    if: github.repository == 'getindiekit/indiekit'
+    permissions:
+      contents: read
+    outputs:
+      tags: ${{ steps.derive.outputs.tags }}
+      version: ${{ steps.derive.outputs.version }}
+    steps:
+      - name: Checkout ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Validate channel and derive tags
+        id: derive
+        env:
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          [[ "$CHANNEL" =~ ^[a-z0-9][a-z0-9.-]*$ ]] || { echo "channel must match ^[a-z0-9][a-z0-9.-]*$"; exit 1; }
+          for reserved in latest nightly beta; do
+            [ "$CHANNEL" = "$reserved" ] && { echo "channel '$CHANNEL' is reserved for the release and nightly workflows"; exit 1; }
+          done
+          short=$(git rev-parse --short=7 HEAD)
+          image=ghcr.io/${{ github.repository }}
+          echo "version=$CHANNEL-$short" >> "$GITHUB_OUTPUT"
+          {
+            echo 'tags<<EOF'
+            echo "$image:$CHANNEL"
+            echo "$image:$CHANNEL-$short"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  image:
+    needs: tags
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      ref: ${{ inputs.ref }}
+      tags: ${{ needs.tags.outputs.tags }}
+      version: ${{ needs.tags.outputs.version }}
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,59 @@
+name: docker-release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build, e.g. v1.0.0-beta.29
+        required: true
+        type: string
+
+jobs:
+  tags:
+    runs-on: ubuntu-latest
+    if: github.repository == 'getindiekit/indiekit'
+    permissions:
+      contents: read
+    outputs:
+      ref: ${{ steps.derive.outputs.ref }}
+      tags: ${{ steps.derive.outputs.tags }}
+      version: ${{ steps.derive.outputs.version }}
+    steps:
+      - name: Derive image tags from the release version
+        id: derive
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]] || { echo "not a version tag: $TAG"; exit 1; }
+          image=ghcr.io/${{ github.repository }}
+          version="${TAG#v}"
+          echo "ref=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          {
+            echo 'tags<<EOF'
+            echo "$image:$version"
+            if [[ "$version" == *-* ]]; then
+              # Prerelease: the identifier is the channel (1.0.0-beta.29 -> beta).
+              channel="${version#*-}"; channel="${channel%%.*}"
+              echo "$image:$channel"
+            else
+              echo "$image:latest"
+              echo "$image:${version%%.*}"
+              echo "$image:${version%.*}"
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  image:
+    needs: tags
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      ref: ${{ needs.tags.outputs.ref }}
+      tags: ${{ needs.tags.outputs.tags }}
+      version: ${{ needs.tags.outputs.version }}
+    permissions:
+      contents: read
+      packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Official Indiekit runtime image.
+#
+# The whole workspace is installed, so every official package (endpoints, post
+# types, presets, stores, syndicators) resolves by name from a mounted
+# indiekit.config.js. Third-party plugins are not included.
+#
+# Run it with your configuration and content store mounted at /app, as your
+# own user so files written to ./content belong to you:
+#   docker run -p 3000:3000 \
+#     -v ./indiekit.config.js:/app/indiekit.config.js:ro \
+#     -v ./content:/app/content \
+#     --user "$(id -u):$(id -g)" \
+#     -e PUBLICATION_URL -e MONGO_URL -e SECRET -e PASSWORD_SECRET \
+#     ghcr.io/getindiekit/indiekit
+ARG NODE_VERSION=24
+FROM node:${NODE_VERSION}-alpine
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Run as the unprivileged user the base image provides, so files written to a
+# mounted content store are not owned by root.
+RUN chown node:node /app
+USER node
+
+# The workspace manifests live inside packages/ and helpers/, so the whole
+# tree is copied before install; a source change therefore reinstalls
+# dependencies. Acceptable for a release image.
+COPY --chown=node:node package.json package-lock.json ./
+COPY --chown=node:node helpers ./helpers
+COPY --chown=node:node packages ./packages
+# --ignore-scripts: the root postinstall is husky, a development hook. Native
+# modules (sharp) ship prebuilt binaries and need no install script.
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+
+EXPOSE 3000
+CMD ["node", "packages/indiekit/bin/cli.js", "serve"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A [MongoDB](https://www.mongodb.com) database is optional, but required for the 
 
 ## Get started
 
-Learn how to [set up an Indiekit server](docs/get-started.md) and view an [example server configuration](https://github.com/getindiekit/example-config).
+Learn how to [set up an Indiekit server](docs/get-started.md) and view an [example server configuration](https://github.com/getindiekit/example-config). A container image is published on each release at `ghcr.io/getindiekit/indiekit`; see [docs/docker.md](docs/docker.md).
 
 ## Documentation website
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -9,6 +9,7 @@ const sidebar = [
     text: "Introduction",
     items: [
       { text: "Get started", link: "/get-started" },
+      { text: "Run in a container", link: "/docker" },
       { text: "How Indiekit works", link: "/introduction" },
       { text: "Core concepts", link: "/concepts" },
       { text: "Sponsors", link: "/sponsors" },

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,107 @@
+# Run Indiekit in a container
+
+An image with every official plugin is published at `ghcr.io/getindiekit/indiekit`. You supply a configuration file, a content store and a MongoDB database; the image supplies everything else.
+
+## Quick start with Docker Compose
+
+Create `indiekit.config.js` (see [Configuration](/configuration/)) and a `compose.yml`:
+
+```yaml
+services:
+  indiekit:
+    image: ghcr.io/getindiekit/indiekit:beta
+    restart: unless-stopped
+    user: "1000:1000"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./indiekit.config.js:/app/indiekit.config.js:ro
+      - ./content:/app/content
+    environment:
+      PUBLICATION_URL: http://localhost:3000
+      MONGO_URL: mongodb://mongo:27017/indiekit
+      SECRET: ${SECRET}
+      PASSWORD_SECRET: ${PASSWORD_SECRET}
+    depends_on:
+      mongo:
+        condition: service_healthy
+  mongo:
+    image: mongo:8
+    restart: unless-stopped
+    volumes:
+      - mongo:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+volumes:
+  mongo:
+```
+
+Replace `1000:1000` with your own user and group ids (`id -u` and `id -g`), so files written to `./content` belong to you.
+
+Create the store directory yourself, so it is owned by you:
+
+```sh
+mkdir content
+```
+
+Write a `.env` file beside `compose.yml` with your secrets:
+
+```sh
+printf "SECRET='…'\nPASSWORD_SECRET='…'\n" > .env
+```
+
+`SECRET` is any long random string; `PASSWORD_SECRET` comes from the "Set your password" section below.
+
+Then:
+
+```sh
+docker compose up -d
+```
+
+Indiekit listens on port 3000. Put a reverse proxy with HTTPS in front of it for a public site.
+
+## What the image expects
+
+Run the container as your own uid:gid so the mounted store is writable; the default `node` user (1000) only works when your uid is 1000.
+
+| Path or variable | Purpose |
+|---|---|
+| `/app/indiekit.config.js` | Your configuration. Mounted read-only. |
+| `/app/content` | The directory for `@indiekit/store-file-system`, if you use it. |
+| `PUBLICATION_URL` | Your site’s URL. |
+| `MONGO_URL` | MongoDB connection string. |
+| `SECRET`, `PASSWORD_SECRET` | See [Get started](/get-started). |
+| `PORT` | Optional, defaults to 3000. |
+
+Any plug-ins you configure may need their own secrets; pass them the same way.
+
+Any official plugin named in your configuration is already installed. Third-party plugins are not included in the image; build your own image on top of this one to add them.
+
+> [!WARNING]
+> `PUBLICATION_URL` must resolve from inside the container: signing in makes the server fetch its own URL to complete IndieAuth. On a laptop that means the published host port must equal the container port (`3000:3000` with `PUBLICATION_URL=http://localhost:3000`); behind a reverse proxy, the public URL must be reachable from the container.
+
+## Set your password
+
+1. Start the stack without `PASSWORD_SECRET` set.
+2. Visit `/auth/new-password` at your `PUBLICATION_URL`.
+3. Enter the password you want to use and copy the generated value.
+4. Set `PASSWORD_SECRET` to that value and restart the stack.
+
+See [Get started](/get-started) for the `$` quoting rules that apply to this value in `compose.yml`.
+
+## Tags
+
+The first image appears with the first release after this lands; until then no tag exists.
+
+| Tag | Built from | When |
+|---|---|---|
+| `1.0.0-beta.29` | The release tag | Each GitHub release |
+| `beta` | The newest prerelease | Each GitHub release while Indiekit is in beta |
+| `latest`, `1`, `1.0` | The newest stable release | From the first stable release onward |
+| `nightly`, `main-<sha>` | `main` | Every night `main` has changed |
+| `<channel>`, `<channel>-<sha>` | Any ref, on request | When a maintainer publishes a preview |
+
+Images are built for `linux/amd64` and `linux/arm64`.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -55,6 +55,8 @@ where `[directory]` is the name of the directory within which you want to save y
 
 This is the fastest way to set up a new Indiekit server from scratch.
 
+Prefer containers? See [Run Indiekit in a container](/docker).
+
 > Alternatively, you can clone this [example configuration](https://github.com/getindiekit/example-config) repository on GitHub and manually edit the values in the configuration file.
 
 The wizard will walk you through every step of configuring a new server, and will ask you questions about:


### PR DESCRIPTION
## Why

Deploying Indiekit today means building your own image from an example config. A published runtime image makes it a config file plus `docker compose up`, and gives starter themes something to point at. This adds one. Happy to convert this into a proposal issue first if you would rather discuss the shape before reviewing the files.

## Yours to veto

Three decisions in here are yours, and each is a small change:

- **Registry.** This uses `ghcr.io/getindiekit/indiekit`, which needs no secrets. `example-config` already uses the Docker Hub-shaped name `getindiekit/indiekit`; switching is two lines.
- **Nightly channel.** A daily multi-arch build costs your Actions minutes and leaves a `main-<sha>` version in the registry per run. It is one file; I can drop it, make it weekly, or add a retention step.
- **Preview channel.** Manual only, severable on its own.

## What

- `Dockerfile` and `.dockerignore`: `node:24-alpine` (the engine floor is `>=24.17`), the whole workspace installed with `npm ci --omit=dev --ignore-scripts`, so every official plugin resolves by name from a mounted `indiekit.config.js`. Ignoring install scripts is safe here: the root `postinstall` is husky; `bcrypt@6` resolves its prebuild through `node-gyp-build` at require time; `sharp`, `esbuild` and `lightningcss` resolve through optional platform packages; the lockfile carries the musl and arm64 variants of all of them. Runs as the unprivileged `node` user, working directory `/app`, entrypoint `node packages/indiekit/bin/cli.js serve` rather than `npx`, so the container can run as any `--user`. 128 MB.
- `.github/workflows/docker-image.yml`: one reusable job that builds `linux/amd64` and `linux/arm64` and pushes with OCI labels, using the repository token with `packages: write`. Guarded to this repository, so forks never publish.
- `docker-release.yml`: on `release: published` (and manual dispatch with a tag). I checked how releases happen here: `lerna publish` creates the tag and the GitHub release is created by hand afterwards, the last four all by you about a quarter of an hour after each tag, so the release event does fire. A tag pushed by the publish job's own token could not trigger a workflow, which is why the tag push is not the trigger. The channel is derived from the version string rather than the release's prerelease flag, because the beta releases here are not flagged as prereleases. Tags: `<version>` plus `beta` while the version is a prerelease; `latest`, `<major>`, `<major>.<minor>` once a stable release lands, with no workflow change.
- `docker-nightly.yml`: daily from `main`, tags `nightly` and `main-<sha>`, skipped when the registry already has that sha.
- `docker-preview.yml`: manual, any ref, a named channel such as `preview-v1` or `rc`, for milestone testing without cutting a release.
- `docker-check.yml`: on pull requests touching the Dockerfile, builds the amd64 image without pushing and starts the CLI as an arbitrary user, so the Dockerfile cannot rot between releases.
- `docs/docker.md`, linked from the sidebar and from Get started.

No JavaScript changes, so `build.yml` is unaffected. Every file is root-level, so Lerna's version bumping sees nothing. `create-indiekit`'s generated Dockerfile and compose file are untouched and out of scope; a follow-up could point its compose at the published image and drop the generated Dockerfile.

## Proof

Built locally from this branch and run with MongoDB, a mounted `indiekit.config.js` (the Eleventy preset and the file-system store, six post types) and a mounted `content/` directory, as the host user. Signed in through the browser and created a note from the Posts UI. The store received `content/notes/c7c13.md`, owned by the host user, and an Eleventy build of the mounted site rendered it at `/notes/c7c13/` and in its feeds.

Two things the proof taught, both in the docs: the container must run as the host user or a mounted store is read-only to it, and `PUBLICATION_URL` must resolve from inside the container because the server fetches its own URL during sign-in.

Only the amd64 image has been started. The arm64 image builds under QEMU but has not been run; the lockfile carries the arm64 and musl native variants, so it should work, but that is not proven.

## Limits

- Third-party plugins are not in the image. Build on top of it to add them.
- Multi-arch builds under QEMU are slow; the Actions cache is enabled.
- The root `dependencies` include `lerna` and `husky`, so they ride along in the image. Moving them to `devDependencies` would shave the image; not touched here because it changes your development setup.

## What I would most like a second opinion on

The tag policy, and whether you want the nightly at all.
