### PR TITLE
fix(endpoint-auth): bind code exchange to the code’s own claims, not application state

### DIFF
--- a/packages/endpoint-auth/lib/middleware/code.js
+++ b/packages/endpoint-auth/lib/middleware/code.js
@@ -2,7 +2,6 @@ import { IndiekitError } from "@indiekit/error";
 import { getCanonicalUrl } from "@indiekit/util";
 
 import { verifyCode } from "../pkce.js";
-import { validateRedirect } from "../redirect.js";
 import { verifyToken } from "../token.js";
 import { getRequestParameters } from "../utils.js";
 
@@ -12,7 +11,6 @@ import { getRequestParameters } from "../utils.js";
  */
 export const codeValidator = async (request, response, next) => {
   try {
-    const { client, usePkce } = request.app.locals;
     const parameters = getRequestParameters(request);
     const { client_id, code, code_verifier, grant_type, redirect_uri } =
       parameters;
@@ -45,22 +43,7 @@ export const codeValidator = async (request, response, next) => {
       );
     }
 
-    // Validate `client_id` against that provided in authorization request
-    if (getCanonicalUrl(client_id) !== getCanonicalUrl(client.id)) {
-      throw IndiekitError.unauthorized(
-        response.locals.__("BadRequestError.invalidValue", "client_id"),
-      );
-    }
-
-    // Validate `redirect_uri`
-    const validRedirect = await validateRedirect(redirect_uri, client_id);
-    if (!validRedirect) {
-      throw IndiekitError.badRequest(
-        response.locals.__("BadRequestError.invalidValue", "redirect_uri"),
-      );
-    }
-
-    // Verify token
+    // Verify the code before reading anything from it
     try {
       request.verifiedToken = verifyToken(code);
     } catch {
@@ -69,9 +52,45 @@ export const codeValidator = async (request, response, next) => {
       );
     }
 
-    // PKCE (Proof Key for Code Exchange)
-    if (usePkce) {
-      const { code_challenge } = request.verifiedToken;
+    // An authorization code records the client it was issued to and the
+    // redirect it was issued for. A code missing either cannot be checked
+    // against the request, so it is not one this server issued.
+    if (
+      !request.verifiedToken.client_id ||
+      !request.verifiedToken.redirect_uri
+    ) {
+      throw IndiekitError.unauthorized(
+        response.locals.__("UnauthorizedError.invalidToken"),
+      );
+    }
+
+    // Validate `client_id` against the client the code was issued to. Reading
+    // this from the code rather than from application state is what ties the
+    // two requests together: `app.locals` is shared by every request the
+    // server handles, so it holds whichever authorization request happened
+    // last, which need not be the one that produced this code.
+    if (
+      getCanonicalUrl(client_id) !==
+      getCanonicalUrl(String(request.verifiedToken.client_id))
+    ) {
+      throw IndiekitError.unauthorized(
+        response.locals.__("BadRequestError.invalidValue", "client_id"),
+      );
+    }
+
+    // Validate `redirect_uri` against the one the code was issued for. It was
+    // checked against the client's metadata during the authorization request,
+    // so matching it here is what remains to be done.
+    if (redirect_uri !== request.verifiedToken.redirect_uri) {
+      throw IndiekitError.badRequest(
+        response.locals.__("BadRequestError.invalidValue", "redirect_uri"),
+      );
+    }
+
+    // PKCE (Proof Key for Code Exchange). Whether it applies is recorded in
+    // the code itself, by the presence of the challenge it was issued with.
+    const { code_challenge } = request.verifiedToken;
+    if (code_challenge) {
       const verifiedCode = verifyCode(code_verifier, code_challenge);
       if (!verifiedCode) {
         throw IndiekitError.unauthorized(

--- a/packages/endpoint-auth/lib/middleware/code.js
+++ b/packages/endpoint-auth/lib/middleware/code.js
@@ -65,10 +65,8 @@ export const codeValidator = async (request, response, next) => {
     }
 
     // Validate `client_id` against the client the code was issued to. Reading
-    // this from the code rather than from application state is what ties the
-    // two requests together: `app.locals` is shared by every request the
-    // server handles, so it holds whichever authorization request happened
-    // last, which need not be the one that produced this code.
+    // it from the code, rather than from state shared across requests, is what
+    // ties this exchange to the authorization request that produced the code.
     if (
       getCanonicalUrl(client_id) !==
       getCanonicalUrl(String(request.verifiedToken.client_id))

--- a/packages/endpoint-auth/test/integration/200-authorization-profile-json.js
+++ b/packages/endpoint-auth/test/integration/200-authorization-profile-json.js
@@ -24,7 +24,9 @@ describe("endpoint-auth POST /auth", () => {
   it("Returns JSON profile", async () => {
     const code = signToken({
       access_token: "token",
+      client_id: "https://auth-endpoint.example",
       me: "https://website.example",
+      redirect_uri: "https://auth-endpoint.example/redirect",
       scope: "create update delete media",
       token_type: "Bearer",
     });

--- a/packages/endpoint-auth/test/integration/200-authorization-profile-no-grant-type.js
+++ b/packages/endpoint-auth/test/integration/200-authorization-profile-no-grant-type.js
@@ -24,7 +24,9 @@ describe("endpoint-auth POST /auth", () => {
   it("Returns profile when `grant_type` omitted", async () => {
     const code = signToken({
       access_token: "token",
+      client_id: "https://auth-endpoint.example",
       me: "https://website.example",
+      redirect_uri: "https://auth-endpoint.example/redirect",
       scope: "create update delete media",
       token_type: "Bearer",
     });

--- a/packages/endpoint-auth/test/integration/200-token-grant-json.js
+++ b/packages/endpoint-auth/test/integration/200-token-grant-json.js
@@ -24,7 +24,9 @@ describe("endpoint-auth POST /auth/token", () => {
   it("Returns JSON access token", async () => {
     const code = signToken({
       access_token: "token",
+      client_id: "https://auth-endpoint.example",
       me: "https://website.example",
+      redirect_uri: "https://auth-endpoint.example/redirect",
       scope: "create update delete media",
       token_type: "Bearer",
     });

--- a/packages/endpoint-auth/test/integration/200-token-grant-url-encoded.js
+++ b/packages/endpoint-auth/test/integration/200-token-grant-url-encoded.js
@@ -24,7 +24,9 @@ describe("endpoint-auth POST /auth/token", () => {
   it("Returns URL encoded access token", async () => {
     const code = signToken({
       access_token: "token",
+      client_id: "https://auth-endpoint.example",
       me: "https://website.example",
+      redirect_uri: "https://auth-endpoint.example/redirect",
       scope: "create update delete media",
       token_type: "Bearer",
     });

--- a/packages/endpoint-auth/test/integration/400-token-grant-invalid-pkce-code.js
+++ b/packages/endpoint-auth/test/integration/400-token-grant-invalid-pkce-code.js
@@ -29,8 +29,10 @@ describe("endpoint-auth POST /auth/token", () => {
   it("Returns 401 error fails PKCE code challenge", async () => {
     const code = signToken({
       access_token: "token",
+      client_id: "https://auth-endpoint.example",
       code_challenge: codeChallenge,
       code_challenge_method: "S256",
+      redirect_uri: "https://auth-endpoint.example/redirect",
       scope: "create update delete media",
       token_type: "Bearer",
     });

--- a/packages/endpoint-auth/test/integration/400-token-grant-invalid-redirect-uri.js
+++ b/packages/endpoint-auth/test/integration/400-token-grant-invalid-redirect-uri.js
@@ -24,7 +24,9 @@ describe("endpoint-auth POST /auth/token", () => {
   it("Returns 400 error invalid `redirect_uri`", async () => {
     const code = signToken({
       access_token: "token",
+      client_id: "https://auth-endpoint.example",
       me: "https://website.example",
+      redirect_uri: "https://auth-endpoint.example/redirect",
       scope: "create update delete media",
       token_type: "Bearer",
     });

--- a/packages/endpoint-auth/test/integration/401-token-grant-code-issued-to-other-client.js
+++ b/packages/endpoint-auth/test/integration/401-token-grant-code-issued-to-other-client.js
@@ -11,7 +11,9 @@ await mockAgent("endpoint-auth");
 const server = await testServer();
 const request = supertest.agent(server);
 
-describe("endpoint-auth POST /auth", () => {
+describe("endpoint-auth POST /auth/token", () => {
+  // Begin an authorization request as this client, so that whatever
+  // application-wide state the server keeps refers to it.
   before(async () => {
     await request
       .get("/auth")
@@ -21,27 +23,26 @@ describe("endpoint-auth POST /auth", () => {
       .query({ state: "12345" });
   });
 
-  it("Returns URL encoded profile", async () => {
+  // The authorization code records the client it was issued to. Redeeming it
+  // as a different client must fail, whatever authorization request happened
+  // most recently on the server.
+  it("Rejects a code issued to a different client", async () => {
     const code = signToken({
-      access_token: "token",
-      client_id: "https://auth-endpoint.example",
+      client_id: "https://other-client.example",
       me: "https://website.example",
-      redirect_uri: "https://auth-endpoint.example/redirect",
-      scope: "create update delete media",
-      token_type: "Bearer",
+      redirect_uri: "https://other-client.example/redirect",
+      scope: "create",
     });
-    const response = await request
-      .post("/auth")
-      .set("accept", "application/x-www-form-urlencoded")
+    const result = await request
+      .post("/auth/token")
+      .set("accept", "application/json")
       .query({ client_id: "https://auth-endpoint.example" })
       .query({ code })
       .query({ grant_type: "authorization_code" })
       .query({ redirect_uri: "https://auth-endpoint.example/redirect" });
-    const responseTextRegexp = /me=(?<me>.*)/;
-    const result = response.text.match(responseTextRegexp).groups;
 
-    assert.equal(response.status, 200);
-    assert.equal(result.me, encodeURIComponent("https://website.example"));
+    assert.notEqual(result.status, 200);
+    assert.equal(result.body.access_token, undefined);
   });
 
   after(() => server.close());

--- a/packages/endpoint-auth/test/integration/401-token-grant-invalid-client-id.js
+++ b/packages/endpoint-auth/test/integration/401-token-grant-invalid-client-id.js
@@ -24,7 +24,9 @@ describe("endpoint-auth POST /auth/token", () => {
   it("Returns 401 error invalid `client_id`", async () => {
     const code = signToken({
       access_token: "token",
+      client_id: "https://auth-endpoint.example",
       me: "https://website.example",
+      redirect_uri: "https://website.example/redirect",
       scope: "create update delete media",
       token_type: "Bearer",
     });

--- a/packages/endpoint-auth/test/integration/401-token-grant-no-authorization-request.js
+++ b/packages/endpoint-auth/test/integration/401-token-grant-no-authorization-request.js
@@ -10,9 +10,9 @@ const server = await testServer();
 const request = supertest.agent(server);
 
 describe("endpoint-auth POST /auth/token", () => {
-  // No authorization request precedes this exchange, so nothing has populated
-  // `request.app.locals`. The response should describe the problem, not fail
-  // with an unhandled error.
+  // No authorization request precedes this exchange, so the code itself has to
+  // carry everything needed to validate it. The response should describe the
+  // problem, not fail with an unhandled error.
   it("Returns an error, not 500, with no preceding authorization request", async () => {
     const code = signToken({
       client_id: "https://client.example",

--- a/packages/endpoint-auth/test/integration/401-token-grant-no-authorization-request.js
+++ b/packages/endpoint-auth/test/integration/401-token-grant-no-authorization-request.js
@@ -1,0 +1,36 @@
+import { strict as assert } from "node:assert";
+import { after, describe, it } from "node:test";
+
+import { testServer } from "@indiekit-test/server";
+import supertest from "supertest";
+
+import { signToken } from "../../lib/token.js";
+
+const server = await testServer();
+const request = supertest.agent(server);
+
+describe("endpoint-auth POST /auth/token", () => {
+  // No authorization request precedes this exchange, so nothing has populated
+  // `request.app.locals`. The response should describe the problem, not fail
+  // with an unhandled error.
+  it("Returns an error, not 500, with no preceding authorization request", async () => {
+    const code = signToken({
+      client_id: "https://client.example",
+      me: "https://website.example",
+      redirect_uri: "https://client.example/redirect",
+      scope: "create",
+    });
+    const result = await request
+      .post("/auth/token")
+      .set("accept", "application/json")
+      .query({ client_id: "https://other-client.example" })
+      .query({ code })
+      .query({ grant_type: "authorization_code" })
+      .query({ redirect_uri: "https://other-client.example/redirect" });
+
+    assert.notEqual(result.status, 500);
+    assert.equal(result.body.error, "unauthorized");
+  });
+
+  after(() => server.close());
+});


### PR DESCRIPTION
Fixes #892.

`codeValidator` took the client an authorization code was issued to from `request.app.locals.client`. That is application-wide state, holding whichever authorization request last reached the server, so it can be absent (500) or refer to a different client than the one the code was issued to (a code redeemable by another client).

### The change

Verify the code first, then compare the request against the claims it carries:

```js
request.verifiedToken = verifyToken(code);

if (!request.verifiedToken.client_id || !request.verifiedToken.redirect_uri) {
  throw IndiekitError.unauthorized(__("UnauthorizedError.invalidToken"));
}

if (getCanonicalUrl(client_id) !== getCanonicalUrl(String(request.verifiedToken.client_id))) { … }
if (redirect_uri !== request.verifiedToken.redirect_uri) { … }
```

`consent.js:82` already signs both into the code, so nothing new has to be recorded. PKCE now keys off the challenge in the code rather than `app.locals.usePkce`, which removes the last read of application state here.

`validateRedirect` is no longer called at redemption: `redirect_uri` is validated against the client's metadata during the authorization request, so what remains is matching the value the code was issued for. That is a behaviour change worth a look — it trades a network-dependent check for an equality one.

### Tests

Two added, both failing on `main`:

- `401-token-grant-no-authorization-request.js` — an exchange with no preceding authorization request. `main` returns 500 with a `TypeError`.
- `401-token-grant-code-issued-to-other-client.js` — a code issued to one client, redeemed by another that began its own authorization request first. `main` returns **200 with an access token**.

Seven existing tests signed codes carrying neither `client_id` nor `redirect_uri`, which `consent.js` cannot produce, so they exercised codes that cannot occur. They now sign the claims a real code carries. Two of them — invalid `client_id` and invalid `redirect_uri` — assert the same statuses and messages as before, now reached through the code's claims rather than through `app.locals`.

`node --test` in `packages/endpoint-auth`: **68 tests, 68 passing**. Reverting only `code.js` and keeping the tests fails exactly the two new ones. `main` is 66/66 before this change.

### Relationship to the other open branches

Independent of #884, #887 and #889. This branch is cut from `main`, as is #891, and both change `packages/endpoint-auth/lib/middleware/code.js`.

I described that overlap as a trivial rebase when opening this. Having since merged the two locally, that was understated, so to correct it: `code.js` does merge cleanly — #891 adds a `grant_type` allowance to the required-parameter list, this one replaces the checks that follow it, and git resolves that without conflict. But the merged result **fails a test**, and it is #891's own:

`200-authorization-profile-no-grant-type.js`, added there, signs a code with neither `client_id` nor `redirect_uri` — the same gap as the seven fixtures this PR updates. It passes on either branch alone and fails on both together, because this PR starts rejecting codes missing those claims. Adding them to that fixture resolves it, after which the combined branches give 70 tests, 70 passing.

So whichever merges second needs a one-line fixture change as well as the merge, and CI on the second branch will go red until it is made. Nothing structural — but it will not go green on the merge alone, which is what "trivial rebase" implied.

---

Replaces #893, which was opened from a branch on `rmdes/indiekit`. PRs from a fork do not receive the Localazy `readKey` secret, so the "Download localisations" step fails and every step after it — install, lint and the whole test suite — is skipped. Same two commits, rebased onto current `main`, on a branch here so CI actually runs.
